### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-deploy-api.yml
+++ b/.github/workflows/prod-deploy-api.yml
@@ -1,4 +1,6 @@
 name: Deploy API to prod
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/32](https://github.com/lootlog/monorepo/security/code-scanning/32)

To resolve this issue, you should add a `permissions` block to the workflow. The most secure location is at the root, directly underneath the workflow `name` or `on:` block. The correct value for the `permissions` block typically starts with the least permissions required for the job; for most deploy-only workflows, `contents: read` is sufficient unless the workflow requires additional write access (e.g., to deployments or environments). Review the requirements of both this workflow and the called reusable workflow to determine if permissions such as `deployments: write` or others are needed.  
In `.github/workflows/prod-deploy-api.yml`, add the following block near the top (after the workflow `name:`):

```yaml
permissions:
  contents: read
```
You may update or expand this list based on actual workflow needs. If you know the reusable workflow requires additional permissions (such as deployments write), add those here.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
