### PR TITLE
refactor: small type safety and readability cleanups

### DIFF
--- a/apps/api/src/kills/kills.controller.ts
+++ b/apps/api/src/kills/kills.controller.ts
@@ -28,6 +28,12 @@ import { MemberRoles } from "src/shared/decorators/member-roles.decorator";
 import { AuthGuard } from "src/shared/guards/auth.guard";
 import { Permissions } from "src/shared/permissions/permissions.decorator";
 import { PermissionsGuard } from "src/shared/permissions/permissions.guard";
+
+const DEFAULT_BOSS_NPC_TYPES: NpcType[] = [
+  NpcType.TITAN,
+  NpcType.HERO,
+  NpcType.EVENT_HERO,
+];
 import { KillsService } from "./kills.service";
 import { CreateKillDto } from "./dto/create-kill.dto";
 import {
@@ -239,7 +245,7 @@ export class KillsController {
       guildData.id,
       permissions,
       roles,
-      [NpcType.TITAN, NpcType.HERO, NpcType.EVENT_HERO],
+      DEFAULT_BOSS_NPC_TYPES,
       limit ?? 5,
     );
     return plainToInstance(GuildTopKillersByTypeEntity, result, {

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -374,18 +374,20 @@ export class LootsService implements OnModuleInit {
       items,
     );
 
-    if (Object.keys(mappedLootShare).length === 0) {
+    const mappedItemsCount = Object.keys(mappedLootShare).length;
+
+    if (mappedItemsCount === 0) {
       throw new BadRequestException(ErrorKey.MISSING_LOOT_SHARE_ITEM_OR_PLAYER);
     }
 
-    if (Object.keys(mappedLootShare).length < items.length) {
+    if (mappedItemsCount < items.length) {
       this.logger.log({
         level: "warn",
         message:
           "Loot share does not include all items, some items may not be shared",
         lootId,
         lootShareMsg: data.msg,
-        mappedItemsCount: Object.keys(mappedLootShare).length,
+        mappedItemsCount,
         totalItemsCount: items.length,
       });
     }

--- a/apps/api/src/notifications/notification-job.service.ts
+++ b/apps/api/src/notifications/notification-job.service.ts
@@ -54,11 +54,11 @@ type TimerUpdatedEvent = {
   } | null;
 };
 
-const FINAL_JOB_STATUSES = [
+const FINAL_JOB_STATUSES: DbNotificationJobStatus[] = [
   DbNotificationJobStatus.SENT,
   DbNotificationJobStatus.FAILED,
   DbNotificationJobStatus.CANCELED,
-] as const;
+];
 
 @Injectable()
 export class NotificationJobService {
@@ -416,11 +416,7 @@ export class NotificationJobService {
       return;
     }
 
-    if (
-      (FINAL_JOB_STATUSES as readonly DbNotificationJobStatus[]).includes(
-        notificationJob.status,
-      )
-    ) {
+    if (FINAL_JOB_STATUSES.includes(notificationJob.status)) {
       return;
     }
 
@@ -786,12 +782,7 @@ export class NotificationJobService {
     });
 
     if (
-      currentCycleJobs.some(
-        (job) =>
-          !(FINAL_JOB_STATUSES as readonly DbNotificationJobStatus[]).includes(
-            job.status,
-          ),
-      )
+      currentCycleJobs.some((job) => !FINAL_JOB_STATUSES.includes(job.status))
     ) {
       return;
     }
@@ -961,7 +952,7 @@ export class NotificationJobService {
           ownerType: owner.ownerType,
           ownerId: owner.ownerId,
           status: {
-            in: FINAL_JOB_STATUSES as unknown as DbNotificationJobStatus[],
+            in: FINAL_JOB_STATUSES,
           },
         },
         include: {
@@ -982,7 +973,7 @@ export class NotificationJobService {
         ownerType: owner.ownerType,
         ownerId: owner.ownerId,
         status: {
-          in: FINAL_JOB_STATUSES as unknown as DbNotificationJobStatus[],
+          in: FINAL_JOB_STATUSES,
         },
       },
       orderBy: [{ updatedAt: "desc" }],


### PR DESCRIPTION
## Summary
- **notification-job.service.ts**: Type `FINAL_JOB_STATUSES` as `DbNotificationJobStatus[]` instead of `as const`, eliminating 4 redundant type assertions (`as unknown as` and `as readonly`) at usage sites
- **loots.service.ts**: Cache `Object.keys(mappedLootShare).length` in a `mappedItemsCount` variable instead of computing it 3 times in succession
- **kills.controller.ts**: Extract inline `[NpcType.TITAN, NpcType.HERO, NpcType.EVENT_HERO]` array to a named `DEFAULT_BOSS_NPC_TYPES` constant for readability

## Safety
All changes are behavior-preserving:
- The `FINAL_JOB_STATUSES` change only widens the type from a narrow readonly tuple to `DbNotificationJobStatus[]`, which is what every usage site was already casting to
- The `mappedItemsCount` variable caches an already-computed value with no side effects
- The `DEFAULT_BOSS_NPC_TYPES` constant is a direct extraction of an inline literal

## Test plan
- [x] `pnpm lint` passes (0 errors, 2 pre-existing warnings)
- [x] `pnpm format:check` passes on changed files
- [x] `pnpm test` — all 131 running tests pass; 32 pre-existing failures due to unrelated `@lootlog/nest-shared` package resolution issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code structure and type handling for improved maintainability.
  * Reduced redundant computations in service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->