### PR TITLE
fix: guild by char id

### DIFF
--- a/apps/game-client/src/components/guild-selector.tsx
+++ b/apps/game-client/src/components/guild-selector.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/ui/select";
 import { useGuilds } from "@/hooks/api/use-guilds";
 import { cn } from "@/lib/utils";
+import { useGlobalStore } from "@/store/global.store";
 import { useSettingsStore } from "@/store/settings.store";
 import { FC } from "react";
 import { useDeepCompareEffect } from "react-use";
@@ -24,23 +25,35 @@ export const GuildSelector: FC<GuildSelectorProps> = ({
   onChange,
   value,
 }) => {
+  const { characterId } = useGlobalStore((state) => state.gameState);
   const { data: guilds, isFetched } = useGuilds();
-  const { setGuildId, guildId } = useSettingsStore();
+  const { setGuildId, guildIdByCharId } = useSettingsStore();
+
+  const guildId = guildIdByCharId[characterId!];
 
   useDeepCompareEffect(() => {
     if (!isFetched || !guilds || guilds.length === 0 || value) return;
     const exists = guilds.some((guild) => guild.id === guildId);
     if (!exists) {
-      setGuildId(guilds[0].id);
+      setGuildId(characterId!, guilds[0].id);
     }
   }, [guilds, isFetched, guildId]);
 
   const selectedValue = value !== undefined ? value : guildId;
 
+  const handleChange = (newGuildId: string) => {
+    if (onChange) {
+      onChange(newGuildId);
+      return;
+    }
+
+    setGuildId(characterId!, newGuildId);
+  };
+
   return (
     <Select
       value={selectedValue}
-      onValueChange={onChange || setGuildId}
+      onValueChange={handleChange}
       disabled={disabled}
     >
       <SelectTrigger

--- a/apps/game-client/src/components/world-selector.tsx
+++ b/apps/game-client/src/components/world-selector.tsx
@@ -20,8 +20,11 @@ export const WorldSelector: FC<WorldSelectorProps> = ({
   disabled = false,
   className = "",
 }) => {
-  const { world: defaultWorld } = useGlobalStore((state) => state.gameState);
-  const { guildId, world, setWorld } = useSettingsStore();
+  const { world: defaultWorld, characterId } = useGlobalStore(
+    (state) => state.gameState
+  );
+  const { guildIdByCharId, world, setWorld } = useSettingsStore();
+  const guildId = guildIdByCharId[characterId!];
   const { data: worlds, isFetched } = useWorlds({ guildId });
 
   useEffect(() => {

--- a/apps/game-client/src/features/online-players/components/online-players-list.tsx
+++ b/apps/game-client/src/features/online-players/components/online-players-list.tsx
@@ -8,8 +8,11 @@ import { useSettingsStore } from "@/store/settings.store";
 import { FC } from "react";
 
 export const OnlinePlayersList: FC = () => {
-  const { world: defaultWorld } = useGlobalStore((state) => state.gameState);
-  const { allowWorldSelection, guildId, world } = useSettingsStore();
+  const { world: defaultWorld, characterId } = useGlobalStore(
+    (state) => state.gameState
+  );
+  const { allowWorldSelection, guildIdByCharId, world } = useSettingsStore();
+  const guildId = guildIdByCharId[characterId!];
   const [onlinePlayers] = usePlayersPresence(guildId, world || defaultWorld);
 
   const onlinePlayersList = Object.entries(onlinePlayers);

--- a/apps/game-client/src/features/timers/components/add-timer-form.tsx
+++ b/apps/game-client/src/features/timers/components/add-timer-form.tsx
@@ -65,8 +65,9 @@ type FormValues = z.infer<typeof schema>;
 
 export const AddTimerForm: React.FC = () => {
   const { mutate: createManualTimer, isPending } = useCreateManualTimer();
-  const { world } = useGlobalStore((state) => state.gameState);
-  const { guildId } = useSettingsStore();
+  const { world, characterId } = useGlobalStore((state) => state.gameState);
+  const { guildIdByCharId } = useSettingsStore();
+  const guildId = guildIdByCharId[characterId!];
   const { setOpen } = useWindowsStore();
 
   const { register, handleSubmit, setValue, watch } = useForm<FormValues>({

--- a/apps/game-client/src/features/timers/timers.tsx
+++ b/apps/game-client/src/features/timers/timers.tsx
@@ -69,9 +69,11 @@ const mergeTimers = (timers: Timer[]): TimerWithTimeLeft[] => {
 };
 
 export const Timers = () => {
-  const { world: defaultWorld, gameInterface } = useGlobalStore(
-    (s) => s.gameState
-  );
+  const {
+    world: defaultWorld,
+    gameInterface,
+    characterId,
+  } = useGlobalStore((s) => s.gameState);
   const {
     timers: { open },
     "add-timer": { open: addTimerOpen },
@@ -92,7 +94,8 @@ export const Timers = () => {
     setTimersSortOrder,
     timersFilters,
   } = useTimersStore();
-  const { world, allowWorldSelection, guildId } = useSettingsStore();
+  const { world, allowWorldSelection, guildIdByCharId } = useSettingsStore();
+  const guildId = guildIdByCharId[characterId!];
   const desiredWorld = timersGrouping ? defaultWorld : world || defaultWorld;
   const desiredWorldRef = useRef<string | undefined>(desiredWorld);
 

--- a/apps/game-client/src/store/settings.store.ts
+++ b/apps/game-client/src/store/settings.store.ts
@@ -4,8 +4,8 @@ import { createJSONStorage, persist } from "zustand/middleware";
 interface SettingsState {
   allowWorldSelection?: boolean;
   world?: string;
-  guildId?: string;
-  setGuildId: (guildId: string) => void;
+  guildIdByCharId: Record<string, string>;
+  setGuildId: (charId: string, guildId: string) => void;
   setWorld: (world: string) => void;
   toggleAllowWorldSelection: () => void;
 }
@@ -15,9 +15,14 @@ export const useSettingsStore = create<SettingsState>()(
     (set, get) => ({
       world: undefined,
       allowWorldSelection: false,
-      guildId: undefined,
-      setGuildId: (guildId: string) => {
-        set({ guildId });
+      guildIdByCharId: {},
+      setGuildId: (charId: string, guildId: string) => {
+        set((state) => ({
+          guildIdByCharId: {
+            ...state.guildIdByCharId,
+            [charId]: guildId,
+          },
+        }));
       },
       setWorld: (world: string) => {
         set({ world });
@@ -31,7 +36,7 @@ export const useSettingsStore = create<SettingsState>()(
       partialize: (state) => ({
         allowWorldSelection: state.allowWorldSelection,
         world: state.world,
-        guildId: state.guildId,
+        guildIdByCharId: state.guildIdByCharId,
       }),
       storage: createJSONStorage(() => localStorage),
       version: 1,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated guild selection to track guild IDs by character, fixing issues when switching between characters.

- **Bug Fixes**
  - Guild and world selection now use the correct guild for each character.
  - Timers and online players lists show data for the selected character’s guild.

<!-- End of auto-generated description by cubic. -->

