### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-api.yml
+++ b/.github/workflows/dev-deploy-api.yml
@@ -15,6 +15,9 @@ concurrency:
   group: deploy-api-dev
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-service.yml


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/27](https://github.com/lootlog/monorepo/security/code-scanning/27)

To fix this issue, add a `permissions` block at the root level of the workflow (`.github/workflows/dev-deploy-api.yml`). Root-level permissions ensure that all jobs—including those that use reusable workflows—adhere to these least-privilege settings unless overridden. The most restrictive safe default is `contents: read`, which allows jobs to fetch code but prevents them from making changes to the repository. If the workflow (or the called reusable workflow) requires more permissions, they can be explicitly added later. The `permissions` block should be added before the `jobs` definition (i.e., after `concurrency`) to set the default for all jobs.

**What to do:**  
- Insert the `permissions:` block after the `concurrency:` block (before `jobs:`).
- Set `contents: read` as a minimal starting point, following GitHub’s example.
- If later review reveals that more permissions are needed, they can be added as required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
