### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-gateway.yml
+++ b/.github/workflows/dev-deploy-gateway.yml
@@ -1,4 +1,6 @@
 name: Deploy Gateway to dev
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/30](https://github.com/lootlog/monorepo/security/code-scanning/30)

To fix this issue, we need to add a `permissions` block to the workflow. The best approach is to add it at the root of the workflow file (immediately after the `name` key and before `on`) so it applies to all jobs unless overridden. Ideally, the permissions set should be the most restrictive required for workflow operation; for most deployment workflows this usually means `contents: read`, which enables reading repository contents but not writing/publishing, unless additional access is demonstrably necessary (e.g., `packages: write` or `deployments: write` for deployment tasks). Since this workflow triggers a deployment using a reusable workflow, the minimal starting point is likely `contents: read`, unless the reusable workflow explicitly relies on further permissions.

The code change is adding the following block directly after the `name: Deploy Gateway to dev` line:
```yaml
permissions:
  contents: read
```
(You can expand more if necessary, but start with the minimal safe set unless explicitly needed.)

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
