### PR TITLE
fix: correct staleAfterMs unit and remove dead facade method

### DIFF
--- a/apps/api/src/events/events.service.spec.ts
+++ b/apps/api/src/events/events.service.spec.ts
@@ -58,7 +58,6 @@ describe("EventsService", () => {
 
   const mockPointsService = {
     getRanking: mockFn(),
-    calculateMemberPoints: mockFn(),
     recalculateEventPoints: mockFn(),
     getMemberPresenceStats: mockFn(),
     updateRankingAfterKill: mockFn(),
@@ -126,13 +125,6 @@ describe("EventsService", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    mockPointsService.calculateMemberPoints.mockReturnValue({
-      totalPoints: 1,
-      basePoints: 1,
-      bonusPoints: 0,
-      appliedBonuses: [],
-    });
-
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EventsService,
@@ -1153,14 +1145,6 @@ describe("EventsService", () => {
         "guild-1",
         "event-1",
       );
-    });
-
-    it("should delegate calculateMemberPoints", () => {
-      const event = { id: "event-1" } as Parameters<
-        typeof service.calculateMemberPoints
-      >[0];
-      service.calculateMemberPoints(event, new Date(), 3, 2);
-      expect(mockPointsService.calculateMemberPoints).toHaveBeenCalled();
     });
 
     it("should delegate updateKillPoint", async () => {

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -11,7 +11,6 @@ import type {
 } from "src/generated/prisma/client";
 import type { EventWrappedResponseDto } from "./dto/event-wrapped.dto";
 import { EVENT_HERO_KILL_QUEUE } from "./constants/event-hero-kill-queue.constant";
-import { DEFAULT_ADVANCED_EVENT_SCORING_RULES } from "./constants/scoring-rules.constant";
 import type { CreateEventDto } from "./dto/create-event.dto";
 import type { CreateHeroDto } from "./dto/create-hero.dto";
 import type { CreateLocationDto } from "./dto/create-location.dto";
@@ -377,33 +376,6 @@ export class EventsService {
       event,
       timerData,
     );
-  }
-
-  calculateMemberPoints(
-    _event: Event,
-    killTime: Date,
-    _heroMapCount: number,
-    assignedMembersCount: number,
-  ): { points: number } {
-    const result = this.pointsService.calculateMemberPoints({
-      scoringMode: "SIMPLE",
-      scoringRules: DEFAULT_ADVANCED_EVENT_SCORING_RULES,
-      eligible: true,
-      trackingDurationPercentage: 100,
-      trackingDurationSeconds: 0,
-      assignedMembersCount,
-      killTime,
-      respawnStartTime: killTime,
-      memberLeaveTime: null,
-      memberPresentAtKill: true,
-      timeOnMapSeconds: 0,
-      afkPercentage: 0,
-      wasPresent: true,
-    });
-
-    return {
-      points: result.totalPoints,
-    };
   }
 
   recalculateEventPoints(

--- a/apps/api/src/guilds/guilds.service.ts
+++ b/apps/api/src/guilds/guilds.service.ts
@@ -64,7 +64,7 @@ export class GuildsService {
     private readonly redisService: RedisService,
     private readonly amqpConnection: AmqpConnection,
   ) {
-    this.staleAfterMs = discordBotConfig.channelSnapshotStaleSeconds;
+    this.staleAfterMs = discordBotConfig.channelSnapshotStaleSeconds * 1000;
   }
 
   async getUserGuilds(discordId: string, userId: string, source?: string) {


### PR DESCRIPTION
## Summary
- **guilds.service.ts**: Fix `staleAfterMs` initialization — was storing raw seconds from `channelSnapshotStaleSeconds` instead of multiplying by 1000 to get milliseconds. This caused the staleness check (`Date.now() - updatedAt > staleAfterMs`) to treat guild Discord sync as stale after ~300ms instead of ~5min, triggering unnecessary refresh calls. Now matches `channels.service.ts` behavior.
- **events.service.ts**: Remove unused `calculateMemberPoints` facade method (no callers outside its spec file) and its sole import `DEFAULT_ADVANCED_EVENT_SCORING_RULES`.
- **events.service.spec.ts**: Remove corresponding mock setup and test case.

## Why each change is safe
1. **staleAfterMs fix**: Corrects a unit mismatch bug. The variable name (`staleAfterMs`) and comparison target (`Date.now()`) both expect milliseconds. The identical pattern in `channels.service.ts` already uses `* 1000`.
2. **Dead code removal**: Grep across the entire monorepo confirms `calculateMemberPoints` on the facade has zero callers outside the spec. The real scoring logic lives in `EventPointsService.calculateMemberPoints` which is called directly.

## Touched files
- `apps/api/src/guilds/guilds.service.ts` (1 line)
- `apps/api/src/events/events.service.ts` (removed 27 lines)
- `apps/api/src/events/events.service.spec.ts` (removed 16 lines)

## Residual risks
- The staleAfterMs fix changes runtime behavior: guild Discord sync will refresh less frequently (correct 5-min threshold vs previous ~instant). This is the intended behavior based on the config name and the channels.service.ts reference implementation.

## Test plan
- [x] All 598 unit tests pass (52/52 test files)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Lint passes (only pre-existing warnings)
- [x] Format check passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Discord guild synchronization staleness threshold calculation to correctly measure refresh intervals.

* **Refactor**
  * Removed event points calculation method from service layer.

* **Tests**
  * Cleaned up event points delegation test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->