### PR TITLE
refactor: extract publish helper and deduplicate RequestLike type

### DIFF
--- a/apps/api/src/events/services/event-emitter.service.ts
+++ b/apps/api/src/events/services/event-emitter.service.ts
@@ -15,20 +15,12 @@ export class EventEmitterService {
     mapId: string,
     reason?: string,
   ): Promise<void> {
-    try {
-      await this.amqpConnection.publish(
-        DEFAULT_EXCHANGE_NAME,
-        RoutingKey.EVENT_MAP_STATUS_UPDATE,
-        {
-          guildId,
-          eventId,
-          mapId,
-          reason,
-        },
-      );
-    } catch (error) {
-      this.logger.error("Failed to emit map status update", error);
-    }
+    await this.publish(RoutingKey.EVENT_MAP_STATUS_UPDATE, {
+      guildId,
+      eventId,
+      mapId,
+      reason,
+    });
   }
 
   async emitHeroKilled(
@@ -36,34 +28,18 @@ export class EventEmitterService {
     eventId: string,
     killId: string,
   ): Promise<void> {
-    try {
-      await this.amqpConnection.publish(
-        DEFAULT_EXCHANGE_NAME,
-        RoutingKey.EVENT_HERO_KILLED,
-        {
-          guildId,
-          eventId,
-          killId,
-        },
-      );
-    } catch (error) {
-      this.logger.error("Failed to emit hero killed event", error);
-    }
+    await this.publish(RoutingKey.EVENT_HERO_KILLED, {
+      guildId,
+      eventId,
+      killId,
+    });
   }
 
   async emitRankingUpdate(guildId: string, eventId: string): Promise<void> {
-    try {
-      await this.amqpConnection.publish(
-        DEFAULT_EXCHANGE_NAME,
-        RoutingKey.EVENT_RANKING_UPDATE,
-        {
-          guildId,
-          eventId,
-        },
-      );
-    } catch (error) {
-      this.logger.error("Failed to emit ranking update event", error);
-    }
+    await this.publish(RoutingKey.EVENT_RANKING_UPDATE, {
+      guildId,
+      eventId,
+    });
   }
 
   async emitRespawnWindowOpened(
@@ -71,15 +47,11 @@ export class EventEmitterService {
     eventId: string,
     heroId: string,
   ): Promise<void> {
-    try {
-      await this.amqpConnection.publish(
-        DEFAULT_EXCHANGE_NAME,
-        RoutingKey.EVENT_RESPAWN_WINDOW_OPENED,
-        { guildId, eventId, heroId },
-      );
-    } catch (error) {
-      this.logger.error("Failed to emit respawn window opened event", error);
-    }
+    await this.publish(RoutingKey.EVENT_RESPAWN_WINDOW_OPENED, {
+      guildId,
+      eventId,
+      heroId,
+    });
   }
 
   async emitRespawnWindowClosed(
@@ -87,26 +59,29 @@ export class EventEmitterService {
     eventId: string,
     heroId: string,
   ): Promise<void> {
-    try {
-      await this.amqpConnection.publish(
-        DEFAULT_EXCHANGE_NAME,
-        RoutingKey.EVENT_RESPAWN_WINDOW_CLOSED,
-        { guildId, eventId, heroId },
-      );
-    } catch (error) {
-      this.logger.error("Failed to emit respawn window closed event", error);
-    }
+    await this.publish(RoutingKey.EVENT_RESPAWN_WINDOW_CLOSED, {
+      guildId,
+      eventId,
+      heroId,
+    });
   }
 
   async emitTimerUpdate(timer: unknown): Promise<void> {
+    await this.publish(RoutingKey.GUILDS_TIMERS_UPDATE, timer);
+  }
+
+  private async publish(
+    routingKey: RoutingKey,
+    payload: unknown,
+  ): Promise<void> {
     try {
       await this.amqpConnection.publish(
         DEFAULT_EXCHANGE_NAME,
-        RoutingKey.GUILDS_TIMERS_UPDATE,
-        timer,
+        routingKey,
+        payload,
       );
     } catch (error) {
-      this.logger.error("Failed to emit timer update", error);
+      this.logger.error(`Failed to emit ${routingKey}`, error);
     }
   }
 }

--- a/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, type ExecutionContext } from "@nestjs/common";
 
-type RequestLike = {
+export type RequestLike = {
   [key: string]: unknown;
   params?: Record<string, string | undefined>;
 };

--- a/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
@@ -1,11 +1,9 @@
 import { UnauthorizedException } from "@nestjs/common";
 
-import { createRequiredRequestValueDecorator } from "./create-required-request-value.decorator";
-
-type RequestLike = {
-  [key: string]: unknown;
-  params?: Record<string, string | undefined>;
-};
+import {
+  createRequiredRequestValueDecorator,
+  type RequestLike,
+} from "./create-required-request-value.decorator";
 
 export function createRequiredUnauthorizedRequestValueDecorator<Value>(
   getValue: (request: RequestLike) => Value | null | undefined,


### PR DESCRIPTION
## Summary
- **EventEmitterService**: Extracted a private `publish()` method to eliminate 6 identical try-catch blocks. Each public method now delegates to the shared helper, reducing boilerplate by ~30 lines while preserving identical behavior (same exchange, routing keys, and error logging).
- **nest-shared decorators**: Exported `RequestLike` type from `create-required-request-value.decorator.ts` and imported it in `create-required-unauthorized-request-value.decorator.ts` instead of redefining the same type.

## Safety
- EventEmitterService: All 14 existing tests pass unchanged — the refactor only moves the try-catch into a private method with the same semantics. Error log messages now include the routing key name for better debugging.
- RequestLike: Pure type-level change — no runtime behavior change. The type definition is identical in both files.

## Touched files
- `apps/api/src/events/services/event-emitter.service.ts`
- `packages/nest-shared/src/decorators/create-required-request-value.decorator.ts`
- `packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts`

## Test plan
- [x] EventEmitterService unit tests pass (14/14)
- [x] Format check passes on changed files
- [x] Lint passes on changed files (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and error handling for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->