### PR TITLE
feat: members panel

### DIFF
--- a/apps/api/prisma/migrations/20250720001945_global_user_id/migration.sql
+++ b/apps/api/prisma/migrations/20250720001945_global_user_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "globalUserId" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -86,6 +86,7 @@ model Member {
   roles           Role[]
   timers          Timer[]
   lootSubmissions LootSubmission[]
+  globalUserId    String?
 
   @@unique(name: "memberId", [userId, guildId])
   @@index([id, guildId])

--- a/apps/api/src/members/members.controller.ts
+++ b/apps/api/src/members/members.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { MembersService } from './members.service';
 import { Permissions } from 'src/shared/permissions/permissions.decorator';
 import { PermissionsGuard } from 'src/shared/permissions/permissions.guard';
@@ -39,6 +39,19 @@ export class MembersController {
       userId,
       refresh: true,
       standalone: true,
+    });
+  }
+
+  @Permissions(Permission.ADMIN, Permission.OWNER)
+  @UseGuards(PermissionsGuard)
+  @Post('/:discordId/refresh')
+  async refreshMember(
+    @Param('discordId') discordId: string,
+    @Param('guildId') guildId: string,
+  ) {
+    return this.membersService.refreshMember({
+      discordId,
+      guildId,
     });
   }
 

