### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-deploy-battlelog-service.yml
+++ b/.github/workflows/dev-deploy-battlelog-service.yml
@@ -1,4 +1,6 @@
 name: Deploy Battlelog Service to dev
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/28](https://github.com/lootlog/monorepo/security/code-scanning/28)

To fix this issue, we should add a `permissions` block at the root level of the workflow file (`.github/workflows/dev-deploy-battlelog-service.yml`), immediately following the `name:` declaration and before any `on:` or `jobs:` sections.  
For most deploy-related workflows, read access to repository contents is usually sufficient (`contents: read`). If any additional permissions are required for deployment (such as access to container registries, issues, or pull-requests), they should be added explicitly. As a minimal fix, we'll specify:

```yaml
permissions:
  contents: read
```

This ensures the workflow jobs run with only read access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
