### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-search.yml
+++ b/.github/workflows/dev-deploy-search.yml
@@ -9,6 +9,9 @@ on:
       - develop
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   IMAGE_NAME: kamilwronka7/lootlog-search
   IMAGE_TAG: dev-${{ github.sha }}


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/21](https://github.com/lootlog/monorepo/security/code-scanning/21)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves committing and pushing changes to the repository, it requires `contents: write` permissions. Other permissions, such as `pull-requests: write`, are not necessary based on the current workflow steps.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build-and-push` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
