### PR TITLE
refactor: extract clampLimit helper and remove redundant optional chaining

### DIFF
--- a/apps/activity/src/activities/services/activities-query.service.ts
+++ b/apps/activity/src/activities/services/activities-query.service.ts
@@ -103,7 +103,7 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 10,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.clampLimit(limit);
     const trimmedSearch = search?.trim();
 
     const where: Prisma.ActivityActorSnapshotWhereInput = {
@@ -137,7 +137,7 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 20,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.clampLimit(limit);
     const trimmedSearch = search?.trim();
 
     const worldFilter: Prisma.StringNullableFilter = {
@@ -173,7 +173,7 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 10,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.clampLimit(limit);
     const trimmedSearch = search?.trim();
 
     const clanNameFilter: Prisma.StringNullableFilter = {
@@ -219,6 +219,10 @@ export class ActivitiesQueryService {
     query: QueryActivitiesDto,
   ): Promise<PaginatedActivitiesEntity> {
     return this.findMany({ ...query, userId, guildId });
+  }
+
+  private clampLimit(limit: number): number {
+    return Math.min(Math.max(limit, 1), 50);
   }
 
   private deduplicateNames(

--- a/apps/api/src/events/utils/find-active-event-heroes-by-npc.ts
+++ b/apps/api/src/events/utils/find-active-event-heroes-by-npc.ts
@@ -53,11 +53,11 @@ export async function findActiveEventHeroesByNpc(
   return Array.from(uniqueMatches.values()).sort((leftHero, rightHero) => {
     const leftStart =
       leftHero.event.startsAt?.getTime() ??
-      leftHero.event.createdAt?.getTime?.() ??
+      leftHero.event.createdAt?.getTime() ??
       0;
     const rightStart =
       rightHero.event.startsAt?.getTime() ??
-      rightHero.event.createdAt?.getTime?.() ??
+      rightHero.event.createdAt?.getTime() ??
       0;
 
     return rightStart - leftStart;


### PR DESCRIPTION
## Summary
- **Extract `clampLimit` helper** in `ActivitiesQueryService`: the expression `Math.min(Math.max(limit, 1), 50)` was duplicated 3 times across `suggestActorNames`, `suggestWorlds`, and `suggestClanNames`. Extracted into a private `clampLimit` method.
- **Remove redundant `.getTime?.()` optional chaining** in `find-active-event-heroes-by-npc.ts`: when `createdAt` is a `Date`, `.getTime` is always defined — the `?.` on the method call was unnecessary. Changed `.getTime?.()` to `.getTime()`.

## Files touched
- `apps/activity/src/activities/services/activities-query.service.ts`
- `apps/api/src/events/utils/find-active-event-heroes-by-npc.ts`

## Safety
- Both changes are behavior-preserving
- All 599 API tests pass, all 3 activity tests pass
- Lint and format checks pass on changed files

## Test plan
- [x] Existing tests pass (599 API tests, 3 activity tests)
- [x] Format check passes (`oxfmt --check`)
- [x] Lint passes (`oxlint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and consistency across utility functions to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->