### PR TITLE
refactor: remove redundant level property from typed logger calls

### DIFF
--- a/apps/activity/src/activities/services/activities-events.service.ts
+++ b/apps/activity/src/activities/services/activities-events.service.ts
@@ -53,7 +53,6 @@ export class ActivitiesEventsService {
 
     if (!result.success) {
       this.logger.error({
-        level: "error",
         message:
           "Invalid activity payload - validation failed (permanent error, sending to DLQ)",
         rawPayload: data,
@@ -94,7 +93,6 @@ export class ActivitiesEventsService {
       await this.activitiesService.create(dto);
     } catch (error) {
       this.logger.error({
-        level: "error",
         message: "Failed to create activity",
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
@@ -116,8 +114,7 @@ export class ActivitiesEventsService {
     },
   })
   handleActivityCreateDlq(@RabbitPayload() message: unknown) {
-    this.logger.log({
-      level: "warn",
+    this.logger.warn({
       message: "Activity CREATE DLQ message - manual intervention needed",
       rawPayload: message,
     });

--- a/apps/api/src/kills/kills.service.ts
+++ b/apps/api/src/kills/kills.service.ts
@@ -82,7 +82,6 @@ export class KillsService {
       });
     } catch (error) {
       this.logger.error({
-        level: "error",
         message: "Failed to upsert user kill stats",
         error: error instanceof Error ? error.message : error,
       });
@@ -205,7 +204,6 @@ export class KillsService {
           return { guildId, isFirstGuildKill };
         } catch (error) {
           this.logger.error({
-            level: "error",
             message: `Failed to upsert kill stats for guildId ${guildId}`,
             error: error instanceof Error ? error.message : error,
           });

--- a/apps/api/src/timers/timers.service.ts
+++ b/apps/api/src/timers/timers.service.ts
@@ -281,7 +281,6 @@ export class TimersService implements OnModuleInit {
       };
     } catch (error) {
       this.logger.warn({
-        level: "warn",
         message: "Failed to resolve synthetic timer context for event hero",
         guildId,
         world,
@@ -788,7 +787,6 @@ export class TimersService implements OnModuleInit {
         })
         .catch((error) => {
           this.logger.error({
-            level: "error",
             message: "Failed to enqueue event hero kill check",
             error: error instanceof Error ? error.message : error,
             guildId,


### PR DESCRIPTION
## Summary
- Removed redundant `level: "error"` property from `logger.error()` calls and `level: "warn"` from `logger.warn()` calls across 3 files
- Changed one `logger.log({ level: "warn" })` to `logger.warn()` for consistency
- Winston's typed methods (`.error()`, `.warn()`) already set the level, making the explicit property a no-op

## Files touched
- `apps/activity/src/activities/services/activities-events.service.ts` — 3 redundant level properties removed
- `apps/api/src/kills/kills.service.ts` — 2 redundant level properties removed
- `apps/api/src/timers/timers.service.ts` — 2 redundant level properties removed

## Why this is safe
- The `level` property was identical to what the method already sets — removing it produces identical log output
- No behavior change, no new abstractions, no API surface changes
- Lint, format, and tests pass (pre-existing unrelated test failure in `activities.controller.spec.ts` due to `@lootlog/nest-shared` package resolution)

## Residual risks
- None. This is a pure redundancy removal with no functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized logging calls across multiple services by removing redundant configuration parameters and aligning with logger method conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->