### PR TITLE
refactor: clean up chat service redundant cast and double JSON.parse

### DIFF
--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -136,9 +136,7 @@ export class ChatService {
     messages: ChatMessage[],
     roles: Role[],
   ): ChatMessage[] {
-    return messages.filter((message) =>
-      canViewChatMessage(message as SendMessageDto, roles),
-    );
+    return messages.filter((message) => canViewChatMessage(message, roles));
   }
 
   async clearMessages(guildId: string) {
@@ -163,16 +161,14 @@ export class ChatService {
     const key = this.getChatMessagesKey(guildId);
     const elements = await this.redisService.lrange(key, 0, -1);
 
-    const messageIndex = elements.findIndex((element) => {
-      const parsed = JSON.parse(element);
-      return parsed.id === messageId;
-    });
+    const parsed = elements.map((el) => JSON.parse(el) as ChatMessage);
+    const messageIndex = parsed.findIndex((msg) => msg.id === messageId);
 
     if (messageIndex === -1) {
       throw new NotFoundException("Message not found");
     }
 
-    const message = JSON.parse(elements[messageIndex]);
+    const message = parsed[messageIndex];
     if (message.senderId !== discordId) {
       throw new ForbiddenException("Not the owner of this message");
     }
@@ -202,21 +198,18 @@ export class ChatService {
     const key = this.getChatMessagesKey(guildId);
     const elements = await this.redisService.lrange(key, 0, -1);
 
-    const targetElement = elements.find((element) => {
-      const parsed = JSON.parse(element);
-      return parsed.id === messageId;
-    });
+    const parsed = elements.map((el) => JSON.parse(el) as ChatMessage);
+    const targetIndex = parsed.findIndex((msg) => msg.id === messageId);
 
-    if (!targetElement) {
+    if (targetIndex === -1) {
       throw new NotFoundException("Message not found");
     }
 
-    const message = JSON.parse(targetElement);
-    if (message.senderId !== discordId) {
+    if (parsed[targetIndex].senderId !== discordId) {
       throw new ForbiddenException("Not the owner of this message");
     }
 
-    await this.redisService.lrem(key, 1, targetElement);
+    await this.redisService.lrem(key, 1, elements[targetIndex]);
 
     this.amqpConnection.publish(
       DEFAULT_EXCHANGE_NAME,


### PR DESCRIPTION
## Summary
- Removed unnecessary `as SendMessageDto` cast in `filterMessagesByPermissions` — `ChatMessage` already extends `SendMessageDto`, making the cast redundant
- Eliminated double `JSON.parse` in `updateMessage` and `deleteMessage` methods by parsing all elements once upfront and reusing the parsed array for both lookup and data access

## Why this is safe
- The cast removal is purely cosmetic — `ChatMessage` is a supertype of `SendMessageDto` so the function signature already accepts it
- The JSON.parse consolidation preserves identical behavior: same elements are parsed, same exceptions are thrown, same Redis operations are performed
- All 590 existing tests pass

## Test plan
- [x] All API unit tests pass (590/590)
- [x] Format check passes on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and consistency in chat message handling operations across filtering, updating, and deletion to enhance reliability and prevent potential data processing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->