### PR TITLE
[codex] normalize MIT license metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -173,4 +173,4 @@ Related to #
 
 - [ ] I have read and understood the [Contributing Guidelines](../CONTRIBUTING.md)
 - [ ] I agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
-- [ ] My contribution is my own original work and I have the right to submit it under the project's license
+- [ ] My contribution is my own original work and I have the right to submit it under the project's MIT License

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ Enhancement suggestions are tracked as GitHub issues. When creating an enhanceme
 ### Pull Requests
 
 - Fill in the pull request template
+- Confirm that you have the right to submit your contribution under this project's MIT License
 - Follow the code style guidelines (Oxlint, Oxfmt)
 - Include tests when adding new features
 - Update documentation when necessary

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Lootlog.pl and Contributors
+Copyright (c) 2025-2026 Lootlog.pl and Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Full-stack microservices application for Margonem clan management**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node Version](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org/)
 [![pnpm](https://img.shields.io/badge/pnpm-10.32.1-orange)](https://pnpm.io/)
 
@@ -540,7 +540,7 @@ If you discover a security vulnerability, please email **kamilwronka7@gmail.com*
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project and all apps and packages in this monorepo are licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/apps/activity/package.json
+++ b/apps/activity/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "description": "",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "author": "",
   "scripts": {
     "prebuild": "pnpm activity:generate",

--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/auth",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/developer/package.json
+++ b/apps/developer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lootlog/developer",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "BASE_PATH=/developer/ vite dev",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/docs",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 3005 --turbopack",

--- a/apps/game-client/package.json
+++ b/apps/game-client/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/game-client",
   "version": "1.0.1",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/landing",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "next dev -p 3003 --turbopack",

--- a/apps/search/package.json
+++ b/apps/search/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/search",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "build": "nest build",
     "dev": "nest start --watch",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/web",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "files": [
     "dist",
     "nginx.conf"

--- a/apps/wiki/package.json
+++ b/apps/wiki/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lootlog/wiki",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "imports": {

--- a/packages/api-helpers/package.json
+++ b/packages/api-helpers/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/api-helpers",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/battle-processor/package.json
+++ b/packages/battle-processor/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/battle-processor",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/cli",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "bin": {
     "lootlog": "./dist/index.mjs"
   },

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@lootlog/instrumentation",
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/margonem/package.json
+++ b/packages/margonem/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/margonem",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/nest-shared/package.json
+++ b/packages/nest-shared/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Shared NestJS modules, services, and utilities for backend microservices",
+  "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/socket-parser/package.json
+++ b/packages/socket-parser/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/socket-parser",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/types",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -2,7 +2,7 @@
   "name": "@lootlog/typescript-config",
   "version": "1.0.0",
   "private": true,
-  "license": "PROPRIETARY",
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,7 @@
   "name": "@lootlog/ui",
   "version": "1.0.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "exports": {
     "./globals.css": "./src/styles/globals.css",


### PR DESCRIPTION
## Summary

- Keep the project under the MIT License and restore the root license notice accordingly.
- Clarify in README that the MIT License applies to the full monorepo, including all apps and packages.
- Normalize every workspace package manifest to declare `"license": "MIT"`.
- Update contribution wording and the PR template so contributions are explicitly submitted under the project's MIT License.

## Validation

- `git diff --cached --check`
- `pnpm exec oxfmt --check README.md CONTRIBUTING.md .github/PULL_REQUEST_TEMPLATE.md LICENSE package.json apps/*/package.json packages/*/package.json`
- Node script verifying all 24 `package.json` files use `MIT`
- Pre-commit hooks passed, including staged formatting, lint-staged checks, changed-package linting, and changed-package tests.