--- a/apps/web/src/components/layout/page-header.tsx
+++ b/apps/web/src/components/layout/page-header.tsx
@@ -4,7 +4,7 @@ type Props = {
 
 export const PageHeader: React.FC<Props> = ({ children }) => {
   return (
-    <div className="h-14 min-h-14 flex items-center px-2 justify-between border-b sticky top-0 backdrop-blur z-50">
+    <div className="h-14 min-h-14 flex items-center px-2 justify-between border-b sticky top-0 backdrop-blur z-50 box-border">
       {children}
     </div>
   );

--- a/apps/web/src/components/layout/settings-layout.tsx
+++ b/apps/web/src/components/layout/settings-layout.tsx
@@ -21,6 +21,11 @@ const NAV_ELEMENTS = [
     label: "Ustawienia potworów i NPC",
     href: "/settings/npcs",
   },
+  {
+    id: "members",
+    label: "Członkowie",
+    href: "/settings/members",
+  },
 ];
 
 export const SettingsLayout: React.FC = () => {
@@ -28,7 +33,7 @@ export const SettingsLayout: React.FC = () => {
   const { pathname } = useLocation();
 
   return (
-    <div className="flex flex-row w-full h-[calc(100%)]">
+    <div className="flex flex-row w-full h-full">
       <div className="w-full h-full flex flex-col">
         <PageHeader>
           <div className="flex flex-row gap-2">
@@ -36,7 +41,7 @@ export const SettingsLayout: React.FC = () => {
             <h1 className="font-semibold p-0">Ustawienia</h1>
           </div>
         </PageHeader>
-        <div className="p-2 flex flex-row gap-2 border-b">
+        <div className="p-2 flex flex-row gap-2 border-b box-border">
           {NAV_ELEMENTS.map((navElement) => {
             const url = `/${guildId}${navElement.href}`;
             const active = pathname === url;

--- a/apps/web/src/hooks/api/use-guild-member.tsx
+++ b/apps/web/src/hooks/api/use-guild-member.tsx
@@ -1,12 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 import { useApiClient } from "@/hooks/api/use-api-client";
 import { useGuildId } from "@/hooks/use-guild-id";
+import { GuildRole } from "@/hooks/api/use-guild-roles";
 
 export type GuildMember = {
   id: string;
   name: string;
   avatar: string | null;
   updatedAt: string;
+  roles: GuildRole[];
+  userId: string;
+  globalUserId?: string;
 };
 
 export const useGuildMember = () => {
@@ -14,7 +18,7 @@ export const useGuildMember = () => {
   const { client } = useApiClient();
 
   const query = useQuery({
-    queryKey: ["member", guildId],
+    queryKey: ["member", guildId, "@me"],
     queryFn: () => client.get<GuildMember>(`/guilds/${guildId}/members/@me`),
     enabled: !!guildId,
     select: (response) => response.data,

--- a/apps/web/src/hooks/api/use-guild-members.ts
+++ b/apps/web/src/hooks/api/use-guild-members.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { useApiClient } from "@/hooks/api/use-api-client";
+import { useGuildId } from "@/hooks/use-guild-id";
+import { GuildMember } from "@/hooks/api/use-guild-member";
+
+export const useGuildMembers = () => {
+  const guildId = useGuildId();
+  const { client } = useApiClient();
+
+  const query = useQuery({
+    queryKey: ["members", guildId],
+    queryFn: () => client.get<GuildMember[]>(`/guilds/${guildId}/members`),
+    enabled: !!guildId,
+    select: (response) => response.data,
+  });
+
+  return query;
+};

--- a/apps/web/src/hooks/api/use-member-refresh.ts
+++ b/apps/web/src/hooks/api/use-member-refresh.ts
@@ -24,6 +24,12 @@ export const useMemberRefresh = () => {
       queryClient.invalidateQueries({
         queryKey: ["member", guildId],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["members", guildId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["loots", guildId],
+      });
     },
     onError: () => {
       toast({

--- a/apps/web/src/i18n/translations/permissions.json
+++ b/apps/web/src/i18n/translations/permissions.json
@@ -1,4 +1,5 @@
 {
+  "OWNER": "Właściciel",
   "ADMIN": "Administrator",
   "LOOTLOG_MANAGE": "Moderator",
   "LOOTLOG_READ": "Dostęp do lootloga",

--- a/apps/web/src/navigation/navigation.tsx
+++ b/apps/web/src/navigation/navigation.tsx
@@ -13,6 +13,7 @@ import { GeneralSettings } from "@/screens/general-settings/general-settings";
 import { RolesSettings } from "@/screens/roles-settings/roles-settings";
 import { AuthenticationGuard } from "@/components/auth/authentication-guard";
 import { NpcSettings } from "@/screens/lootlog-settings/npc-settings";
+import { MembersSettings } from "@/screens/members-settings/members-settings";
 
 export const Navigation = () => {
   return (
@@ -38,6 +39,10 @@ export const Navigation = () => {
                 element={<RolesSettings />}
               />
               <Route path="/:guildId/settings/npcs" element={<NpcSettings />} />
+              <Route
+                path="/:guildId/settings/members"
+                element={<MembersSettings />}
+              />
             </Route>
           </Route>
         </Route>

--- a/apps/web/src/screens/members-settings/components/member-data.tsx
+++ b/apps/web/src/screens/members-settings/components/member-data.tsx
@@ -1,0 +1,55 @@
+import { GuildMember } from "@/hooks/api/use-guild-member";
+import { useTranslation } from "react-i18next";
+
+export type MemberDataProps = {
+  member: GuildMember;
+};
+
+export const MemberData = ({ member }: MemberDataProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      {member.roles.length === 0 && (
+        <div className="text-gray-500 p-4">
+          Brak przypisanych ról - może być potrzebna synchronizacja
+        </div>
+      )}
+      {member.roles.map((role) => {
+        console.log(role);
+        const color = role.color === 0 ? "FFF" : role.color.toString(16);
+
+        return (
+          <span
+            key={role.id}
+            className="border-b p-4 text-sm font-semibold flex flex-col"
+            style={{ color: `#${color}` }}
+          >
+            <span>
+              <span>{role.name} </span>
+              <span>
+                <span className="text-xs text-gray-500">
+                  ({role.lvlRangeFrom} - {role.lvlRangeTo})
+                </span>
+              </span>
+            </span>
+            <span className="flex gap-1 flex-wrap">
+              {role.permissions.length > 0 &&
+                role.permissions.map((permission) => {
+                  return (
+                    <span key={permission} className="text-xs text-gray-400">
+                      {t(`permissions.${permission}`)}
+                      {role.permissions.length > 1 &&
+                        permission !==
+                          role.permissions[role.permissions.length - 1] &&
+                        ", "}
+                    </span>
+                  );
+                })}
+            </span>
+          </span>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/web/src/screens/members-settings/components/member-item.tsx
+++ b/apps/web/src/screens/members-settings/components/member-item.tsx
@@ -1,0 +1,64 @@
+import { GuildMember } from "@/hooks/api/use-guild-member";
+import { MemberSyncButton } from "@/screens/members-settings/components/member-sync-button";
+import { cn } from "@/utils/cn";
+import { getDiscordAvatarUrl } from "@/utils/get-avatar-url";
+import { getColorFromRole } from "@/utils/get-color-from-role";
+import { Avatar, AvatarImage } from "@lootlog/ui/components/avatar";
+import { Button } from "@lootlog/ui/components/button";
+import { EllipsisVertical } from "lucide-react";
+import { FC } from "react";
+
+export type MemberItemProps = {
+  member: GuildMember;
+  active?: boolean;
+  onSelect: () => void;
+  showActions?: boolean;
+};
+
+export const MemberItem: FC<MemberItemProps> = ({
+  member,
+  active,
+  onSelect,
+  showActions = true,
+}) => {
+  const color = getColorFromRole(member.roles);
+  const avatarUrl = getDiscordAvatarUrl(member.userId, member.avatar);
+
+  return (
+    <div
+      key={member.id}
+      className={cn(
+        "border-b flex flex-row justify-between py-4 px-6 h-12 items-center hover:bg-[#181C25] cursor-pointer text-sm box-border",
+        {
+          "bg-[#181C25]": active,
+        }
+      )}
+      onClick={onSelect}
+    >
+      <div className="flex gap-4 items-center">
+        <Avatar className="size-8">
+          <AvatarImage src={avatarUrl} />
+        </Avatar>
+        <div>
+          <div className="font-semibold" style={{ color: `#${color}` }}>
+            {member.name}
+          </div>
+        </div>
+      </div>
+      {showActions && (
+        <div className="flex items-center gap-2">
+          <MemberSyncButton member={member} />
+          <div className="flex gap-2">
+            <Button
+              className="size-8 rounded-full"
+              size="sm"
+              variant="secondary"
+            >
+              <EllipsisVertical />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/screens/members-settings/components/member-sync-button.tsx
+++ b/apps/web/src/screens/members-settings/components/member-sync-button.tsx
@@ -1,0 +1,86 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { REFRESH_PERMISSIONS_TTL } from "@/constants/refresh-permissions-ttl";
+import { GuildMember } from "@/hooks/api/use-guild-member";
+import { useMemberRefresh } from "@/hooks/api/use-member-refresh";
+import { Button } from "@lootlog/ui/components/button";
+import { RefreshCcw } from "lucide-react";
+import { FC, useCallback } from "react";
+
+export type MemberSyncButtonProps = {
+  member: GuildMember;
+};
+
+const getRefreshInfo = (member: GuildMember) => {
+  const canRefresh = !!member.globalUserId;
+  const updatedAt = member?.updatedAt
+    ? new Date(member.updatedAt).getTime()
+    : 0;
+  const canTriggerRefresh =
+    updatedAt && updatedAt < Date.now() - REFRESH_PERMISSIONS_TTL;
+
+  let canTriggerRefreshText = "Uprawnienia są aktualne";
+  if (canTriggerRefresh) {
+    canTriggerRefreshText = "Odśwież swoje uprawnienia";
+  } else if (updatedAt) {
+    const nextRefreshTime = updatedAt + REFRESH_PERMISSIONS_TTL;
+    const timeUntilRefresh = Math.ceil(
+      (nextRefreshTime - Date.now()) / (1000 * 60)
+    );
+    if (timeUntilRefresh > 0) {
+      canTriggerRefreshText = `Spróbuj ponownie za ${timeUntilRefresh} min`;
+    }
+  }
+
+  if (!canRefresh) {
+    canTriggerRefreshText =
+      "Nie można odświeżyć danych członka (musi się zalogować przez Discord ponownie)";
+  }
+
+  return { canRefresh, canTriggerRefresh, canTriggerRefreshText };
+};
+
+export const MemberSyncButton: FC<MemberSyncButtonProps> = ({ member }) => {
+  const { mutate: refreshMember, isPending } = useMemberRefresh();
+
+  const handleRefresh = useCallback(
+    (memberId: string) => {
+      refreshMember(
+        { memberId },
+        {
+          onSuccess: () => {},
+          onError: () => {},
+        }
+      );
+    },
+    [refreshMember]
+  );
+
+  const { canRefresh, canTriggerRefresh, canTriggerRefreshText } =
+    getRefreshInfo(member);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>
+          <Button
+            className="size-8 rounded-full"
+            size="sm"
+            variant="secondary"
+            disabled={isPending || !canRefresh || !canTriggerRefresh}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleRefresh(member.userId);
+            }}
+          >
+            <RefreshCcw />
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{canTriggerRefreshText}</TooltipContent>
+    </Tooltip>
+  );
+};

--- a/apps/web/src/screens/members-settings/components/members-panel.tsx
+++ b/apps/web/src/screens/members-settings/components/members-panel.tsx
@@ -1,0 +1,42 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { GuildMember } from "@/hooks/api/use-guild-member";
+import { MemberData } from "@/screens/members-settings/components/member-data";
+import { MemberSyncButton } from "@/screens/members-settings/components/member-sync-button";
+import { ArrowLeft } from "lucide-react";
+import { FC } from "react";
+
+export type MembersPanelContentProps = {
+  selectedMember: GuildMember;
+  setSelectedMember: (member: GuildMember | null) => void;
+  selectedMemberColor: string | undefined;
+};
+
+export const MembersPanelContent: FC<MembersPanelContentProps> = ({
+  selectedMember,
+  setSelectedMember,
+  selectedMemberColor,
+}) => (
+  <>
+    <div className="p-4 border-b h-12 flex flex-row gap-4 items-center justify-between">
+      <div className="flex items-center gap-4">
+        <ArrowLeft
+          className="cursor-pointer"
+          onClick={() => setSelectedMember(null)}
+        />
+        <div className="flex gap-4 items-center">
+          <div
+            className="font-semibold text-sm"
+            style={{ color: `#${selectedMemberColor}` }}
+          >
+            {selectedMember.name}
+          </div>
+        </div>
+      </div>
+
+      <MemberSyncButton member={selectedMember} />
+    </div>
+    <ScrollArea className="h-[calc(100vh-318px)]">
+      <MemberData member={selectedMember} />
+    </ScrollArea>
+  </>
+);

--- a/apps/web/src/screens/members-settings/members-settings.tsx
+++ b/apps/web/src/screens/members-settings/members-settings.tsx
@@ -1,0 +1,105 @@
+import { SearchInput } from "@/components/ui/search-input";
+import { useEffect, useRef, useState, useMemo } from "react";
+import { cn } from "@/utils/cn";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { AnimatePresence, motion } from "framer-motion";
+import { useGuildMembers } from "@/hooks/api/use-guild-members";
+import { GuildMember } from "@/hooks/api/use-guild-member";
+import { MembersPanelContent } from "@/screens/members-settings/components/members-panel";
+import { MemberItem } from "@/screens/members-settings/components/member-item";
+import { getColorFromRole } from "@/utils/get-color-from-role";
+
+export const MembersSettings = () => {
+  const { data: members } = useGuildMembers();
+  const [searchValue, setSearchValue] = useState("");
+  const [selectedMember, setSelectedMember] = useState<GuildMember | null>(
+    null
+  );
+  const [shouldAnimate, setShouldAnimate] = useState(false);
+
+  const prevSelectedMember = useRef<GuildMember | null>(null);
+
+  useEffect(() => {
+    setShouldAnimate(
+      prevSelectedMember.current === null && selectedMember !== null
+    );
+    prevSelectedMember.current = selectedMember;
+  }, [selectedMember]);
+
+  const filteredMembers = useMemo(() => {
+    if (!members) return [];
+    const search = searchValue.trim().toLowerCase();
+    if (!search) return members;
+    return members.filter((member) =>
+      member.name.toLowerCase().includes(search)
+    );
+  }, [members, searchValue]);
+
+  const selectedMemberColor = useMemo(() => {
+    if (!selectedMember) return undefined;
+    return getColorFromRole(selectedMember.roles);
+  }, [selectedMember]);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="p-4 pb-6">
+        <div className="text-lg font-semibold">Ustawienia członków</div>
+        <div className="text-sm text-gray-500">
+          Ustawienia członków, którzy mogą być przypisani do ról na serwerze
+          Discord. Tutaj możesz przypisać uprawnienia do ról.
+        </div>
+      </div>
+      <div className="p-4 border-t box-border">
+        <SearchInput
+          onChange={(e) => setSearchValue(e.target.value)}
+          placeholder="Szukaj roli..."
+        />
+      </div>
+      <div
+        className={cn("border-t grid grid-cols-[1fr] flex-1 box-border", {
+          "grid-cols-[theme(width.64)_1fr]": selectedMember,
+        })}
+      >
+        <ScrollArea className="flex flex-col h-[calc(100vh-280px)]">
+          {filteredMembers?.map((member) => (
+            <MemberItem
+              key={member.id}
+              member={member}
+              active={selectedMember?.id === member.id}
+              onSelect={() => setSelectedMember(member)}
+              showActions={!selectedMember}
+            />
+          ))}
+        </ScrollArea>
+        <AnimatePresence>
+          {selectedMember &&
+            (shouldAnimate ? (
+              <motion.div
+                className="border-l"
+                initial={{ opacity: 0, x: 64 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                key={selectedMember.id}
+              >
+                <MembersPanelContent
+                  selectedMember={selectedMember}
+                  setSelectedMember={setSelectedMember}
+                  selectedMemberColor={selectedMemberColor}
+                />
+              </motion.div>
+            ) : (
+              <div className="border-l">
+                <MembersPanelContent
+                  key={selectedMember.id}
+                  selectedMember={selectedMember}
+                  setSelectedMember={setSelectedMember}
+                  selectedMemberColor={selectedMemberColor}
+                />
+              </div>
+            ))}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/screens/roles-settings/roles-settings.tsx
+++ b/apps/web/src/screens/roles-settings/roles-settings.tsx
@@ -52,7 +52,7 @@ export const RolesSettings = () => {
           "grid-cols-[theme(width.64)_1fr]": selectedRole,
         })}
       >
-        <ScrollArea className="flex flex-col h-[calc(100vh-270px)]">
+        <ScrollArea className="flex flex-col h-[calc(100vh-280px)]">
           {filteredRoles?.map((role) => {
             const color = role.color === 0 ? "FFF" : role.color.toString(16);
             const active = selectedRole?.id === role.id;

--- a/apps/web/src/utils/get-avatar-url.ts
+++ b/apps/web/src/utils/get-avatar-url.ts
@@ -1,0 +1,19 @@
+export const getDiscordAvatarUrl = (
+  userId?: string,
+  avatar?: string | null | undefined,
+  size: number = 128
+): string => {
+  if (avatar?.startsWith("http")) {
+    return avatar;
+  }
+
+  if (!userId) {
+    return `https://cdn.discordapp.com/embed/avatars/${Math.floor(Math.random() * 5)}.png`;
+  }
+
+  if (!avatar) {
+    return `https://cdn.discordapp.com/embed/avatars/${Number(userId) % 5}.png`;
+  }
+
+  return `https://cdn.discordapp.com/avatars/${userId}/${avatar}?size=${size}`;
+};

--- a/apps/web/src/utils/get-color-from-role.ts
+++ b/apps/web/src/utils/get-color-from-role.ts
@@ -1,0 +1,6 @@
+import { GuildMember } from "@/hooks/api/use-guild-member";
+
+export const getColorFromRole = (roles: GuildMember["roles"]) => {
+  const color = roles[0]?.color;
+  return color === 0 ? "FFF" : color?.toString(16);
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a members panel to the settings, allowing admins to view, search, and refresh Discord member data and roles.

- **New Features**
  - New members settings page with searchable member list and detail panel.
  - Member roles and permissions are displayed, with sync button to refresh data.
  - Backend endpoints and schema updated to support member refresh and global user IDs.

<!-- End of auto-generated description by cubic. -->

