### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-discord-bot.yml
+++ b/.github/workflows/dev-deploy-discord-bot.yml
@@ -1,4 +1,6 @@
 name: Deploy Discord Bot to dev
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/29](https://github.com/lootlog/monorepo/security/code-scanning/29)

To resolve this issue, we need to add a `permissions` block at the appropriate level in the `.github/workflows/dev-deploy-discord-bot.yml` file. Since the workflow delegates directly to another workflow (via `uses` syntax), there are no steps or jobs defined directly in this workflow. However, GitHub permits setting job-level or workflow-level permissions for reusable workflows. Best practice is to set the workflow-level permissions block at the top of the file, restricting permissions to only what is needed for this deploy job. If no permissions are required in this workflow itself (no steps run here), we can set all permissions to `none` or `read` only. If the called workflow requires elevated permissions, those should be set there, not here. A minimal starting block that restricts GITHUB_TOKEN would be:

```yaml
permissions:
  contents: read
```

or, for stricter restriction (if absolutely no repo read operations are required locally):

```yaml
permissions:
  contents: none
```

Here, adding a root-level permissions block just below `name:` will suffice.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
