### PR TITLE
[codex] Fix chat input cut shortcut

### DIFF
--- a/apps/game-client/src/features/chat/components/chat-input-editor.tsx
+++ b/apps/game-client/src/features/chat/components/chat-input-editor.tsx
@@ -291,6 +291,33 @@ export const ChatInputEditor: FC<ChatInputEditorProps> = ({
     });
   };
 
+  const handleCut = (event: ClipboardEvent<HTMLDivElement>) => {
+    event.stopPropagation();
+
+    const editor = editorRef.current;
+
+    if (!editor) {
+      return;
+    }
+
+    const selectionOffsets = getChatEditorSelectionOffsets(editor);
+
+    if (!selectionOffsets || selectionOffsets.start === selectionOffsets.end) {
+      return;
+    }
+
+    event.preventDefault();
+    event.clipboardData.setData(
+      "text/plain",
+      message.slice(selectionOffsets.start, selectionOffsets.end),
+    );
+    replaceSelection({
+      selectionStart: selectionOffsets.start,
+      selectionEnd: selectionOffsets.end,
+      insertedText: "",
+    });
+  };
+
   const handleEditorKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     event.stopPropagation();
     onKeyDown?.(event);
@@ -428,6 +455,7 @@ export const ChatInputEditor: FC<ChatInputEditorProps> = ({
           syncSelectionOffsets();
         }}
         onPaste={handlePaste}
+        onCut={handleCut}
         onBeforeInput={(event: FormEvent<HTMLDivElement>) => {
           const nativeInputEvent = event.nativeEvent as InputEvent;
 

--- a/apps/game-client/src/features/chat/components/chat-input.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-input.test.tsx
@@ -598,6 +598,28 @@ describe("ChatInput", () => {
     expect(editor.textContent).toBe("linia 1 linia 2");
   });
 
+  it("cuts selected text through controlled state instead of native contentEditable mutation", async () => {
+    const user = userEvent.setup();
+    const clipboardData = {
+      setData: vi.fn(),
+    };
+    render(<ChatInput selectedGuildId="guild-1" />);
+
+    const editor = getEditor() as HTMLDivElement;
+    await user.click(editor);
+    await user.type(editor, "hello world");
+
+    restoreChatEditorSelection({
+      root: editor,
+      start: 6,
+      end: 11,
+    });
+    fireEvent.cut(editor, { clipboardData });
+
+    expect(clipboardData.setData).toHaveBeenCalledWith("text/plain", "world");
+    expect(editor.textContent).toBe("hello ");
+  });
+
   it("scrolls the single-line editor horizontally to keep the caret visible", async () => {
     const user = userEvent.setup();
     render(<ChatInput selectedGuildId="guild-1" />);


### PR DESCRIPTION
## What changed

- Added controlled `cut` handling for the chat `contentEditable` input.
- Copies the selected text into the clipboard and removes it through React state instead of allowing the browser to mutate the DOM directly.
- Added a regression test for cutting a selected text range.

## Why

`Ctrl+X` on a text selection could trigger a native `contentEditable` DOM mutation before React reconciled the rendered mention/text tree. That could surface as `NotFoundError: Failed to execute 'removeChild' on 'Node'`.

## Validation

- `pnpm --dir apps/game-client test -- src/features/chat/components/chat-input.test.tsx`
- Pre-commit hook ran changed-package checks, including `@lootlog/game-client:test` with 108 files and 497 tests passing.