### PR TITLE
refactor: deduplicate RequestLike type and use nullish coalescing for headers

### DIFF
--- a/apps/api/src/guilds/guilds-events.handler.ts
+++ b/apps/api/src/guilds/guilds-events.handler.ts
@@ -42,7 +42,7 @@ export class GuildsEventsHandler {
     },
   })
   async handleGuildsCreate(data: CreateGuildDto, amqpMsg: AmqpMessage) {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
 
     const shouldContinue = await this.retryService.handleRetryLogic(
       data,
@@ -126,7 +126,7 @@ export class GuildsEventsHandler {
     },
   })
   async handleGuildsUpdate(data: CreateGuildDto, amqpMsg: AmqpMessage) {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
 
     const shouldContinue = await this.retryService.handleRetryLogic(
       data,
@@ -159,7 +159,7 @@ export class GuildsEventsHandler {
     },
   })
   async handleGuildsDelete(data: CreateGuildDto, amqpMsg: AmqpMessage) {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
 
     const shouldContinue = await this.retryService.handleRetryLogic(
       data,

--- a/apps/api/src/roles/roles-events.handler.ts
+++ b/apps/api/src/roles/roles-events.handler.ts
@@ -44,7 +44,7 @@ export class RolesEventsHandler {
     },
   })
   async handleRoleCreate(data: CreateRoleDto, amqpMsg: AmqpMessage) {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
 
     const shouldContinue = await this.retryService.handleRetryLogic(
       data,
@@ -78,7 +78,7 @@ export class RolesEventsHandler {
     },
   })
   async handleRoleUpdate(data: UpdateRoleDto, amqpMsg: AmqpMessage) {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
 
     const shouldContinue = await this.retryService.handleRetryLogic(
       data,
@@ -112,7 +112,7 @@ export class RolesEventsHandler {
     },
   })
   async handleRoleDelete(data: DeleteRoleDto, amqpMsg: AmqpMessage) {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
 
     const shouldContinue = await this.retryService.handleRetryLogic(
       data,
@@ -150,7 +150,7 @@ export class RolesEventsHandler {
       roleId: data.id,
       guildId: data.guildId,
       retryCount: this.retryService.getRetryCount(
-        amqpMsg.properties.headers || {},
+        amqpMsg.properties.headers ?? {},
       ),
       headers: amqpMsg.properties.headers,
     });
@@ -171,7 +171,7 @@ export class RolesEventsHandler {
       roleId: data.id,
       guildId: data.guildId,
       retryCount: this.retryService.getRetryCount(
-        amqpMsg.properties.headers || {},
+        amqpMsg.properties.headers ?? {},
       ),
       headers: amqpMsg.properties.headers,
     });
@@ -192,7 +192,7 @@ export class RolesEventsHandler {
       roleId: data.id,
       guildId: data.guildId,
       retryCount: this.retryService.getRetryCount(
-        amqpMsg.properties.headers || {},
+        amqpMsg.properties.headers ?? {},
       ),
       headers: amqpMsg.properties.headers,
     });

--- a/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-request-value.decorator.ts
@@ -1,6 +1,6 @@
 import { createParamDecorator, type ExecutionContext } from "@nestjs/common";
 
-type RequestLike = {
+export type RequestLike = {
   [key: string]: unknown;
   params?: Record<string, string | undefined>;
 };

--- a/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
+++ b/packages/nest-shared/src/decorators/create-required-unauthorized-request-value.decorator.ts
@@ -1,11 +1,9 @@
 import { UnauthorizedException } from "@nestjs/common";
 
-import { createRequiredRequestValueDecorator } from "./create-required-request-value.decorator";
-
-type RequestLike = {
-  [key: string]: unknown;
-  params?: Record<string, string | undefined>;
-};
+import {
+  type RequestLike,
+  createRequiredRequestValueDecorator,
+} from "./create-required-request-value.decorator";
 
 export function createRequiredUnauthorizedRequestValueDecorator<Value>(
   getValue: (request: RequestLike) => Value | null | undefined,


### PR DESCRIPTION
## Summary
- **Deduplicate `RequestLike` type** in `packages/nest-shared/src/decorators/`: exported from `create-required-request-value.decorator.ts` and imported in `create-required-unauthorized-request-value.decorator.ts` instead of defining the identical type twice.
- **Replace `|| {}` with `?? {}`** for AMQP message headers in `guilds-events.handler.ts` (3 occurrences) and `roles-events.handler.ts` (6 occurrences) to follow the project convention of preferring `??` over `||` for nullish coalescing.

## Why these changes are safe
- The `RequestLike` type is identical in both files — pure deduplication with no semantic change.
- `amqpMsg.properties.headers` is typed as `Record<string, unknown> | undefined`. Since headers can only be `undefined` or an object (never `0`, `""`, or `false`), `??` and `||` behave identically here. Using `??` aligns with the AGENTS.md convention.

## Test plan
- [x] All 52 test files pass (599 tests)
- [x] Lint passes (0 errors)
- [x] Format check passes
- [x] TypeScript type check passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null/undefined value handling in event processing to correctly preserve explicitly provided values.

* **Refactor**
  * Reorganized internal type definitions for improved code reuse and maintainability across decorators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->