### PR TITLE
feat: swagger

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm build:*)",
+      "Bash(npx tsc:*)",
+      "Bash(pnpm test:*)",
+      "Bash(npx prisma generate:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ npm-debug.log*
 *.pem
 
 generated
+
+CLAUDE.md

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@axiomhq/winston": "^1.3.0",
     "@discordjs/rest": "^2.5.1",
+    "@fastify/static": "^8.2.0",
     "@golevelup/nestjs-rabbitmq": "^6.0.1",
     "@nestjs/axios": "^4.0.0",
     "@nestjs/common": "^11.1.2",
@@ -32,6 +33,7 @@
     "@nestjs/microservices": "^11.1.2",
     "@nestjs/platform-fastify": "^11.1.2",
     "@nestjs/platform-socket.io": "^11.1.2",
+    "@nestjs/swagger": "^11.2.0",
     "@nestjs/websockets": "^11.1.2",
     "@prisma/client": "6.10.1",
     "axios": "^1.8.2",

--- a/apps/api/src/guilds/dto/update-guild-config.dto.ts
+++ b/apps/api/src/guilds/dto/update-guild-config.dto.ts
@@ -1,6 +1,12 @@
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateGuildConfigDto {
+  @ApiProperty({
+    description: 'Custom vanity URL for the guild',
+    example: 'my-awesome-guild',
+    required: false
+  })
   @IsNotEmpty()
   @IsString()
   @IsOptional()

--- a/apps/api/src/guilds/guilds.controller.ts
+++ b/apps/api/src/guilds/guilds.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam, ApiQuery } from '@nestjs/swagger';
 import { Guild, Permission } from 'generated/client';
 import { UpdateGuildConfigDto } from 'src/guilds/dto/update-guild-config.dto';
 import { GuildsService } from 'src/guilds/guilds.service';
@@ -21,12 +22,17 @@ import { AuthGuard } from 'src/shared/guards/auth.guard';
 import { Permissions } from 'src/shared/permissions/permissions.decorator';
 import { PermissionsGuard } from 'src/shared/permissions/permissions.guard';
 
