### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-deploy-discord-bot.yml
+++ b/.github/workflows/prod-deploy-discord-bot.yml
@@ -7,6 +7,9 @@ concurrency:
   group: deploy-discord-bot-prod
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-service.yml


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/36](https://github.com/lootlog/monorepo/security/code-scanning/36)

To fix this issue, add a `permissions` block with the minimum required permissions to the workflow at `.github/workflows/prod-deploy-discord-bot.yml`. Unless this workflow (or the called reusable workflow) needs write access to repository contents, setting `contents: read` is the recommended starting point. If no GitHub token access is needed at all, it can even be set to `none`. The block can be added at the workflow root (above `jobs:`) so it applies to all jobs unless they override it. No changes to the logic of the workflow are required—just this single YAML block.

- Edit `.github/workflows/prod-deploy-discord-bot.yml`
- Insert a `permissions:` block after the `on:` or after `concurrency:`, before `jobs:`
- Use the minimum required permissions, e.g., `contents: read` (if unsure, this is a safe default given best practices)
- No new imports, methods, or extra definitions are needed


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
