### PR TITLE
fix: sanitize member refresh BullMQ job ids

### DIFF
--- a/apps/api/src/members/member-bulk-refresh.service.ts
+++ b/apps/api/src/members/member-bulk-refresh.service.ts
@@ -83,7 +83,7 @@ export class MemberBulkRefreshService {
             type: "exponential",
             delay: 2000,
           },
-          jobId: `member-bulk-refresh:${job.id}`,
+          jobId: `member-bulk-refresh-${job.id}`,
         },
       );
     } catch (error) {

--- a/apps/api/src/members/member-refresh-scheduler.service.spec.ts
+++ b/apps/api/src/members/member-refresh-scheduler.service.spec.ts
@@ -170,7 +170,7 @@ describe("MemberRefreshSchedulerService", () => {
       : mockFn().mockResolvedValue(undefined);
 
     return {
-      id: `member-refresh:${refreshData.userId}:${refreshData.guildId}`,
+      id: `member-refresh-${refreshData.userId}-${refreshData.guildId}`,
       data: overrides.data ?? refreshData,
       opts: { priority: overrides.priority ?? refreshData.priority },
       getState,
@@ -197,7 +197,7 @@ describe("MemberRefreshSchedulerService", () => {
         "member-refresh",
         refreshData,
         expect.objectContaining({
-          jobId: "member-refresh:user-123:guild-123",
+          jobId: "member-refresh-user-123-guild-123",
           delay: 0,
           priority: refreshData.priority,
         }),
@@ -345,7 +345,7 @@ describe("MemberRefreshSchedulerService", () => {
           "member-refresh",
           refreshData,
           expect.objectContaining({
-            jobId: "member-refresh:user-123:guild-123",
+            jobId: "member-refresh-user-123-guild-123",
           }),
         );
       },

--- a/apps/api/src/members/member-refresh-scheduler.service.ts
+++ b/apps/api/src/members/member-refresh-scheduler.service.ts
@@ -354,7 +354,8 @@ return 0
   }
 
   private getJobId(userId: string, guildId: string): string {
-    return `member-refresh:${userId}:${guildId}`;
+    const parts = ["member", "refresh", userId, guildId];
+    return parts.map(sanitizeBullMqJobIdPart).join("-");
   }
 
   private getUserLockKey(userId: string): string {
@@ -368,4 +369,8 @@ function hasErrorCode(error: unknown): error is { code: unknown } {
   }
 
   return "code" in error;
+}
+
+function sanitizeBullMqJobIdPart(value: string): string {
+  return value.replaceAll(":", "_");
 }

--- a/apps/api/src/members/members.service.spec.ts
+++ b/apps/api/src/members/members.service.spec.ts
@@ -1394,7 +1394,7 @@ describe("MembersService", () => {
             type: "exponential",
             delay: 2000,
           },
-          jobId: `member-bulk-refresh:${mockJob.id}`,
+          jobId: `member-bulk-refresh-${mockJob.id}`,
         }),
       );
       expect(amqpConnection.publish).not.toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Replace colon-delimited BullMQ custom job IDs for member bulk refresh jobs with BullMQ-safe IDs.
- Sanitize per-member refresh job ID parts so embedded colons cannot break queue insertion.
- Update affected member refresh specs to match the new deterministic ID format.

## Root cause

BullMQ 5 rejects custom `jobId` values containing `:`, which caused `/guilds/:guildId/members/refresh-all` to fail while enqueueing the bulk refresh job.

## Validation

- `pnpm --filter api test -- member-bulk-refresh members.service member-refresh-scheduler`
- Pre-commit hooks: staged formatting, API lint/build/test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal job queue identifier formatting for member refresh operations to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->