+@ApiTags('guilds')
+@ApiBearerAuth()
 @UseGuards(AuthGuard)
 @Controller('guilds')
 export class GuildsController {
   constructor(private readonly guildsService: GuildsService) {}
 
   @Get('/@me')
+  @ApiOperation({ summary: 'Get user guilds', description: 'Retrieve all guilds for the authenticated user' })
+  @ApiResponse({ status: 200, description: 'List of user guilds' })
+  @ApiQuery({ name: 'source', required: false, description: 'Source of the request' })
   async getUserGuilds(
     @DiscordId() discordId: string,
     @UserId() userId: string,
@@ -46,6 +52,9 @@ export class GuildsController {
   @Permissions(Permission.LOOTLOG_READ)
   @UseGuards(PermissionsGuard)
   @Get(':guildId')
+  @ApiOperation({ summary: 'Get guild by ID', description: 'Retrieve guild information by guild ID' })
+  @ApiParam({ name: 'guildId', description: 'Guild ID' })
+  @ApiResponse({ status: 200, description: 'Guild information' })
   async getGuildById(@GuildData() guild: Guild) {
     return this.guildsService.getGuildById(guild.id);
   }

--- a/apps/api/src/healthz/healthz.controller.ts
+++ b/apps/api/src/healthz/healthz.controller.ts
@@ -1,11 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { HealthzService } from 'src/healthz/healthz.service';
 
+@ApiTags('health')
 @Controller('healthz')
 export class HealthzController {
   constructor(private readonly healthzService: HealthzService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Health check', description: 'Check the health status of the API' })
+  @ApiResponse({ status: 200, description: 'API is healthy' })
   healthCheck() {
     return this.healthzService.healthCheck();
   }

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -1,18 +1,622 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { LootsService } from './loots.service';
+import { PlayersService } from '../players/players.service';
+import { NpcsService } from '../npcs/npcs.service';
+import { GuildsService } from '../guilds/guilds.service';
+import { PrismaService } from '../db/prisma.service';
+import { LootlogConfigService } from '../lootlog-config/lootlog-config.service';
+import { UserLootlogConfigService } from '../user-lootlog-config/user-lootlog-config.service';
+import { CreateLootDto } from './dto/create-loot.dto';
+import { UpdateLootDto } from './dto/update-loot.dto';
+import { CreateCommentDto } from './dto/create-comment-dto';
+import { FetchLootsParamsDto } from './dto/fetch-loots-params.dto';
+import { 
+  ItemRarity, 
+  Profession, 
+  Permission, 
+  NpcType, 
+  LootSource,
+  Guild,
+  Role 
+} from 'generated/client';
+import { ErrorKey } from './enum/error-key.enum';
+
+// Mock constants to avoid import issues
+const MAX_PAGE_LIMIT = 100;
 
 describe('LootsService', () => {
   let service: LootsService;
+  let prismaService: any;
+  let playersService: jest.Mocked<PlayersService>;
+  let npcsService: jest.Mocked<NpcsService>;
+  let guildsService: jest.Mocked<GuildsService>;
+  let lootlogConfigService: jest.Mocked<LootlogConfigService>;
+  let userLootlogConfigService: jest.Mocked<UserLootlogConfigService>;
+
+  const mockGuild: Guild = {
+    id: 'guild1',
+    name: 'Test Guild',
+    vanityUrl: null,
+    icon: 'icon.png',
+    ownerId: 'owner123',
+    active: true,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const mockRole: Role = {
+    id: 'role1',
+    name: 'Test Role',
+    color: 16711680, // #FF0000 as number
+    position: 1,
+    permissions: [Permission.LOOTLOG_READ],
+    lvlRangeFrom: 1,
+    lvlRangeTo: 100,
+    guildId: 'guild1',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const mockCreateLootDto: CreateLootDto = {
+    loots: [{
+      id: 1,
+      hid: 'item1',
+      name: 'Test Item',
+      icon: 'item.png',
+      pr: 1000,
+      prc: '1k',
+      stat: 'lvl=50;rarity=UNIQUE',
+      cl: 1,
+      own: 1
+    }],
+    npcs: [{
+      id: 1,
+      name: 'Test NPC',
+      location: 'Test Location',
+      lvl: 50,
+      prof: 'w',
+      wt: 1000,
+      hpp: 5000,
+      icon: 'npc.png',
+      type: 1,
+      x: 100,
+      y: 200
+    }],
+    players: [{
+      id: 1,
+      accountId: 123,
+      name: 'Test Player',
+      lvl: 50,
+      prof: 'w',
+      icon: 'player.png',
+      hpp: 3000
+    }],
+    world: 'testworld',
+    source: LootSource.FIGHT,
+    location: 'Test Location',
+    accountId: '123',
+    characterId: '1'
+  };
 
   beforeEach(async () => {
+    const mockPrismaService = {
+      loot: {
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn()
+      },
+      lootSubmission: {
+        createMany: jest.fn(),
+        upsert: jest.fn(),
+        deleteMany: jest.fn(),
+        findMany: jest.fn()
+      },
+      lootComment: {
+        create: jest.fn(),
+        findMany: jest.fn()
+      },
+      member: {
+        findMany: jest.fn()
+      },
+      $queryRaw: jest.fn()
+    };
+
+    const mockPlayersService = {
+      bulkIndexPlayers: jest.fn()
+    };
+
+    const mockNpcsService = {
+      bulkIndexNpcs: jest.fn()
+    };
+
+    const mockGuildsService = {
+      getGuildsForRequiredPermissions: jest.fn()
+    };
+
+    const mockLootlogConfigService = {
+      getMultipleLootlogConfigs: jest.fn()
+    };
+
+    const mockUserLootlogConfigService = {
+      getLootlogCharacterConfig: jest.fn()
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [LootsService],
+      providers: [
+        LootsService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: PlayersService, useValue: mockPlayersService },
+        { provide: NpcsService, useValue: mockNpcsService },
+        { provide: GuildsService, useValue: mockGuildsService },
+        { provide: LootlogConfigService, useValue: mockLootlogConfigService },
+        { provide: UserLootlogConfigService, useValue: mockUserLootlogConfigService }
+      ],
     }).compile();
 
     service = module.get<LootsService>(LootsService);
+    prismaService = module.get(PrismaService);
+    playersService = module.get(PlayersService);
+    npcsService = module.get(NpcsService);
+    guildsService = module.get(GuildsService);
+    lootlogConfigService = module.get(LootlogConfigService);
+    userLootlogConfigService = module.get(UserLootlogConfigService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
+  });
+
+  describe('createLoot', () => {
+    const discordId = 'discord123';
+    const userId = 'user123';
+
+    beforeEach(() => {
+      guildsService.getGuildsForRequiredPermissions.mockResolvedValue([mockGuild]);
+      userLootlogConfigService.getLootlogCharacterConfig.mockResolvedValue(null);
+      lootlogConfigService.getMultipleLootlogConfigs.mockResolvedValue([{
+        id: 'guild1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        npcs: [{
+          id: 1,
+          npcType: NpcType.COMMON,
+          allowedRarities: [ItemRarity.UNIQUE, ItemRarity.LEGENDARY],
+          lootlogConfigId: 'config1',
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }]
+      } as any]);
+      prismaService.member.findMany.mockResolvedValue([{
+        id: 'member1',
+        guildId: 'guild1',
+        userId: discordId
+      }]);
+    });
+
+    it('should throw BadRequestException when too many loots', async () => {
+      const tooManyLoots = Array(11).fill(mockCreateLootDto.loots[0]);
+      const dto = { ...mockCreateLootDto, loots: tooManyLoots };
+
+      await expect(service.createLoot(discordId, userId, dto))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ForbiddenException when user has no guilds with write permission', async () => {
+      guildsService.getGuildsForRequiredPermissions.mockResolvedValue([]);
+
+      await expect(service.createLoot(discordId, userId, mockCreateLootDto))
+        .rejects.toThrow(ForbiddenException);
+    });
+
+    it('should create new loot when it does not exist', async () => {
+      const mockLoot = { id: 1, uniqueId: 'unique123' };
+      prismaService.loot.findUnique.mockResolvedValue(null);
+      prismaService.loot.create.mockResolvedValue(mockLoot);
+
+      const result = await service.createLoot(discordId, userId, mockCreateLootDto);
+
+      expect(prismaService.loot.create).toHaveBeenCalled();
+      expect(prismaService.lootSubmission.createMany).toHaveBeenCalled();
+      expect(playersService.bulkIndexPlayers).toHaveBeenCalled();
+      expect(npcsService.bulkIndexNpcs).toHaveBeenCalled();
+      expect(result).toEqual({ id: mockLoot.id });
+    });
+
+    it('should return existing loot when it already exists', async () => {
+      const mockLoot = { id: 1, uniqueId: 'unique123' };
+      prismaService.loot.findUnique.mockResolvedValue(mockLoot);
+
+      const result = await service.createLoot(discordId, userId, mockCreateLootDto);
+
+      expect(prismaService.loot.create).not.toHaveBeenCalled();
+      expect(playersService.bulkIndexPlayers).not.toHaveBeenCalled();
+      expect(npcsService.bulkIndexNpcs).not.toHaveBeenCalled();
+      expect(result).toEqual({ id: mockLoot.id });
+    });
+
+    it('should handle race condition on loot creation (P2002 error)', async () => {
+      const mockLoot = { id: 1, uniqueId: 'unique123' };
+      prismaService.loot.findUnique
+        .mockResolvedValueOnce(null) // First call returns null
+        .mockResolvedValueOnce(mockLoot); // Second call after P2002 returns loot
+      
+      const p2002Error = new Error('Unique constraint failed');
+      (p2002Error as any).code = 'P2002';
+      prismaService.loot.create.mockRejectedValue(p2002Error);
+
+      const result = await service.createLoot(discordId, userId, mockCreateLootDto);
+
+      expect(prismaService.loot.findUnique).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ id: mockLoot.id });
+    });
+
+    it('should not create submissions when no valid configs found', async () => {
+      lootlogConfigService.getMultipleLootlogConfigs.mockResolvedValue([]);
+      const mockLoot = { id: 1, uniqueId: 'unique123' };
+      prismaService.loot.findUnique.mockResolvedValue(null);
+      prismaService.loot.create.mockResolvedValue(mockLoot);
+
+      await service.createLoot(discordId, userId, mockCreateLootDto);
+
+      expect(prismaService.lootSubmission.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getComments', () => {
+    const options = {
+      discordId: 'discord123',
+      guildId: 'guild1',
+      lootId: 1
+    };
+
+    it('should return comments for loot', async () => {
+      const mockComments = [{
+        id: 'comment1',
+        content: 'Test comment',
+        member: {
+          name: 'Test User',
+          avatar: 'avatar.png',
+          userId: 'user123',
+          roles: [{ color: 16711680 }]
+        }
+      }];
+      prismaService.lootComment.findMany.mockResolvedValue(mockComments);
+
+      const result = await service.getComments(options);
+
+      expect(prismaService.lootComment.findMany).toHaveBeenCalledWith({
+        where: { guildId: options.guildId, lootId: options.lootId },
+        orderBy: { createdAt: 'desc' },
+        include: {
+          member: {
+            select: {
+              name: true,
+              avatar: true,
+              userId: true,
+              roles: {
+                select: { color: true },
+                orderBy: { position: 'desc' }
+              }
+            }
+          }
+        }
+      });
+      expect(result).toEqual(mockComments);
+    });
+  });
+
+  describe('deleteLoot', () => {
+    const options = { guildId: 'guild1', lootId: 1 };
+
+    it('should delete loot submissions when loot exists', async () => {
+      const mockLoot = { id: 1 };
+      prismaService.loot.findFirst.mockResolvedValue(mockLoot);
+
+      await service.deleteLoot(options);
+
+      expect(prismaService.lootSubmission.deleteMany).toHaveBeenCalledWith({
+        where: { lootId: options.lootId, guildId: options.guildId }
+      });
+    });
+
+    it('should throw ForbiddenException when loot does not exist', async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+
+      await expect(service.deleteLoot(options))
+        .rejects.toThrow(new ForbiddenException(ErrorKey.CANT_DELETE_LOOT));
+    });
+  });
+
+  describe('createComment', () => {
+    const options = {
+      discordId: 'discord123',
+      userId: 'user123',
+      guildId: 'guild1',
+      lootId: 1,
+      body: { content: 'Test comment' } as CreateCommentDto
+    };
+
+    it('should create comment when loot exists', async () => {
+      const mockLoot = { id: 1 };
+      const mockComment = { id: 'comment1', content: 'Test comment' };
+      prismaService.loot.findFirst.mockResolvedValue(mockLoot);
+      prismaService.lootComment.create.mockResolvedValue(mockComment);
+
+      const result = await service.createComment(options);
+
+      expect(prismaService.lootComment.create).toHaveBeenCalled();
+      expect(result).toEqual(mockComment);
+    });
+
+    it('should throw ForbiddenException when loot does not exist', async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+
+      await expect(service.createComment(options))
+        .rejects.toThrow(new ForbiddenException(ErrorKey.CANT_CREATE_COMMENT));
+    });
+  });
+
+  describe('updateLoot', () => {
+    const discordId = 'discord123';
+    const lootId = 1;
+    const updateData: UpdateLootDto = {
+      msg: 'Test Player otrzymał: [item1]'
+    };
+
+    it('should update loot share when valid', async () => {
+      const mockLoot = {
+        id: 1,
+        lootShare: {},
+        players: JSON.stringify([{ id: '1123', name: 'Test Player' }]),
+        items: JSON.stringify([{ hid: 'item1', name: 'Test Item' }])
+      };
+      const mockUpdatedLoot = { lootShare: { '1123': ['item1'] } };
+      
+      prismaService.loot.findFirst.mockResolvedValue(mockLoot);
+      prismaService.loot.update.mockResolvedValue(mockUpdatedLoot);
+
+      const result = await service.updateLoot(discordId, lootId, updateData);
+
+      expect(prismaService.loot.update).toHaveBeenCalledWith({
+        where: { id: lootId },
+        data: { lootShare: { '1123': ['item1'] } }
+      });
+      expect(result).toEqual({ '1123': ['item1'] });
+    });
+
+    it('should throw ForbiddenException when loot not found', async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+
+      await expect(service.updateLoot(discordId, lootId, updateData))
+        .rejects.toThrow(new ForbiddenException(ErrorKey.CANT_UPDATE_LOOT));
+    });
+
+    it('should throw BadRequestException when no loot share found in message', async () => {
+      const mockLoot = {
+        id: 1,
+        lootShare: {},
+        players: JSON.stringify([]),
+        items: JSON.stringify([])
+      };
+      prismaService.loot.findFirst.mockResolvedValue(mockLoot);
+
+      const invalidUpdateData = { msg: 'Invalid message' };
+
+      await expect(service.updateLoot(discordId, lootId, invalidUpdateData))
+        .rejects.toThrow(new BadRequestException(ErrorKey.MISSING_LOOT_SHARE));
+    });
+  });
+
+  describe('fetchLootsByGuildId', () => {
+    const params: FetchLootsParamsDto = {
+      cursor: null,
+      limit: 10,
+      npcTypes: [],
+      npcs: [],
+      players: [],
+      rarities: [],
+      world: 'testworld'
+    };
+
+    it('should throw BadRequestException when limit too high', async () => {
+      const highLimitParams = { ...params, limit: 1000 };
+
+      await expect(service.fetchLootsByGuildId(mockGuild, [], [], highLimitParams))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should return loots with submissions', async () => {
+      const mockLoots = [{ id: 1, uniqueId: 'unique1' }];
+      const mockSubmissions = [{
+        lootId: 1,
+        member: { name: 'Test User', avatar: 'avatar.png', userId: 'user123' }
+      }];
+
+      prismaService.$queryRaw.mockResolvedValue(mockLoots);
+      prismaService.lootSubmission.findMany.mockResolvedValue(mockSubmissions);
+
+      const result = await service.fetchLootsByGuildId(mockGuild, [], [], params);
+
+      expect(result).toEqual([{
+        id: 1,
+        uniqueId: 'unique1',
+        submissions: [mockSubmissions[0]]
+      }]);
+    });
+
+    it('should return empty array when no loots found', async () => {
+      prismaService.$queryRaw.mockResolvedValue([]);
+
+      const result = await service.fetchLootsByGuildId(mockGuild, [], [], params);
+
+      expect(result).toEqual([]);
+      expect(prismaService.lootSubmission.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('helper methods', () => {
+    describe('createUniqueLootId', () => {
+      it('should create consistent hash for same input', () => {
+        const loots = [{ hid: 'item1' }, { hid: 'item2' }];
+        const world = 'testworld';
+
+        const result1 = service.createUniqueLootId(loots as any, world);
+        const result2 = service.createUniqueLootId(loots as any, world);
+
+        expect(result1).toBe(result2);
+        expect(result1).toHaveLength(64); // SHA256 hex length
+      });
+
+      it('should create different hashes for different inputs', () => {
+        const loots1 = [{ hid: 'item1' }];
+        const loots2 = [{ hid: 'item2' }];
+        const world = 'testworld';
+
+        const result1 = service.createUniqueLootId(loots1 as any, world);
+        const result2 = service.createUniqueLootId(loots2 as any, world);
+
+        expect(result1).not.toBe(result2);
+      });
+    });
+
+    describe('parseItemStats', () => {
+      it('should parse item stats correctly', () => {
+        const stats = 'lvl=50;rarity=UNIQUE;reqp=w';
+        
+        const result = service.parseItemStats(stats);
+
+        expect(result).toEqual({
+          lvl: '50',
+          rarity: 'UNIQUE',
+          reqp: 'w'
+        });
+      });
+
+      it('should handle empty stats', () => {
+        const result = service.parseItemStats('');
+        expect(result).toEqual({});
+      });
+
+      it('should ignore malformed entries', () => {
+        const stats = 'lvl=50;invalidentry;rarity=UNIQUE';
+        
+        const result = service.parseItemStats(stats);
+
+        expect(result).toEqual({
+          lvl: '50',
+          rarity: 'UNIQUE'
+        });
+      });
+    });
+
+    describe('getItemStats', () => {
+      it('should extract item statistics correctly', () => {
+        const item = {
+          stat: 'lvl=50;rarity=UNIQUE;reqp=w',
+          cl: 1
+        } as any;
+
+        const result = service.getItemStats(item);
+
+        expect(result).toEqual({
+          lvl: 50,
+          rarity: ItemRarity.UNIQUE,
+          prof: [Profession.WARRIOR],
+          type: expect.any(String) // Depends on getItemTypeByCl implementation
+        });
+      });
+
+      it('should handle missing level', () => {
+        const item = {
+          stat: 'rarity=UNIQUE',
+          cl: 1
+        } as any;
+
+        const result = service.getItemStats(item);
+
+        expect(result.lvl).toBe(0);
+      });
+
+      it('should default to all professions when no reqp specified', () => {
+        const item = {
+          stat: 'lvl=50;rarity=UNIQUE',
+          cl: 1
+        } as any;
+
+        const result = service.getItemStats(item);
+
+        expect(result.prof).toEqual(Object.values(Profession));
+      });
+    });
+
+    describe('parseJsonField', () => {
+      it('should parse JSON string', () => {
+        const jsonString = '{"test": "value"}';
+        
+        const result = service['parseJsonField'](jsonString);
+
+        expect(result).toEqual({ test: 'value' });
+      });
+
+      it('should return non-string values as-is', () => {
+        const objectValue = { test: 'value' };
+        
+        const result = service['parseJsonField'](objectValue);
+
+        expect(result).toBe(objectValue);
+      });
+    });
+
+    describe('processNpcs', () => {
+      it('should sort NPCs by wt descending and return processed data', () => {
+        const npcs = [
+          { id: 1, wt: 100, name: 'NPC1', lvl: 10, prof: 'w', icon: 'icon1.png', location: 'loc1', type: 1, hpp: 1000, x: 100, y: 200 },
+          { id: 2, wt: 200, name: 'NPC2', lvl: 20, prof: 'p', icon: 'icon2.png', location: 'loc2', type: 2, hpp: 2000, x: 150, y: 250 }
+        ];
+
+        const result = service['processNpcs'](npcs);
+
+        expect(result.highest).toEqual(npcs[1]); // Highest wt NPC
+        expect(result.sorted).toEqual([npcs[1], npcs[0]]); // Sorted descending
+        expect(result.mapped).toHaveLength(2);
+        expect(result.mapped[0].wt).toBe(200); // First should be highest
+      });
+    });
+
+    describe('getLootShareFromMsg', () => {
+      it('should parse loot share message correctly', () => {
+        const msg = 'Test Player otrzymał: [item1][item2]';
+        
+        const result = service.getLootShareFromMsg(msg);
+
+        expect(result).toEqual({
+          'Test Player': ['item1', 'item2']
+        });
+      });
+
+      it('should handle empty message', () => {
+        const result = service.getLootShareFromMsg('');
+        expect(result).toEqual({});
+      });
+
+      it('should handle multiple players', () => {
+        const msg = 'Player1 otrzymał: [item1] Player2 otrzymał: [item2]';
+        
+        const result = service.getLootShareFromMsg(msg);
+
+        expect(result).toEqual({
+          'Player1': ['item1'],
+          'Player2': ['item2']
+        });
+      });
+    });
   });
 });

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -9,8 +9,8 @@ import { FetchLootsParamsDto } from 'src/loots/dto/fetch-loots-params.dto';
 import {
   DEFAULT_PAGE_LIMIT,
   MAX_PAGE_LIMIT,
-} from 'src/loots/config/pagination';
-import { ErrorKey } from 'src/loots/enum/error-key.enum';
+} from './config/pagination';
+import { ErrorKey } from './enum/error-key.enum';
 import { PlayersService } from 'src/players/players.service';
 import { NpcsService } from 'src/npcs/npcs.service';
 import { getNpcTypeByWt } from 'src/shared/utils/get-npc-type-by-wt';
@@ -96,25 +96,25 @@ export class LootsService {
       }),
     ]);
 
-    const highestWtNpc = body.npcs.reduce((prev, current) => {
-      return prev && prev.wt > current.wt ? prev : current;
-    });
+    const npcData = this.processNpcs(body.npcs);
     const highestWtNpcType = getNpcTypeByWt(
-      highestWtNpc.wt,
-      highestWtNpc.prof,
-      highestWtNpc.type,
+      npcData.highest.wt,
+      npcData.highest.prof,
+      npcData.highest.type,
     );
 
-    const sortedNpcsByWt = this.sortNpcsByWt(body.npcs);
-    const npcs = this.mapNpcs(sortedNpcsByWt);
-    const players = this.mapPlayers(body.players);
-    const items = this.mapItems(body.loots);
-    const share =
-      highestWtNpcType === NpcType.COLOSSUS
-        ? this.mapLootShare(body.loots, body.players)
-        : {};
-
     let loot = await this.prisma.loot.findUnique({ where: { uniqueId } });
+
+    let npcs: any, players: any, items: any, share: any;
+    if (!loot) {
+      npcs = npcData.mapped;
+      players = this.mapPlayers(body.players);
+      items = this.mapItems(body.loots);
+      share =
+        highestWtNpcType === NpcType.COLOSSUS
+          ? this.mapLootShare(body.loots, body.players)
+          : {};
+    }
 
     if (!loot) {
       try {
@@ -140,42 +140,40 @@ export class LootsService {
       }
     }
 
-    await Promise.all(
-      filteredGuilds.map(async (guild) => {
+    const submissionData = filteredGuilds
+      .map((guild) => {
         const config = lootlogConfigs.find((c) => c.id === guild.id);
-        if (!config) return;
+        if (!config) return null;
 
         const calculatedLoot = this.getLootForGivenConfig(
           body.loots,
           config.npcs,
           highestWtNpcType,
         );
-
-        if (calculatedLoot.length === 0) return;
+        if (calculatedLoot.length === 0) return null;
 
         const member = members.find(({ guildId }) => guildId === guild.id);
-        if (!member) return;
+        if (!member) return null;
 
-        await this.prisma.lootSubmission.upsert({
-          where: {
-            lootId_guildId_memberId: {
-              lootId: loot.id,
-              guildId: guild.id,
-              memberId: member.id,
-            },
-          },
-          update: {},
-          create: {
-            lootId: loot.id,
-            guildId: guild.id,
-            memberId: member.id,
-          },
-        });
-      }),
-    );
+        return {
+          lootId: loot.id,
+          guildId: guild.id,
+          memberId: member.id,
+        };
+      })
+      .filter(Boolean);
 
-    this.playersService.bulkIndexPlayers(players);
-    this.npcsService.bulkIndexNpcs(npcs);
+    if (submissionData.length > 0) {
+      await this.prisma.lootSubmission.createMany({
+        data: submissionData,
+        skipDuplicates: true,
+      });
+    }
+
+    if (players && npcs) {
+      this.playersService.bulkIndexPlayers(players);
+      this.npcsService.bulkIndexNpcs(npcs);
+    }
 
     return { id: loot.id };
   }
@@ -299,13 +297,8 @@ export class LootsService {
       throw new BadRequestException(ErrorKey.MISSING_LOOT_SHARE);
     }
 
-    const parsedPlayers =
-      typeof loot.players === 'string'
-        ? JSON.parse(loot.players)
-        : loot.players;
-
-    const parsedLoot =
-      typeof loot.items === 'string' ? JSON.parse(loot.items) : loot.items;
+    const parsedPlayers = this.parseJsonField(loot.players);
+    const parsedLoot = this.parseJsonField(loot.items);
 
     const mappedLootShare = Object.entries(lootShare).reduce(
       (acc, [nick, hids]) => {
@@ -485,13 +478,13 @@ export class LootsService {
       },
     });
 
-    const submissionsByLootId: Record<number, typeof submissions> = {};
-    for (const sub of submissions) {
-      if (!submissionsByLootId[sub.lootId]) {
-        submissionsByLootId[sub.lootId] = [];
-      }
-      submissionsByLootId[sub.lootId].push(sub);
-    }
+    const submissionsByLootId = submissions.reduce(
+      (acc, sub) => {
+        (acc[sub.lootId] ??= []).push(sub);
+        return acc;
+      },
+      {} as Record<number, typeof submissions>,
+    );
 
     return loots.map((loot) => ({
       ...loot,
@@ -532,6 +525,30 @@ export class LootsService {
       : Object.values(Profession);
     const type = getItemTypeByCl(cl);
     return { lvl, rarity, prof: requiredProfArray, type };
+  }
+
+  private parseJsonField(field: any): any {
+    return typeof field === 'string' ? JSON.parse(field) : field;
+  }
+
+  private processNpcs(npcs: CreateLootDto['npcs']) {
+    const sorted = [...npcs].sort((a, b) => b.wt - a.wt);
+    return {
+      highest: sorted[0],
+      sorted,
+      mapped: sorted.map((npc) => ({
+        id: npc.id,
+        name: npc.name,
+        lvl: npc.lvl,
+        prof: getProfByShortname(npc.prof),
+        icon: npc.icon,
+        wt: npc.wt,
+        location: npc.location,
+        type: getNpcTypeByWt(npc.wt, npc.prof, npc.type),
+        margonemType: npc.type,
+        hpp: npc.hpp,
+      })),
+    };
   }
 
   sortNpcsByWt(npcs: CreateLootDto['npcs']) {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -7,6 +7,7 @@ import {
   FastifyAdapter,
 } from '@nestjs/platform-fastify';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -20,6 +21,16 @@ async function bootstrap() {
   });
 
   app.useGlobalPipes(new ValidationPipe());
+
+  // Swagger configuration
+  const config = new DocumentBuilder()
+    .setTitle('Lootlog API')
+    .setDescription('The Lootlog API documentation')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
 
   await app.startAllMicroservices();
   await app.listen(port, '0.0.0.0');

--- a/apps/api/src/users/dto/update-user-preferences.dto.ts
+++ b/apps/api/src/users/dto/update-user-preferences.dto.ts
@@ -5,8 +5,15 @@ import {
   ArrayNotEmpty,
   ArrayUnique,
 } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateUserPreferencesDto {
+  @ApiProperty({
+    description: 'Ordered list of guild IDs for user preferences',
+    example: ['guild1', 'guild2', 'guild3'],
+    required: false,
+    type: [String]
+  })
   @IsOptional()
   @IsArray()
   @ArrayNotEmpty()

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,25 +1,34 @@
 import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { UserId } from 'src/shared/decorators/user-id.decorator';
 import { AuthGuard } from 'src/shared/guards/auth.guard';
 import { UpdateUserPreferencesDto } from 'src/users/dto/update-user-preferences.dto';
 import { UsersService } from 'src/users/users.service';
 
+@ApiTags('users')
+@ApiBearerAuth()
 @UseGuards(AuthGuard)
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Get('/@me/scopes')
+  @ApiOperation({ summary: 'Get user IDP token scopes', description: 'Retrieve authentication token scopes for the user' })
+  @ApiResponse({ status: 200, description: 'User token scopes' })
   async getUserIdpTokenScopes(@UserId() userId: string) {
     return this.usersService.getUserIdpTokenScopes(userId);
   }
 
   @Get('/@me/preferences')
+  @ApiOperation({ summary: 'Get user preferences', description: 'Retrieve user preferences' })
+  @ApiResponse({ status: 200, description: 'User preferences' })
   async getUserPreferences(@UserId() userId: string) {
     return this.usersService.getUserPreferences(userId);
   }
 
   @Patch('/@me/preferences')
+  @ApiOperation({ summary: 'Update user preferences', description: 'Update user preferences' })
+  @ApiResponse({ status: 200, description: 'Updated user preferences' })
   async updateUserPreferences(
     @UserId() userId: string,
     @Body() preferences: UpdateUserPreferencesDto,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@discordjs/rest':
         specifier: ^2.5.1
         version: 2.5.1
+      '@fastify/static':
+        specifier: ^8.2.0
+        version: 8.2.0
       '@golevelup/nestjs-rabbitmq':
         specifier: ^6.0.1
         version: 6.0.1(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -60,10 +63,13 @@ importers:
         version: 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@nestjs/websockets@11.1.3)(amqp-connection-manager@4.1.14(amqplib@0.10.8))(amqplib@0.10.8)(ioredis@5.6.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/platform-fastify':
         specifier: ^11.1.2
-        version: 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)
+        version: 11.1.3(@fastify/static@8.2.0)(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)
       '@nestjs/platform-socket.io':
         specifier: ^11.1.2
         version: 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.3)(rxjs@7.8.2)
+      '@nestjs/swagger':
+        specifier: ^11.2.0
+        version: 11.2.0(@fastify/static@8.2.0)(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
       '@nestjs/websockets':
         specifier: ^11.1.2
         version: 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@nestjs/platform-socket.io@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -1968,6 +1974,9 @@ packages:
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
 
@@ -1994,6 +2003,12 @@ packages:
 
   '@fastify/proxy-addr@5.0.0':
     resolution: {integrity: sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@8.2.0':
+    resolution: {integrity: sha512-PejC/DtT7p1yo3p+W7LiUtLMsV8fEvxAK15sozHy9t8kwo5r0uLYmhV/inURmGz1SkHZFz/8CNtHLPyhKcx4SQ==}
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -2545,6 +2560,13 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@microsoft/tsdoc@0.15.1':
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
   '@nestjs/axios@4.0.0':
     resolution: {integrity: sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==}
     peerDependencies:
@@ -2600,6 +2622,19 @@ packages:
       '@nestjs/platform-express':
         optional: true
       '@nestjs/websockets':
+        optional: true
+
+  '@nestjs/mapped-types@2.1.0':
+    resolution: {integrity: sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
         optional: true
 
   '@nestjs/microservices@11.1.3':
@@ -2674,6 +2709,23 @@ packages:
     resolution: {integrity: sha512-T50SCNyqCZ/fDssaOD7meBKLZ87ebRLaJqZTJPvJKjlib1VYhMOCwXYsr7bjMPmuPgiQHOwvppz77xN/m6GM7A==}
     peerDependencies:
       typescript: '>=4.8.2'
+
+  '@nestjs/swagger@11.2.0':
+    resolution: {integrity: sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@nestjs/testing@11.1.3':
     resolution: {integrity: sha512-CeXG6/eEqgFIkPkmU00y18Dd3DLOIDFhPItzJK1SWckKo6IhcnfoRJzGx75bmuvUMjb51j6An96S/+MJ2ty9jA==}
@@ -3580,6 +3632,9 @@ packages:
   '@sapphire/snowflake@3.5.5':
     resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sideway/address@4.1.5':
     resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
@@ -4822,6 +4877,10 @@ packages:
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
 
   content-disposition@1.0.0:
     resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
@@ -8299,6 +8358,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-ui-dist@5.21.0:
+    resolution: {integrity: sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==}
+
   swap-case@1.1.2:
     resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
 
@@ -9983,6 +10045,8 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
+  '@fastify/accept-negotiator@2.0.1': {}
+
   '@fastify/ajv-compiler@4.0.2':
     dependencies:
       ajv: 8.17.1
@@ -10022,6 +10086,23 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.0
       ipaddr.js: 2.2.0
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.0
+      mime: 3.0.0
+
+  '@fastify/static@8.2.0':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 0.5.4
+      fastify-plugin: 5.0.1
+      fastq: 1.19.1
+      glob: 11.0.1
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -10794,6 +10875,10 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@lukeed/ms@2.0.2': {}
+
+  '@microsoft/tsdoc@0.15.1': {}
+
   '@nestjs/axios@4.0.0(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.10.0)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -10897,6 +10982,14 @@ snapshots:
       '@nestjs/platform-express': 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)
       '@nestjs/websockets': 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@nestjs/platform-socket.io@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
 
+  '@nestjs/mapped-types@2.1.0(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
+
   '@nestjs/microservices@11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@nestjs/websockets@11.1.3)(amqp-connection-manager@4.1.14(amqplib@0.10.8))(amqplib@0.10.8)(ioredis@5.6.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -10928,7 +11021,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/platform-fastify@11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)':
+  '@nestjs/platform-fastify@11.1.3(@fastify/static@8.2.0)(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)':
     dependencies:
       '@fastify/cors': 11.0.1
       '@fastify/formbody': 8.0.2
@@ -10940,6 +11033,8 @@ snapshots:
       light-my-request: 6.6.0
       path-to-regexp: 8.2.0
       tslib: 2.8.1
+    optionalDependencies:
+      '@fastify/static': 8.2.0
 
   '@nestjs/platform-socket.io@11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.3)(rxjs@7.8.2)':
     dependencies:
@@ -10974,6 +11069,22 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - chokidar
+
+  '@nestjs/swagger@11.2.0(@fastify/static@8.2.0)(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@nestjs/common': 11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.3)(@nestjs/platform-express@11.1.3)(@nestjs/websockets@11.1.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 8.2.0
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.21.0
+    optionalDependencies:
+      '@fastify/static': 8.2.0
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
   '@nestjs/testing@11.1.3(@nestjs/common@11.1.3(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.3)(@nestjs/microservices@11.1.3)(@nestjs/platform-express@11.1.3)':
     dependencies:
@@ -11849,6 +11960,8 @@ snapshots:
   '@sapphire/snowflake@3.5.3': {}
 
   '@sapphire/snowflake@3.5.5': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sideway/address@4.1.5':
     dependencies:
@@ -13297,6 +13410,10 @@ snapshots:
     dependencies:
       snake-case: 2.1.0
       upper-case: 1.1.3
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
 
   content-disposition@1.0.0:
     dependencies:
@@ -17457,6 +17574,10 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swagger-ui-dist@5.21.0:
+    dependencies:
+      '@scarf/scarf': 1.4.0
 
   swap-case@1.1.2:
     dependencies:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Swagger/OpenAPI docs to the API and documents key endpoints. Also refactors LootsService for simpler, faster submissions and adds comprehensive tests.

- **New Features**
  - Swagger UI available at /api/docs with Bearer auth.
  - Added Swagger annotations to guilds, users, and health controllers, plus UpdateGuildConfigDto and UpdateUserPreferencesDto.

- **Refactors**
  - LootsService: defer heavy mapping when loot exists, replace per-guild upsert with createMany(skipDuplicates), add parseJsonField, extract processNpcs, and clean imports.
  - Expanded unit tests for create, comments, delete, update, fetch, and helpers.
  - Added @nestjs/swagger and @fastify/static; updated pnpm-lock.yaml and .gitignore.

<!-- End of auto-generated description by cubic. -->

