### PR TITLE
refactor: extract duplicate RequestLike type

### DIFF
--- a/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
@@ -1,9 +1,6 @@
 import { createParamDecorator, type ExecutionContext } from "@nestjs/common";
 
-type RequestLike = {
-  [key: string]: unknown;
-  params?: Record<string, string | undefined>;
-};
+import type { RequestLike } from "./types";
 
 interface CreateRequiredRequestValueDecoratorOptions<Value> {
   createException: () => Error;

--- a/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
@@ -1,11 +1,7 @@
 import { UnauthorizedException } from "@nestjs/common";
 
 import { createRequiredRequestValueDecorator } from "./create-required-request-value.decorator";
-
-type RequestLike = {
-  [key: string]: unknown;
-  params?: Record<string, string | undefined>;
-};
+import type { RequestLike } from "./types";
 
 export function createRequiredUnauthorizedRequestValueDecorator<Value>(
   getValue: (request: RequestLike) => Value | null | undefined,

--- a/packages/nest-shared/src/decorators/types.ts
+++ b/packages/nest-shared/src/decorators/types.ts
@@ -1,0 +1,4 @@
+export type RequestLike = {
+  [key: string]: unknown;
+  params?: Record<string, string | undefined>;
+};


### PR DESCRIPTION
## Summary
- Extracted the duplicate `RequestLike` type definition from `create-required-request-value.decorator.ts` and `create-required-unauthorized-request-value.decorator.ts` into a shared `types.ts` file in the same decorators directory.
- Both files now import from the single source of truth, eliminating the duplication.

## Why this is safe
- Pure type-level change — no runtime behavior change whatsoever.
- The type definition is identical in both files, so consolidation has zero semantic impact.
- Only affects `packages/nest-shared/src/decorators/` (3 files: 1 new, 2 modified).

## Note
- Pre-commit oxlint hook has a pre-existing config issue on develop (rules like `better-regex`, `consistent-destructuring` not found in their plugins). This is unrelated to this change.

## Test plan
- [x] Format check passes (`oxfmt --check`) on changed files
- [x] TypeScript compilation succeeds for the new types file
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared type definitions into a centralized module for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->