### PR TITLE
fix: disabled guilds sending

### DIFF
--- a/apps/api/src/discord/discord.service.ts
+++ b/apps/api/src/discord/discord.service.ts
@@ -42,9 +42,6 @@ export class DiscordService implements OnModuleInit {
   async getRestClient(userId: string) {
     const token = await this.authService.getIdpToken(userId);
 
-    this.logger.debug(`Retrieving REST client for user: ${userId}`);
-    this.logger.debug(`Token: ${JSON.stringify(token)}`);
-
     if (!token) {
       throw new Error('Failed to retrieve IDP token');
     }
@@ -73,14 +70,9 @@ export class DiscordService implements OnModuleInit {
     if (!bypassCache) {
       const cached = await this.redisService.get(cacheKey);
       if (cached) {
-        this.logger.debug(`Cache hit for user: ${userId}`);
-        this.logger.debug(`Cache key: ${cacheKey}`);
         return (JSON.parse(cached) as APIGuild[]).map((g) => g.id);
       }
     }
-
-    this.logger.debug(`Cache miss for user: ${userId}`);
-    this.logger.debug(`Lock key: ${lockKey}`);
 
     let lock: Awaited<ReturnType<typeof this.redlock.acquire>> | null = null;
 
@@ -89,8 +81,6 @@ export class DiscordService implements OnModuleInit {
 
       if (!bypassCache) {
         const cachedAfterLock = await this.redisService.get(cacheKey);
-        this.logger.debug(`Cache after lock for user: ${userId}`);
-        this.logger.debug(`Cache key after lock: ${cacheKey}`);
         if (cachedAfterLock) {
           return (JSON.parse(cachedAfterLock) as APIGuild[]).map((g) => g.id);
         }
@@ -99,9 +89,6 @@ export class DiscordService implements OnModuleInit {
       const rest = await this.getRestClient(userId);
 
       const guilds = (await rest.get(Routes.userGuilds())) as APIGuild[];
-
-      this.logger.debug(`Fetched guilds for user: ${userId}`);
-      this.logger.debug(`Guilds: ${JSON.stringify(guilds)}`);
 
       if (!guilds || guilds.length === 0) {
         this.logger.warn(`No guilds found for user: ${userId}`);
@@ -126,7 +113,6 @@ export class DiscordService implements OnModuleInit {
     const cacheKey = `user:${userId}:guilds:data`;
 
     await this.redisService.del(cacheKey);
-    this.logger.debug(`Cache cleared for user: ${userId}`);
   }
 
   async getGuildMember(options: {

--- a/apps/game-client/src/index.css
+++ b/apps/game-client/src/index.css
@@ -144,7 +144,7 @@ body.si > #lootlog-root {
   height: 100%;
 }
 
-.bottom-wrapper {
+.inner-wrapper > .right-main-column-wrapper > .bottom-wrapper {
   height: calc(100% - 406px);
   width: 253px !important;
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Stopped sending guilds data to clients by removing the guilds field from user objects in socket events and room presence. Also cleaned up debug logs and fixed a minor CSS selector.

- **Bug Fixes**
  - Removed guilds from user data sent over sockets to prevent exposure.
  - Updated CSS selector for .bottom-wrapper to target the correct element.
  - Deleted unnecessary debug logging in Discord service.

<!-- End of auto-generated description by cubic. -->

