### PR TITLE
refactor: extract cutoff date helper and remove unused discordId param

### DIFF
--- a/apps/api/src/loots/loots.controller.spec.ts
+++ b/apps/api/src/loots/loots.controller.spec.ts
@@ -294,7 +294,6 @@ describe("LootsController", () => {
   });
 
   describe("getComments", () => {
-    const discordId = "discord123";
     const lootId = 1;
 
     it("should get comments for loot", async () => {
@@ -317,10 +316,9 @@ describe("LootsController", () => {
       ];
       service.getComments.mockResolvedValue(mockComments as never);
 
-      const result = await controller.getComments(discordId, lootId, mockGuild);
+      const result = await controller.getComments(lootId, mockGuild);
 
       expect(service.getComments).toHaveBeenCalledWith({
-        discordId,
         lootId,
         guildId: mockGuild.id,
       });

--- a/apps/api/src/loots/loots.controller.ts
+++ b/apps/api/src/loots/loots.controller.ts
@@ -212,12 +212,10 @@ export class LootsController {
   })
   @ApiResponse({ status: 404, description: "Loot not found" })
   async getComments(
-    @DiscordId() discordId: string,
     @Param("lootId", new ParseIntPipe()) lootId: number,
     @GuildData() guild: Guild,
   ) {
     const comments = await this.lootsService.getComments({
-      discordId,
       lootId,
       guildId: guild.id,
     });

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -650,7 +650,6 @@ describe("LootsService", () => {
 
   describe("getComments", () => {
     const options = {
-      discordId: "discord123",
       guildId: "guild1",
       lootId: 1,
     };

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -278,7 +278,7 @@ export class LootsService implements OnModuleInit {
     }
   }
 
-  getComments(options: { discordId: string; guildId: string; lootId: number }) {
+  getComments(options: { guildId: string; lootId: number }) {
     return this.lootCommentService.getComments(options);
   }
 

--- a/apps/api/src/loots/services/loot-comment.service.ts
+++ b/apps/api/src/loots/services/loot-comment.service.ts
@@ -7,11 +7,7 @@ import { ErrorKey } from "../enum/error-key.enum";
 export class LootCommentService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getComments(options: {
-    discordId: string;
-    guildId: string;
-    lootId: number;
-  }) {
+  async getComments(options: { guildId: string; lootId: number }) {
     const { guildId, lootId } = options;
 
     const comments = await this.prisma.lootComment.findMany({

--- a/apps/api/src/reservations/reservations-cleanup.service.ts
+++ b/apps/api/src/reservations/reservations-cleanup.service.ts
@@ -27,8 +27,7 @@ export class ReservationsCleanupService {
       return;
     }
 
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - this.retentionDays);
+    const cutoffDate = this.createCutoffDate(this.retentionDays);
 
     this.logger.log(
       `Starting reservation cleanup (cutoff: ${cutoffDate.toISOString()}, retention: ${this.retentionDays} days)`,
@@ -59,8 +58,7 @@ export class ReservationsCleanupService {
   async cleanupExpiredReservationsManual(
     retentionDays: number = this.retentionDays,
   ): Promise<number> {
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+    const cutoffDate = this.createCutoffDate(retentionDays);
 
     this.logger.log(
       `Manual cleanup of expired reservations (cutoff: ${cutoffDate.toISOString()}, retention: ${retentionDays} days)`,
@@ -75,5 +73,12 @@ export class ReservationsCleanupService {
     this.logger.log(`Manual cleanup deleted ${count} expired reservations`);
 
     return count;
+  }
+
+  private createCutoffDate(retentionDays: number): Date {
+    const cutoffDate = new Date();
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
+
+    return cutoffDate;
   }
 }


### PR DESCRIPTION
## Summary
- **Extract `createCutoffDate()` in `ReservationsCleanupService`** — the cutoff date calculation was duplicated inline in two methods. Now uses a private helper, matching the identical pattern already in `TimersCleanupService`.
- **Remove unused `discordId` parameter from `getComments()`** — the parameter was passed through the controller → service → comment service chain but never used in the actual database query. Removed from the type signature, call sites, and tests.

## Touched files
- `apps/api/src/reservations/reservations-cleanup.service.ts`
- `apps/api/src/loots/services/loot-comment.service.ts`
- `apps/api/src/loots/loots.service.ts`
- `apps/api/src/loots/loots.controller.ts`
- `apps/api/src/loots/loots.controller.spec.ts`
- `apps/api/src/loots/loots.service.spec.ts`

## Safety
- Both changes are behavior-preserving (extract method + remove dead parameter)
- All 599 tests pass, lint clean, format clean
- No public API changes (controller route signatures unchanged — `@DiscordId()` decorator removal doesn't affect HTTP contract)

## Test plan
- [x] All 52 test files pass (599 tests)
- [x] Pre-commit hooks pass (lint + format + tests)
- [x] No new lint warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the comments retrieval API by removing an unused parameter requirement, making the endpoint more straightforward.
  * Improved code maintainability in the reservations cleanup service by consolidating duplicate date calculation logic into a reusable helper method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->