### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-deploy-gateway.yml
+++ b/.github/workflows/prod-deploy-gateway.yml
@@ -1,5 +1,7 @@
 name: Deploy Gateway to prod
 
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/35](https://github.com/lootlog/monorepo/security/code-scanning/35)

To fix the problem, explicitly limit the permissions of the GITHUB_TOKEN used by this workflow. This can be done by adding a `permissions:` block either at the workflow root (applies to all jobs unless overridden) or directly under the `deploy` job (applies only to this job). Given the workflow only delegates to a reusable workflow and does not push code, open PRs, etc., the minimal permission is likely `contents: read`. If more permissions are needed by the called workflow, expand accordingly; however, for least privilege, start with `contents: read` and adjust if future errors occur.

In `.github/workflows/prod-deploy-gateway.yml`, add the following after the `name` (line 1) but before `on:` (line 3):

```yaml
permissions:
  contents: read
```

This configures the GITHUB_TOKEN for all jobs in the workflow to have read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
