### PR TITLE
refactor: extract shared simpleStringHash utility

### DIFF
--- a/apps/api/src/events/utils/get-synthetic-npc-id.ts
+++ b/apps/api/src/events/utils/get-synthetic-npc-id.ts
@@ -1,8 +1,5 @@
+import { simpleStringHash } from "src/shared/utils/simple-string-hash";
+
 export function getSyntheticNpcId(heroId: string): number {
-  let hash = 0;
-  for (let i = 0; i < heroId.length; i++) {
-    hash = (hash << 5) - hash + heroId.charCodeAt(i);
-    hash |= 0;
-  }
-  return -Math.abs(hash || 1);
+  return -Math.abs(simpleStringHash(heroId) || 1);
 }

--- a/apps/api/src/shared/utils/get-stable-npc-id.ts
+++ b/apps/api/src/shared/utils/get-stable-npc-id.ts
@@ -1,4 +1,7 @@
 import { NpcType } from "prisma/generated/client";
+import { simpleStringHash } from "./simple-string-hash";
+
+const MAX_NPC_NAME_LENGTH = 256;
 
 /**
  * For COLOSSUS type monsters, generates a stable ID from the name
@@ -11,22 +14,8 @@ export const getStableNpcId = (
   npcType: NpcType,
 ): number => {
   if (npcType === NpcType.COLOSSUS) {
-    // Generate a deterministic hash from the name
-    // Use a simple string hash that produces a stable negative number
-    // (negative to avoid collision with real NPC IDs)
-    // Normalize and bound the name length to avoid unbounded iteration
-    const safeName = String(npcName ?? "");
-    const MAX_NPC_NAME_LENGTH = 256;
-    const length = Math.min(safeName.length, MAX_NPC_NAME_LENGTH);
-
-    let hash = 0;
-    for (let i = 0; i < length; i++) {
-      const char = safeName.charCodeAt(i);
-      hash = (hash << 5) - hash + char;
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-    // Ensure it's negative and distinct from real IDs
-    return -Math.abs(hash || 1);
+    const safeName = String(npcName ?? "").substring(0, MAX_NPC_NAME_LENGTH);
+    return -Math.abs(simpleStringHash(safeName) || 1);
   }
   return Math.abs(npcId);
 };

--- a/apps/api/src/shared/utils/simple-string-hash.ts
+++ b/apps/api/src/shared/utils/simple-string-hash.ts
@@ -1,0 +1,12 @@
+/**
+ * Simple DJB2-style string hash that produces a 32-bit integer.
+ * Used for generating deterministic numeric IDs from strings.
+ */
+export function simpleStringHash(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash;
+}


### PR DESCRIPTION
## Summary
- Extracted a shared `simpleStringHash` utility from two duplicate DJB2-style hash implementations
- `getSyntheticNpcId` (events/utils) and `getStableNpcId` (shared/utils) both contained identical hash loops — now they share a single source of truth
- Verified behavioral equivalence: all 21 existing tests pass, and manual hash output comparison confirms identical results

## Files changed
- **`apps/api/src/shared/utils/simple-string-hash.ts`** — new shared utility
- **`apps/api/src/events/utils/get-synthetic-npc-id.ts`** — now uses shared hash
- **`apps/api/src/shared/utils/get-stable-npc-id.ts`** — now uses shared hash, simplified

## Why this is safe
- Pure refactor: no behavior change, hash algorithm is identical (`(hash << 5) - hash + charCode`)
- Both `hash |= 0` and `hash & hash` are equivalent 32-bit integer conversions
- `substring(0, 256)` produces the same result as the previous `Math.min(length, 256)` loop bound
- All existing tests pass without modification

## Test plan
- [x] `get-stable-npc-id.spec.ts` — 21/21 tests pass
- [x] Manual hash equivalence verification across edge cases (empty strings, unicode, long strings)
- [x] Lint and format checks pass
- [x] Pre-commit hooks pass (lint + test + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared hashing logic across internal utilities to improve code maintainability and reduce duplication.

---

**Note:** This release contains internal code improvements with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->