### PR TITLE
Refactor localized timer and event helper logic

### DIFF
--- a/apps/api/src/events/services/event-respawn.service.ts
+++ b/apps/api/src/events/services/event-respawn.service.ts
@@ -71,7 +71,7 @@ export class EventRespawnService {
       throw new NotFoundException("Hero not found");
     }
 
-    const effectiveNpcId = hero.npcId ?? getSyntheticNpcId(heroId);
+    const effectiveNpcId = this.getEffectiveNpcId(heroId, hero.npcId);
 
     this.logger.log({
       message: isAutoClose
@@ -231,7 +231,7 @@ export class EventRespawnService {
       throw new NotFoundException("Hero not found");
     }
 
-    const effectiveNpcId = hero.npcId ?? getSyntheticNpcId(heroId);
+    const effectiveNpcId = this.getEffectiveNpcId(heroId, hero.npcId);
 
     const { minSpawnTime, maxSpawnTime } = options;
 
@@ -379,7 +379,7 @@ export class EventRespawnService {
       throw new NotFoundException("Hero not found");
     }
 
-    const effectiveNpcId = hero.npcId ?? getSyntheticNpcId(heroId);
+    const effectiveNpcId = this.getEffectiveNpcId(heroId, hero.npcId);
 
     const now = new Date();
 
@@ -471,5 +471,9 @@ export class EventRespawnService {
         });
       }
     }
+  }
+
+  private getEffectiveNpcId(heroId: string, npcId: number | null): number {
+    return npcId ?? getSyntheticNpcId(heroId);
   }
 }

--- a/apps/api/src/events/utils/scoring-time.util.ts
+++ b/apps/api/src/events/utils/scoring-time.util.ts
@@ -8,57 +8,57 @@ const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const timeFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const offsetFormatterCache = new Map<string, Intl.DateTimeFormat>();
 
-function getDateFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = dateFormatterCache.get(timeZone);
+function getCachedFormatter(
+  cache: Map<string, Intl.DateTimeFormat>,
+  timeZone: string,
+  createFormatter: () => Intl.DateTimeFormat,
+): Intl.DateTimeFormat {
+  const cached = cache.get(timeZone);
   if (cached) {
     return cached;
   }
 
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  dateFormatterCache.set(timeZone, formatter);
+  const formatter = createFormatter();
+  cache.set(timeZone, formatter);
   return formatter;
+}
+
+function getDateFormatter(timeZone: string): Intl.DateTimeFormat {
+  return getCachedFormatter(dateFormatterCache, timeZone, () => {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+  });
 }
 
 function getTimeFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = timeFormatterCache.get(timeZone);
-  if (cached) {
-    return cached;
-  }
-
-  const formatter = new Intl.DateTimeFormat("en-GB", {
-    timeZone,
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
+  return getCachedFormatter(timeFormatterCache, timeZone, () => {
+    return new Intl.DateTimeFormat("en-GB", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
   });
-  timeFormatterCache.set(timeZone, formatter);
-  return formatter;
 }
 
 function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = offsetFormatterCache.get(timeZone);
-  if (cached) {
-    return cached;
-  }
-
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    timeZoneName: "shortOffset",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
+  return getCachedFormatter(offsetFormatterCache, timeZone, () => {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      timeZoneName: "shortOffset",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
   });
-  offsetFormatterCache.set(timeZone, formatter);
-  return formatter;
 }
 
 function getPartValue(

--- a/apps/game-client/src/store/timers.store.ts
+++ b/apps/game-client/src/store/timers.store.ts
@@ -121,6 +121,21 @@ const updateTimestamp = (
   };
 };
 
+const getGuildTimerIds = (
+  timersByGuild: Record<string, string[]>,
+  guildId: string,
+) => {
+  return timersByGuild[guildId] ?? [];
+};
+
+const addTimerId = (timerIds: string[], timerId: string) => {
+  return [...new Set([...timerIds, timerId])];
+};
+
+const removeTimerId = (timerIds: string[], timerId: string) => {
+  return timerIds.filter((id) => id !== timerId);
+};
+
 export const useTimersStore = create<TimersState>()(
   persist(
     (set, get) => {
@@ -208,8 +223,10 @@ export const useTimersStore = create<TimersState>()(
           });
         },
         hideTimer: (guildId: string, timerId: string) => {
-          const currentHidden = get().hiddenTimers[guildId] ?? [];
-          const updatedHidden = [...new Set([...currentHidden, timerId])];
+          const updatedHidden = addTimerId(
+            getGuildTimerIds(get().hiddenTimers, guildId),
+            timerId,
+          );
 
           setWithTimestamp({
             hiddenTimers: {
@@ -223,8 +240,10 @@ export const useTimersStore = create<TimersState>()(
           });
         },
         revealTimer: (guildId: string, timerId: string) => {
-          const currentHidden = get().hiddenTimers[guildId] ?? [];
-          const updatedHidden = currentHidden.filter((id) => id !== timerId);
+          const updatedHidden = removeTimerId(
+            getGuildTimerIds(get().hiddenTimers, guildId),
+            timerId,
+          );
 
           setWithTimestamp({
             hiddenTimers: {
@@ -238,8 +257,10 @@ export const useTimersStore = create<TimersState>()(
           });
         },
         pinTimer: (guildId: string, timerId: string) => {
-          const currentPinned = get().pinnedTimers[guildId] ?? [];
-          const updatedPinned = [...new Set([...currentPinned, timerId])];
+          const updatedPinned = addTimerId(
+            getGuildTimerIds(get().pinnedTimers, guildId),
+            timerId,
+          );
 
           setWithTimestamp({
             pinnedTimers: {
@@ -253,8 +274,10 @@ export const useTimersStore = create<TimersState>()(
           });
         },
         unpinTimer: (guildId: string, timerId: string) => {
-          const currentPinned = get().pinnedTimers[guildId] ?? [];
-          const updatedPinned = currentPinned.filter((id) => id !== timerId);
+          const updatedPinned = removeTimerId(
+            getGuildTimerIds(get().pinnedTimers, guildId),
+            timerId,
+          );
 
           setWithTimestamp({
             pinnedTimers: {


### PR DESCRIPTION
## Summary
- extract a shared `getEffectiveNpcId` helper in the event respawn service
- consolidate formatter cache lookup logic in `scoring-time.util`
- deduplicate guild timer ID add/remove helpers in the timers store
- keep behavior unchanged while improving readability and consistency

## Testing
- Not run (not requested)