### PR TITLE
Refactor scoring and timer utility helpers

### DIFF
--- a/apps/api/src/events/utils/scoring-time.util.ts
+++ b/apps/api/src/events/utils/scoring-time.util.ts
@@ -8,57 +8,61 @@ const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const timeFormatterCache = new Map<string, Intl.DateTimeFormat>();
 const offsetFormatterCache = new Map<string, Intl.DateTimeFormat>();
 
-function getDateFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = dateFormatterCache.get(timeZone);
+function getCachedFormatter(
+  cache: Map<string, Intl.DateTimeFormat>,
+  timeZone: string,
+  createFormatter: (timeZone: string) => Intl.DateTimeFormat,
+): Intl.DateTimeFormat {
+  const cached = cache.get(timeZone);
   if (cached) {
     return cached;
   }
 
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  dateFormatterCache.set(timeZone, formatter);
+  const formatter = createFormatter(timeZone);
+  cache.set(timeZone, formatter);
   return formatter;
+}
+
+function getDateFormatter(timeZone: string): Intl.DateTimeFormat {
+  return getCachedFormatter(dateFormatterCache, timeZone, (cachedTimeZone) => {
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: cachedTimeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    });
+  });
 }
 
 function getTimeFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = timeFormatterCache.get(timeZone);
-  if (cached) {
-    return cached;
-  }
-
-  const formatter = new Intl.DateTimeFormat("en-GB", {
-    timeZone,
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
+  return getCachedFormatter(timeFormatterCache, timeZone, (cachedTimeZone) => {
+    return new Intl.DateTimeFormat("en-GB", {
+      timeZone: cachedTimeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
   });
-  timeFormatterCache.set(timeZone, formatter);
-  return formatter;
 }
 
 function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
-  const cached = offsetFormatterCache.get(timeZone);
-  if (cached) {
-    return cached;
-  }
-
-  const formatter = new Intl.DateTimeFormat("en-US", {
+  return getCachedFormatter(
+    offsetFormatterCache,
     timeZone,
-    timeZoneName: "shortOffset",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  });
-  offsetFormatterCache.set(timeZone, formatter);
-  return formatter;
+    (cachedTimeZone) => {
+      return new Intl.DateTimeFormat("en-US", {
+        timeZone: cachedTimeZone,
+        timeZoneName: "shortOffset",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+      });
+    },
+  );
 }
 
 function getPartValue(

--- a/apps/game-client/src/features/timers/utils/timer-helpers.ts
+++ b/apps/game-client/src/features/timers/utils/timer-helpers.ts
@@ -17,6 +17,9 @@ export const getMembersWithGuilds = (
   members: GuildMember[],
   guilds?: Guild[],
 ): { id: GuildMember["id"]; label: string }[] => {
+  const guildNamesById = new Map<Guild["id"], Guild["name"]>(
+    guilds?.map((guild) => [guild.id, guild.name] as const),
+  );
   const memberMap = new Map<
     GuildMember["id"],
     { id: GuildMember["id"]; label: string }
@@ -24,7 +27,7 @@ export const getMembersWithGuilds = (
 
   for (const member of members) {
     if (!memberMap.has(member.id)) {
-      const guildName = guilds?.find((g) => g.id === member.guildId)?.name;
+      const guildName = guildNamesById.get(member.guildId);
       memberMap.set(member.id, {
         id: member.id,
         label: guildName ? `${member.name} (${guildName})` : member.name,

--- a/apps/web/src/utils/get-permission-refresh-info.ts
+++ b/apps/web/src/utils/get-permission-refresh-info.ts
@@ -5,30 +5,28 @@ export type PermissionRefreshInfo = {
   canTriggerRefreshText: string;
 };
 
-const UP_TO_DATE_TEXT = "Uprawnienia są aktualne";
-const REFRESH_AVAILABLE_TEXT = "Odśwież swoje uprawnienia";
+const UP_TO_DATE_TEXT = "Uprawnienia s\u0105 aktualne";
+const REFRESH_AVAILABLE_TEXT = "Od\u015bwie\u017c swoje uprawnienia";
 const MINUTE_IN_MS = 1000 * 60;
-
-const createPermissionRefreshInfo = (
-  canTriggerRefresh: boolean,
-  canTriggerRefreshText: string,
-): PermissionRefreshInfo => ({
-  canTriggerRefresh,
-  canTriggerRefreshText,
-});
 
 export const getPermissionRefreshInfo = (
   updatedAt: string | null | undefined,
   currentTimestamp = Date.now(),
 ): PermissionRefreshInfo => {
   if (!updatedAt) {
-    return createPermissionRefreshInfo(false, UP_TO_DATE_TEXT);
+    return {
+      canTriggerRefresh: false,
+      canTriggerRefreshText: UP_TO_DATE_TEXT,
+    };
   }
 
   const updatedAtTimestamp = new Date(updatedAt).getTime();
 
   if (updatedAtTimestamp < currentTimestamp - REFRESH_PERMISSIONS_TTL) {
-    return createPermissionRefreshInfo(true, REFRESH_AVAILABLE_TEXT);
+    return {
+      canTriggerRefresh: true,
+      canTriggerRefreshText: REFRESH_AVAILABLE_TEXT,
+    };
   }
 
   const nextRefreshTimestamp = updatedAtTimestamp + REFRESH_PERMISSIONS_TTL;
@@ -37,11 +35,14 @@ export const getPermissionRefreshInfo = (
   );
 
   if (minutesUntilRefresh > 0) {
-    return createPermissionRefreshInfo(
-      false,
-      `Spróbuj ponownie za ${minutesUntilRefresh} min`,
-    );
+    return {
+      canTriggerRefresh: false,
+      canTriggerRefreshText: `Spr\u00f3buj ponownie za ${minutesUntilRefresh} min`,
+    };
   }
 
-  return createPermissionRefreshInfo(false, UP_TO_DATE_TEXT);
+  return {
+    canTriggerRefresh: false,
+    canTriggerRefreshText: UP_TO_DATE_TEXT,
+  };
 };


### PR DESCRIPTION
## Summary
- extract a shared `Intl.DateTimeFormat` cache helper in scoring time utilities to remove duplicated formatter setup
- precompute guild names in timer helpers instead of scanning the guild list for each member
- inline permission refresh info object creation and keep existing return values intact

## Testing
- Not run (not requested)