### PR TITLE
refactor: replace || with ?? for nullish coalescing

### DIFF
--- a/apps/api/scripts/migrate-loots.ts
+++ b/apps/api/scripts/migrate-loots.ts
@@ -71,7 +71,7 @@ const ITEM_TYPES: Record<number, ItemType> = {
 };
 
 const getItemTypeByCl = (cl: number): ItemType | undefined => {
-  return ITEM_TYPES[cl] ?? undefined;
+  return ITEM_TYPES[cl];
 };
 
 const generateStatsHash = (stat: string): string => {
@@ -353,7 +353,7 @@ async function processBatch(db: PrismaClient, loots: Loot[]) {
             characterId,
             snapshotHash,
             lvl: toOptionalInt(player.lvl),
-            hpp: player.hpp || null,
+            hpp: player.hpp ?? null,
           });
         }
       }

--- a/apps/api/src/events/services/event-kill.service.ts
+++ b/apps/api/src/events/services/event-kill.service.ts
@@ -324,7 +324,7 @@ export class EventKillService {
 
       return {
         mapId,
-        mapName: params.mapNameById.get(mapId) || "",
+        mapName: params.mapNameById.get(mapId) ?? "",
         presenceTimeSeconds: presenceStats?.presenceTimeSeconds ?? 0,
         afkTimeSeconds: presenceStats?.afkTimeSeconds ?? 0,
       };
@@ -1385,12 +1385,12 @@ export class EventKillService {
 
         return {
           mapId: assignment.mapId,
-          mapName: mapIdToName.get(assignment.mapId) || "",
+          mapName: mapIdToName.get(assignment.mapId) ?? "",
           assignedAt: assignment.assignedAt.toISOString(),
-          unassignedAt: assignment.unassignedAt?.toISOString() || null,
+          unassignedAt: assignment.unassignedAt?.toISOString() ?? null,
           assignmentDurationSeconds,
-          presenceTimeSeconds: presence?.presenceTimeSeconds || 0,
-          afkTimeSeconds: presence?.afkTimeSeconds || 0,
+          presenceTimeSeconds: presence?.presenceTimeSeconds ?? 0,
+          afkTimeSeconds: presence?.afkTimeSeconds ?? 0,
         };
       });
 
@@ -1572,12 +1572,12 @@ export class EventKillService {
 
             return {
               mapId: assignment.mapId,
-              mapName: mapIdToName.get(assignment.mapId) || "",
+              mapName: mapIdToName.get(assignment.mapId) ?? "",
               assignedAt: assignment.assignedAt.toISOString(),
-              unassignedAt: assignment.unassignedAt?.toISOString() || null,
+              unassignedAt: assignment.unassignedAt?.toISOString() ?? null,
               assignmentDurationSeconds,
-              presenceTimeSeconds: presence?.presenceTimeSeconds || 0,
-              afkTimeSeconds: presence?.afkTimeSeconds || 0,
+              presenceTimeSeconds: presence?.presenceTimeSeconds ?? 0,
+              afkTimeSeconds: presence?.afkTimeSeconds ?? 0,
             };
           })
           .filter((entry): entry is KillPointMapDataEntry => entry !== null);


### PR DESCRIPTION
## Summary
- **migrate-loots.ts**: Removed redundant `?? undefined` in `getItemTypeByCl` (return type already allows `undefined`)
- **migrate-loots.ts**: Changed `player.hpp || null` to `player.hpp ?? null` to preserve `0` as a valid HP value
- **event-kill.service.ts**: Changed `|| 0`, `|| ""`, `|| null` to `?? 0`, `?? ""`, `?? null` for numeric/nullable fields in map data builders (3 locations)

## Why this is safe
All changes only affect behavior when values are falsy-but-valid (`0`, `""`, `false`). For `Map.get()` calls the behavior is identical since missing keys return `undefined`. For numeric fields like `presenceTimeSeconds`, `afkTimeSeconds`, and `hpp`, `??` correctly preserves `0` instead of falling through to the default.

## Test plan
- [x] All 52 test suites pass (599 tests)
- [x] Lint passes (pre-existing warnings only)
- [x] Format check passes on changed files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved data accuracy for player statistics and event records by fixing serialization logic to correctly preserve zero values and empty strings instead of incorrectly converting them to null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->