### PR TITLE
fix: add timer

### DIFF
--- a/apps/game-client/src/components/ui/select.tsx
+++ b/apps/game-client/src/components/ui/select.tsx
@@ -87,7 +87,7 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          "ll-box-border ll-max-h-96 ll-w-full ll-flex ll-flex-col ll-shadow-lg ll-items-center ll-justify-center ll-px-1 ll-gap-1",
+          "ll-box-border ll-w-full ll-flex ll-flex-col ll-shadow-lg ll-items-center ll-justify-center ll-px-1 ll-gap-1",
           position === "popper" &&
             "ll-h-[var(--radix-select-trigger-height)] ll-min-w-[var(--radix-select-trigger-width)]"
         )}

--- a/apps/game-client/src/features/timers/components/add-timer-form.tsx
+++ b/apps/game-client/src/features/timers/components/add-timer-form.tsx
@@ -14,7 +14,6 @@ import { Label } from "@/components/ui/label";
 import { NpcType } from "@/hooks/api/use-npcs";
 import { useCreateManualTimer } from "@/hooks/api/use-create-manual-timer";
 import { useGlobalStore } from "@/store/global.store";
-import { useLocalStorage } from "react-use";
 import { useWindowsStore } from "@/store/windows.store";
 import {
   calculateMaxOffsetFromMinOffset,
@@ -23,6 +22,7 @@ import {
   parseDurationToSeconds,
 } from "@/features/timers/helpers/add-timer-form-helpers";
 import { DEFAULT_RESPAWN_RANDOMNESS } from "@/features/timers/constants/default-respawn-randomness";
+import { useSettingsStore } from "@/store/settings.store";
 
 const MULTIPLIER_BY_NPC_TYPE: Record<string, number> = {
   [NpcType.ELITE2]: 10,
@@ -65,13 +65,8 @@ type FormValues = z.infer<typeof schema>;
 
 export const AddTimerForm: React.FC = () => {
   const { mutate: createManualTimer, isPending } = useCreateManualTimer();
-  const { world, accountId, characterId } = useGlobalStore(
-    (state) => state.gameState
-  );
-  const [selectedGuildId] = useLocalStorage(
-    `ll:timers:selected-guild:${accountId}:${characterId}`,
-    ""
-  );
+  const { world } = useGlobalStore((state) => state.gameState);
+  const { guildId } = useSettingsStore();
   const { setOpen } = useWindowsStore();
 
   const { register, handleSubmit, setValue, watch } = useForm<FormValues>({
@@ -83,7 +78,7 @@ export const AddTimerForm: React.FC = () => {
   });
 
   const onSubmit = (data: FormValues) => {
-    if (!world || !selectedGuildId) return;
+    if (!world || !guildId) return;
 
     const { name, minSpawn, npcType } = data;
     const respawnRandomness = npcType
@@ -101,7 +96,7 @@ export const AddTimerForm: React.FC = () => {
         respBaseSeconds,
         respawnRandomness,
         world,
-        guildId: selectedGuildId,
+        guildId,
       },
       {
         onSuccess: () => {

--- a/apps/game-client/src/features/timers/timers.tsx
+++ b/apps/game-client/src/features/timers/timers.tsx
@@ -93,6 +93,12 @@ export const Timers = () => {
     timersFilters,
   } = useTimersStore();
   const { world, allowWorldSelection, guildId } = useSettingsStore();
+  const desiredWorld = timersGrouping ? defaultWorld : world || defaultWorld;
+  const desiredWorldRef = useRef<string | undefined>(desiredWorld);
+
+  useEffect(() => {
+    desiredWorldRef.current = desiredWorld;
+  }, [desiredWorld]);
 
   const settingsKey = timersGrouping ? "global" : guildId!;
   const filters = timersFilters[settingsKey] || DEFAULT_TIMERS_FILTERS;
@@ -101,7 +107,7 @@ export const Timers = () => {
     guildId,
   });
   const { data: timers } = useTimers({
-    world: timersGrouping ? defaultWorld : world || defaultWorld,
+    world: desiredWorld,
   });
   const { socket, connected } = useGateway();
   const queryClient = useQueryClient();
@@ -138,9 +144,9 @@ export const Timers = () => {
 
   const handleTimerMessage = (data: Timer) => {
     queryClient.setQueryData(
-      ["guild-timers", world],
+      ["guild-timers", desiredWorldRef.current],
       (old: AxiosResponse<Timer[]>) => {
-        if (data.world !== world) return old;
+        if (data.world !== desiredWorldRef.current) return old;
         const updated = [...(old?.data || [])];
         const index = updated.findIndex(
           (t) =>
@@ -156,9 +162,9 @@ export const Timers = () => {
 
   const handleTimerRemove = (data: Timer) => {
     queryClient.setQueryData(
-      ["guild-timers", world],
+      ["guild-timers", desiredWorldRef.current],
       (old: AxiosResponse<Timer[]>) => {
-        if (data.world !== world) return old;
+        if (data.world !== desiredWorldRef.current) return old;
         const filtered =
           old?.data.filter(
             (t) =>

--- a/apps/game-client/src/store/settings.store.ts
+++ b/apps/game-client/src/store/settings.store.ts
@@ -31,6 +31,7 @@ export const useSettingsStore = create<SettingsState>()(
       partialize: (state) => ({
         allowWorldSelection: state.allowWorldSelection,
         world: state.world,
+        guildId: state.guildId,
       }),
       storage: createJSONStorage(() => localStorage),
       version: 1,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed issues with adding timers by updating how guild and world selection are handled in the timer form and timers list.

- **Bug Fixes**
  - Replaced local storage usage with settings store for guild selection in the add timer form.
  - Ensured timers use the correct world and guild context when adding or updating timers.

<!-- End of auto-generated description by cubic. -->

