### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prod-deploy-auth.yml
+++ b/.github/workflows/prod-deploy-auth.yml
@@ -7,6 +7,8 @@ concurrency:
   group: deploy-auth-prod
   cancel-in-progress: false
 
+permissions:
+  contents: read
 jobs:
   deploy:
     uses: ./.github/workflows/deploy-service.yml


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/33](https://github.com/lootlog/monorepo/security/code-scanning/33)

To fix the problem, add a `permissions` block to the root of `.github/workflows/prod-deploy-auth.yml`, above `jobs:` (e.g., after line 9). The block should grant only the minimal privileges necessary; since this workflow appears to deploy an authentication service and does not reference pull requests, issues, or contents writes (but might need to download code), a common minimal default is `contents: read`. If further permissions are required by the downstream workflow or any actions, add them as necessary. The change should consist of a new YAML block, maintaining indentation and convention.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
