### PR TITLE
refactor(cli/seed): consistent crypto.randomInt() and nullish coalescing

### DIFF
--- a/packages/cli/src/commands/seed/generators/battles-generator.ts
+++ b/packages/cli/src/commands/seed/generators/battles-generator.ts
@@ -1,5 +1,6 @@
 import { readFile } from "fs/promises";
 import path from "path";
+import crypto from "node:crypto";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -30,7 +31,7 @@ export class BattlesGenerator {
     }
 
     const worlds = ["gordion", "classic", "katahha", "aldous", "gefion"];
-    const randomWorld = worlds[Math.floor(Math.random() * worlds.length)];
+    const randomWorld = worlds[crypto.randomInt(0, worlds.length)];
 
     return {
       accountId,

--- a/packages/cli/src/commands/seed/generators/guild-generator.ts
+++ b/packages/cli/src/commands/seed/generators/guild-generator.ts
@@ -79,7 +79,7 @@ export class GuildGenerator {
     return {
       id,
       name,
-      color: color || 0,
+      color: color ?? 0,
       position,
       permissions,
       lvlRangeFrom,

--- a/packages/cli/src/commands/seed/scrapers/npcs-scraper.ts
+++ b/packages/cli/src/commands/seed/scrapers/npcs-scraper.ts
@@ -1,5 +1,6 @@
 import { parse } from "node-html-parser";
 import { writeFile, readFile } from "node:fs/promises";
+import crypto from "node:crypto";
 import path from "node:path";
 import { SCRAPER_CONFIG } from "../config.js";
 import { fileExists } from "../utils/file-exists.js";
@@ -31,7 +32,7 @@ const NPC_TYPE_WT_MAP: Record<string, number> = {
 
 function getRandomProfession(): string {
   const { professions } = SCRAPER_CONFIG;
-  return professions[Math.floor(Math.random() * professions.length)] ?? "w";
+  return professions[crypto.randomInt(0, professions.length)] ?? "w";
 }
 
 function getWtByType(type: string): number {
@@ -44,7 +45,7 @@ function getNpcLevelFromMeta(meta: string): number {
 
   const lvl = regex.exec(meta) ?? grpRegex.exec(meta);
 
-  if (!lvl) return Math.floor(Math.random() * 300);
+  if (!lvl) return crypto.randomInt(0, 300);
 
   return Number(lvl[1]);
 }


### PR DESCRIPTION
## Summary
- Replace `Math.random()` with `crypto.randomInt()` in `battles-generator.ts` and `npcs-scraper.ts` for consistency with other seed generators (`loot-generator`, `guild-generator`) that already use `crypto.randomInt()`
- Change `color || 0` to `color ?? 0` in `guild-generator.ts` for correct nullish handling (avoids false-positive on `0` values, though none exist in current data)

## Files touched
- `packages/cli/src/commands/seed/generators/battles-generator.ts`
- `packages/cli/src/commands/seed/generators/guild-generator.ts`
- `packages/cli/src/commands/seed/scrapers/npcs-scraper.ts`

## Why these changes are safe
- `crypto.randomInt(0, n)` produces the same range `[0, n)` as `Math.floor(Math.random() * n)` — no behavioral change
- `??` vs `||` only differs for falsy-but-non-nullish values (`0`, `""`, `false`); `ROLE_COLORS` contains no such values, so behavior is identical
- All changes are in seed/scraper tooling, not production application code

## Residual risks
- None — these are data generation utilities used only for local seeding/scraping

## Test plan
- [x] Pre-commit hooks passed (oxlint, oxfmt)
- [x] Format check passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated random value selection and null/undefined handling in seed generation components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->