### PR TITLE
refactor: remove dead retry code and consolidate reservation emit methods

### DIFF
--- a/apps/activity/src/shared/rabbitmq/retry.service.ts
+++ b/apps/activity/src/shared/rabbitmq/retry.service.ts
@@ -8,12 +8,6 @@ import {
   RETRY_EXCHANGE_NAME,
 } from "src/config/rabbitmq.config";
 
-interface AmqpMessage {
-  properties: {
-    headers?: Record<string, unknown>;
-  };
-}
-
 export interface RetryConfig {
   maxRetries?: number;
   retryDelayMs?: number;
@@ -118,42 +112,5 @@ export class RetryService {
       message: `Processing ${identifier} (attempt ${retryCount + 1}/${maxRetries})`,
     });
     return true;
-  }
-
-  handleRetryQueue(
-    _data: unknown,
-    amqpMsg: AmqpMessage,
-    identifier: string,
-    config: RetryConfig = {},
-  ): void {
-    const headers = amqpMsg.properties.headers ?? {};
-    const currentRetryCount = this.getRetryCount(headers);
-    const retryDelayMs = config.retryDelayMs ?? 30000;
-
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Processing retry for ${identifier}`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Current headers: ${JSON.stringify(headers)}`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Current retry count: ${currentRetryCount}`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] TTL: ${retryDelayMs}ms`,
-    });
-
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Message will expire in ${retryDelayMs}ms and return to main queue`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Next attempt will be #${currentRetryCount + 1}`,
-    });
   }
 }

--- a/apps/api/src/rabbitmq/retry.service.ts
+++ b/apps/api/src/rabbitmq/retry.service.ts
@@ -8,12 +8,6 @@ import {
   RETRY_EXCHANGE_NAME,
 } from "src/config/rabbitmq.config";
 
-interface AmqpMessage {
-  properties: {
-    headers?: Record<string, unknown>;
-  };
-}
-
 export interface RetryConfig {
   maxRetries?: number;
   retryDelayMs?: number;
@@ -118,42 +112,5 @@ export class RetryService {
       message: `Processing ${identifier} (attempt ${retryCount + 1}/${maxRetries})`,
     });
     return true;
-  }
-
-  handleRetryQueue(
-    _data: unknown,
-    amqpMsg: AmqpMessage,
-    identifier: string,
-    config: RetryConfig = {},
-  ): void {
-    const headers = amqpMsg.properties.headers || {};
-    const currentRetryCount = this.getRetryCount(headers);
-    const retryDelayMs = config.retryDelayMs || 30000;
-
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Processing retry for ${identifier}`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Current headers: ${JSON.stringify(headers)}`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Current retry count: ${currentRetryCount}`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] TTL: ${retryDelayMs}ms`,
-    });
-
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Message will expire in ${retryDelayMs}ms and return to main queue`,
-    });
-    this.logger.log({
-      level: "info",
-      message: `[RETRY QUEUE] Next attempt will be #${currentRetryCount + 1}`,
-    });
   }
 }

--- a/apps/api/src/reservations/reservations.service.ts
+++ b/apps/api/src/reservations/reservations.service.ts
@@ -111,36 +111,17 @@ export class ReservationsService {
     };
   }
 
-  private emitReservationCreated(
+  private emitReservationEvent(
     guildId: string,
     reservation: ReservationRecord,
+    routingKey: RoutingKey,
   ) {
     const payload = {
       guildId,
       reservation: this.serializeReservationRecord(reservation),
     };
 
-    this.amqpConnection.publish(
-      DEFAULT_EXCHANGE_NAME,
-      RoutingKey.GUILDS_RESERVATIONS_CREATE,
-      payload,
-    );
-  }
-
-  private emitReservationDeleted(
-    guildId: string,
-    reservation: ReservationRecord,
-  ) {
-    const payload = {
-      guildId,
-      reservation: this.serializeReservationRecord(reservation),
-    };
-
-    this.amqpConnection.publish(
-      DEFAULT_EXCHANGE_NAME,
-      RoutingKey.GUILDS_RESERVATIONS_DELETE,
-      payload,
-    );
+    this.amqpConnection.publish(DEFAULT_EXCHANGE_NAME, routingKey, payload);
   }
 
   async createReservation(guildId: string, data: CreateReservationDto) {
@@ -208,7 +189,11 @@ export class ReservationsService {
     });
 
     const record = this.mapReservationRecord(created);
-    this.emitReservationCreated(guildId, record);
+    this.emitReservationEvent(
+      guildId,
+      record,
+      RoutingKey.GUILDS_RESERVATIONS_CREATE,
+    );
 
     return record;
   }
@@ -345,7 +330,11 @@ export class ReservationsService {
     });
 
     const record = this.mapReservationRecord(reservation);
-    this.emitReservationDeleted(guildId, record);
+    this.emitReservationEvent(
+      guildId,
+      record,
+      RoutingKey.GUILDS_RESERVATIONS_DELETE,
+    );
 
     return record;
   }


### PR DESCRIPTION
## Summary
- **Remove dead `handleRetryQueue` method** from both `apps/api/src/rabbitmq/retry.service.ts` and `apps/activity/src/shared/rabbitmq/retry.service.ts` — this method (and its `AmqpMessage` interface) was never called anywhere in the codebase. Removes ~35 lines of dead code per file.
- **Consolidate duplicate reservation emit methods** in `apps/api/src/reservations/reservations.service.ts` — `emitReservationCreated` and `emitReservationDeleted` were identical except for the routing key. Replaced with a single `emitReservationEvent(guildId, reservation, routingKey)` method.

## Safety
- `handleRetryQueue`: Confirmed zero callers via codebase-wide grep. Only the definition existed.
- Reservation emit consolidation: Pure mechanical refactor — same payload construction, same `amqpConnection.publish` call, just parameterized by routing key.
- All existing tests pass (112/112 in API, 3/3 in activity). Pre-existing test file import failures (`@lootlog/nest-shared` resolution) are unrelated.

## Files touched
| File | Change |
|------|--------|
| `apps/api/src/rabbitmq/retry.service.ts` | Removed `handleRetryQueue` + `AmqpMessage` interface |
| `apps/activity/src/shared/rabbitmq/retry.service.ts` | Removed `handleRetryQueue` + `AmqpMessage` interface |
| `apps/api/src/reservations/reservations.service.ts` | Consolidated 2 emit methods into 1 |

## Residual risks
None — all changes are strictly subtractive or mechanical consolidation with no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal retry queue handling logic for improved code clarity.
  * Consolidated event publishing methods to reduce code duplication and enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->