### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-search.yml
+++ b/.github/workflows/dev-deploy-search.yml
@@ -1,4 +1,6 @@
 name: Deploy Search to dev
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/31](https://github.com/lootlog/monorepo/security/code-scanning/31)

To fix this issue, explicitly set the `permissions` key at the root level of the workflow file (`.github/workflows/dev-deploy-search.yml`). Unless the workflow requires specific permissions, the minimum should be set, such as `contents: read`, which allows the `GITHUB_TOKEN` to read repository contents but not modify them. If downstream steps or reusable workflows require additional permissions, they should be explicitly granted. To implement this, a `permissions` block should be added after the `name` field (line 1), before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
