### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-deploy-battlelog-service.yml
+++ b/.github/workflows/prod-deploy-battlelog-service.yml
@@ -1,4 +1,6 @@
 name: Deploy Battlelog Service to prod
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/34](https://github.com/lootlog/monorepo/security/code-scanning/34)

To fix this issue, you should add an explicit `permissions` block at the top level of your workflow YAML file (.github/workflows/prod-deploy-battlelog-service.yml), directly below the name (or at the same top level before `jobs`). As a minimal safe default, set `permissions: contents: read`, which allows the workflow jobs to read repository contents but does not grant blanket write access or any extra privileges. This ensures the principle of least privilege unless more is strictly required. If the job or the called reusable workflow needs any further permissions (like `pull-requests: write` for PR updates), these should be added explicitly. Based on your current usage, only `contents: read` should be necessary for deployments (unless the reusable workflow overwrites or requires more). Insert the permissions block directly after the workflow `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
