### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-deploy-search.yml
+++ b/.github/workflows/prod-deploy-search.yml
@@ -3,6 +3,9 @@ name: Deploy Search to prod
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   IMAGE_NAME: kamilwronka7/lootlog-search
   IMAGE_TAG: prod-${{ github.sha }}


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/10](https://github.com/lootlog/monorepo/security/code-scanning/10)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- `contents: write` is required for committing and pushing changes to the repository.
- `contents: read` is sufficient for other steps that interact with the repository but do not modify it.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as all jobs in this workflow require the same permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
