### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-auth.yml
+++ b/.github/workflows/dev-deploy-auth.yml
@@ -1,4 +1,6 @@
 name: Deploy Auth to dev
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/26](https://github.com/lootlog/monorepo/security/code-scanning/26)

To address this issue, we should add a `permissions` block to limit the `GITHUB_TOKEN` permissions at the workflow or job level. The most maintainable and clear approach is to add it at the top/workflow level, applying least privilege to all jobs unless overridden. Since this workflow does not appear to need write permissions for content, set `contents: read` as a minimum; additional permissions can be granted if specific jobs or reusable workflows require them. The edit should insert the following after the workflow `name:` at the top of the file:

```yaml
permissions:
  contents: read
```

If the job or reusable workflow needs to write to pull requests or other resources, extend the block accordingly. However, without evidence of such needs in your snippet, `contents: read` is sufficient and recommended as a starting point.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
