### PR TITLE
refactor: deduplicate RequestLike type and simplify parseOtlpHeaders

### DIFF
--- a/packages/instrumentation/src/parse-otlp-headers.ts
+++ b/packages/instrumentation/src/parse-otlp-headers.ts
@@ -1,13 +1,7 @@
 export function parseOtlpHeaders(
   headersString: string,
 ): Record<string, string> {
-  const headers: Record<string, string> = {};
   const paramsString = headersString.replaceAll(",", "&");
   const params = new URLSearchParams(paramsString);
-
-  params.forEach((value, key) => {
-    headers[key] = value;
-  });
-
-  return headers;
+  return Object.fromEntries(params);
 }

--- a/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, type ExecutionContext } from "@nestjs/common";
 
-type RequestLike = {
+export type RequestLike = {
   [key: string]: unknown;
   params?: Record<string, string | undefined>;
 };

--- a/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
@@ -1,11 +1,9 @@
 import { UnauthorizedException } from "@nestjs/common";
 
-import { createRequiredRequestValueDecorator } from "./create-required-request-value.decorator";
-
-type RequestLike = {
-  [key: string]: unknown;
-  params?: Record<string, string | undefined>;
-};
+import {
+  createRequiredRequestValueDecorator,
+  type RequestLike,
+} from "./create-required-request-value.decorator";
 
 export function createRequiredUnauthorizedRequestValueDecorator<Value>(
   getValue: (request: RequestLike) => Value | null | undefined,


### PR DESCRIPTION
## Summary
- **Deduplicate `RequestLike` type** in `nest-shared` decorators: export from `create-required-request-value.decorator.ts` and import in `create-required-unauthorized-request-value.decorator.ts` instead of defining it twice
- **Simplify `parseOtlpHeaders`** in `instrumentation`: replace manual `forEach` loop with `Object.fromEntries(params)` for more idiomatic code

## Why these are safe
- `RequestLike` was identical in both files; exporting it is a pure DRY improvement with no behavioral change
- `Object.fromEntries(URLSearchParams)` produces the same `Record<string, string>` as the manual loop
- Both packages build successfully; pre-commit lint and tests pass

## Test plan
- [x] `nest-shared` builds cleanly with `tsc`
- [x] Pre-commit hooks pass (oxlint + oxfmt)
- [x] No external consumers of the previously-unexported `RequestLike` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal object construction logic for improved code efficiency.
  * Consolidated type definitions to improve code organization and reduce duplication across decorator modules.

* **API Changes**
  * Exported a decorator type for external use, enabling better integration with dependent modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->