### PR TITLE
refactor: replace || with ?? for nullish coalescing in api and gateway

### DIFF
--- a/apps/api/src/members/members.service.ts
+++ b/apps/api/src/members/members.service.ts
@@ -498,8 +498,8 @@ export class MembersService {
             ).map((role) => role.id)
           : [];
 
-      const memberName = nick || user.global_name || user.username;
-      const memberAvatar = avatar || user.avatar;
+      const memberName = nick ?? user.global_name ?? user.username;
+      const memberAvatar = avatar ?? user.avatar;
 
       const member = await this.prisma.member.upsert({
         where: { memberId: { userId: id, guildId } },

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -40,7 +40,7 @@ export class UsersService {
       where: { userId },
     });
 
-    const settings = userSettings || {
+    const settings = userSettings ?? {
       id: 0,
       userId,
       guildsOrder: [],

--- a/apps/gateway/src/gateway/retry.service.ts
+++ b/apps/gateway/src/gateway/retry.service.ts
@@ -32,7 +32,7 @@ export class RetryService {
 
     const xDeath = headers["x-death"];
     if (Array.isArray(xDeath) && xDeath.length > 0) {
-      return (xDeath[0].count as number) || 0;
+      return (xDeath[0].count as number) ?? 0;
     }
 
     return 0;
@@ -44,7 +44,7 @@ export class RetryService {
     headers: Record<string, unknown> = {},
     config: RetryConfig = {},
   ): Promise<void> {
-    const dlqExchange = config.dlqExchange || DEAD_LETTER_EXCHANGE_NAME;
+    const dlqExchange = config.dlqExchange ?? DEAD_LETTER_EXCHANGE_NAME;
 
     this.logger.warn(`Sending message to DLQ: ${dlqRoutingKey}`);
 
@@ -64,7 +64,7 @@ export class RetryService {
     identifier: string,
     config: RetryConfig = {},
   ): Promise<boolean> {
-    const maxRetries = config.maxRetries || GatewayConfig.DEFAULT_MAX_RETRIES;
+    const maxRetries = config.maxRetries ?? GatewayConfig.DEFAULT_MAX_RETRIES;
 
     if (!this.shouldRetry(headers, maxRetries)) {
       this.logger.warn(


### PR DESCRIPTION
## Summary
- Replaced `||` with `??` (nullish coalescing) in `retry.service.ts`, `members.service.ts`, and `users.service.ts` to align with project conventions from AGENTS.md
- Most notable: `config.maxRetries || DEFAULT` → `??` prevents silently ignoring `maxRetries: 0`

## Changed files
- `apps/gateway/src/gateway/retry.service.ts` — 3 changes (retry count, DLQ exchange, max retries)
- `apps/api/src/members/members.service.ts` — 2 changes (member name/avatar fallback)
- `apps/api/src/users/users.service.ts` — 1 change (user settings fallback)

## Safety
All changes are mechanical `||` → `??` replacements. Behavior only differs if a value is falsy-but-not-nullish (e.g., `0`, `""`), which corrects subtle bugs rather than introducing them. Lint passes, all runnable tests pass (pre-existing test environment issues in worktree are unrelated).

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — all runnable tests pass (battlelog-service failures are pre-existing on develop)
- [x] Format check passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected member profile data handling (names and avatars) to properly preserve explicitly set values and prevent unintended overwrites
  * Improved fallback behavior for user preferences, ensuring correct defaults are applied only when database records are unavailable
  * Enhanced retry service configuration to respect explicitly provided settings and ensure reliable retry behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->