### PR TITLE
fix: comment list

### DIFF
--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -185,15 +185,12 @@ export class LootsService {
     guildId: string;
     lootId: number;
   }) {
-    const { discordId, guildId, lootId } = options;
+    const { guildId, lootId } = options;
 
     const comments = await this.prisma.lootComment.findMany({
       where: {
         guildId,
         lootId,
-        member: {
-          userId: discordId,
-        },
       },
       orderBy: {
         createdAt: 'desc',


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the comment list query to return all comments for a loot, not just those from a specific user.

<!-- End of auto-generated description by cubic. -->

