### PR TITLE
refactor: extract duplicate helpers in ActivitiesQueryService

### DIFF
--- a/apps/activity/src/activities/services/activities-query.service.ts
+++ b/apps/activity/src/activities/services/activities-query.service.ts
@@ -7,6 +7,11 @@ import {
 } from "../entities/activity.entity";
 import type { Prisma } from "src/generated/prisma/client";
 
+const NON_EMPTY_STRING_FILTER: Prisma.StringNullableFilter = {
+  not: null,
+  notIn: [""],
+};
+
 @Injectable()
 export class ActivitiesQueryService {
   constructor(private readonly prisma: PrismaService) {}
@@ -103,7 +108,7 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 10,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.clampLimit(limit);
     const trimmedSearch = search?.trim();
 
     const where: Prisma.ActivityActorSnapshotWhereInput = {
@@ -137,12 +142,11 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 20,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.clampLimit(limit);
     const trimmedSearch = search?.trim();
 
     const worldFilter: Prisma.StringNullableFilter = {
-      not: null,
-      notIn: [""],
+      ...NON_EMPTY_STRING_FILTER,
     };
 
     if (trimmedSearch) {
@@ -173,12 +177,11 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 10,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.clampLimit(limit);
     const trimmedSearch = search?.trim();
 
     const clanNameFilter: Prisma.StringNullableFilter = {
-      not: null,
-      notIn: [""],
+      ...NON_EMPTY_STRING_FILTER,
     };
 
     if (trimmedSearch) {
@@ -219,6 +222,10 @@ export class ActivitiesQueryService {
     query: QueryActivitiesDto,
   ): Promise<PaginatedActivitiesEntity> {
     return this.findMany({ ...query, userId, guildId });
+  }
+
+  private clampLimit(limit: number, min = 1, max = 50): number {
+    return Math.min(Math.max(limit, min), max);
   }
 
   private deduplicateNames(


### PR DESCRIPTION
## Summary
- Extracted `Math.min(Math.max(limit, 1), 50)` pattern (repeated 3 times) into a private `clampLimit` method
- Extracted `{ not: null, notIn: [""] }` Prisma filter (repeated 2 times) into a `NON_EMPTY_STRING_FILTER` constant
- Only 1 file changed, no behavior changes

## Why this is safe
- Pure extraction of duplicate expressions into named helpers — identical runtime behavior
- Build passes with 0 TypeScript errors (`pnpm turbo build --filter=@lootlog/activity`)
- Format verified with `oxfmt --check`

## Residual risks
- None — these are localized readability improvements within a single service file

## Test plan
- [x] TypeScript compilation passes (0 errors)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization and consolidation of repeated utility logic to improve maintainability and reduce redundancy across query methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->