### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete URL substring sanitization

### DIFF
--- a/apps/game-client/src/utils/game/get-language-version.ts
+++ b/apps/game-client/src/utils/game/get-language-version.ts
@@ -3,8 +3,13 @@ import { LanguageVersion } from "@/store/global.store";
 const EN_DOMAIN = "margonem.com";
 
 export const getLanguageVersion = (url: string): LanguageVersion => {
-  if (url.includes(EN_DOMAIN)) {
-    return LanguageVersion.EN;
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.hostname === EN_DOMAIN) {
+      return LanguageVersion.EN;
+    }
+  } catch (e) {
+    // If the URL can't be parsed, fall through to PL
   }
 
   return LanguageVersion.PL;


### PR DESCRIPTION
Potential fix for [https://github.com/lootlog/monorepo/security/code-scanning/22](https://github.com/lootlog/monorepo/security/code-scanning/22)

The fix is to avoid using substring checks for domain validation. Instead, parse the URL (using the standard `URL` constructor available in modern JavaScript/TypeScript) and compare the `hostname` property, using an explicit list of allowed hostnames if needed. To replicate the current logic: parse the given `url` string, extract the hostname, and check if it **exactly** matches `margonem.com` or, if subdomains should be included, ensure appropriate logic is used (but do not match superdomains).  
Edit the function `getLanguageVersion` to parse the input URL, check `hostname`, and only return `EN` if the host is *exactly* `margonem.com`.  
You'll need to import or use the global `URL` class, which is available in recent Node.js and browsers (and supported by TypeScript). Handle exceptions for invalid URLs gracefully.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
