### PR TITLE
[codex] restrict chat message editing to authors

### DIFF
--- a/apps/api/src/chat/chat-message-permissions.ts
+++ b/apps/api/src/chat/chat-message-permissions.ts
@@ -2,7 +2,14 @@ import { isAdministrativeUser } from "src/shared/permissions/is-administrative-u
 import type { ChatStoredMessage } from "src/chat/types/chat-stored-message.type";
 import type { ChatMessageViewer } from "src/chat/types/chat-message-viewer.type";
 
-export const canManageChatMessage = (
+export const canEditChatMessage = (
+  viewer: ChatMessageViewer,
+  message: Pick<ChatStoredMessage, "senderId">,
+) => {
+  return viewer.discordId === message.senderId;
+};
+
+export const canDeleteChatMessage = (
   viewer: ChatMessageViewer,
   message: Pick<ChatStoredMessage, "senderId">,
 ) => {

--- a/apps/api/src/chat/chat.service.spec.ts
+++ b/apps/api/src/chat/chat.service.spec.ts
@@ -172,11 +172,36 @@ describe("ChatService", () => {
       );
     });
 
-    it("returns all messages for OWNER users", async () => {
+    it("returns all messages for administrative users without edit capability on other users messages", async () => {
       const messages = [
-        createStoredMessage(),
+        createStoredMessage({ senderId: "discord-other", id: "msg-other" }),
+        createStoredMessage({ senderId: "discord-1", id: "msg-own" }),
+      ];
+      redisService.lrange.mockResolvedValue(
+        messages.map((message) => JSON.stringify(message)),
+      );
+      guildsService.getMultipleGuildsPermissions.mockResolvedValue([
+        {
+          guild: { id: "guild-1" },
+          permissions: [Permission.ADMIN],
+          roles: [],
+        },
+      ]);
+
+      await expect(
+        service.getMessages("discord-1", "guild-1"),
+      ).resolves.toEqual([
+        withCapabilities(messages[0], { canEdit: false, canDelete: true }),
+        withCapabilities(messages[1], { canEdit: true, canDelete: true }),
+      ]);
+    });
+
+    it("returns all messages for OWNER users without edit capability on other users messages", async () => {
+      const messages = [
+        createStoredMessage({ senderId: "discord-other", id: "msg-other" }),
         createStoredMessage({
           id: "msg-2",
+          senderId: "discord-owner",
           type: MessageType.NPC,
           npc: {
             id: 10,
@@ -203,12 +228,11 @@ describe("ChatService", () => {
       ]);
 
       await expect(
-        service.getMessages("discord-1", "guild-1"),
-      ).resolves.toEqual(
-        messages.map((message) =>
-          withCapabilities(message, { canEdit: true, canDelete: true }),
-        ),
-      );
+        service.getMessages("discord-owner", "guild-1"),
+      ).resolves.toEqual([
+        withCapabilities(messages[0], { canEdit: false, canDelete: true }),
+        withCapabilities(messages[1], { canEdit: true, canDelete: true }),
+      ]);
     });
 
     it("filters history for regular users based on NPC permissions and levels", async () => {
@@ -542,11 +566,10 @@ describe("ChatService", () => {
       ).rejects.toBeInstanceOf(ForbiddenException);
     });
 
-    it("allows updates from administrative users for other users messages", async () => {
+    it("rejects updates from administrative users for other users messages", async () => {
       redisService.lrange.mockResolvedValue([
         JSON.stringify(createStoredMessage({ senderId: "discord-owner" })),
       ]);
-      redisService.lset.mockResolvedValue(1);
       guildsService.getMultipleGuildsPermissions.mockResolvedValue([
         {
           guild: { id: "guild-1" },
@@ -557,7 +580,8 @@ describe("ChatService", () => {
 
       await expect(
         service.updateMessage("discord-admin", "guild-1", "msg-1", "updated"),
-      ).resolves.toEqual({ success: true });
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(redisService.lset).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/chat/chat.service.ts
+++ b/apps/api/src/chat/chat.service.ts
@@ -21,7 +21,10 @@ import { Permission, type Role } from "src/generated/prisma/client";
 import { canViewChatMessage } from "src/shared/utils/can-view-chat-message";
 import type { ChatStoredMessage } from "src/chat/types/chat-stored-message.type";
 import type { ChatMessageViewer } from "src/chat/types/chat-message-viewer.type";
-import { canManageChatMessage } from "src/chat/chat-message-permissions";
+import {
+  canDeleteChatMessage,
+  canEditChatMessage,
+} from "src/chat/chat-message-permissions";
 import { isAdministrativeUser } from "src/shared/permissions/is-administrative-user";
 
 const MAX_MESSAGES = 300;
@@ -180,7 +183,7 @@ export class ChatService {
     const message = JSON.parse(elements[messageIndex]) as ChatStoredMessage;
     const viewer = await this.getChatMessageViewer(discordId, guildId);
 
-    if (!viewer || !canManageChatMessage(viewer, message)) {
+    if (!viewer || !canEditChatMessage(viewer, message)) {
       throw new ForbiddenException("Not allowed to manage this message");
     }
 
@@ -223,7 +226,7 @@ export class ChatService {
     const message = JSON.parse(targetElement) as ChatStoredMessage;
     const viewer = await this.getChatMessageViewer(discordId, guildId);
 
-    if (!viewer || !canManageChatMessage(viewer, message)) {
+    if (!viewer || !canDeleteChatMessage(viewer, message)) {
       throw new ForbiddenException("Not allowed to manage this message");
     }
     const routing = this.getMessageRouting(message);
@@ -299,12 +302,10 @@ export class ChatService {
     message: ChatStoredMessage,
     viewer: ChatMessageViewer,
   ) {
-    const canManageMessage = canManageChatMessage(viewer, message);
-
     return {
       ...message,
-      canEdit: canManageMessage,
-      canDelete: canManageMessage,
+      canEdit: canEditChatMessage(viewer, message),
+      canDelete: canDeleteChatMessage(viewer, message),
     };
   }
 

--- a/apps/game-client/src/features/chat/components/chat-message.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message.test.tsx
@@ -216,6 +216,23 @@ describe("ChatMessage", () => {
     expect(screen.getByText("Usuń")).toBeInTheDocument();
   });
 
+  it("shows delete without edit when backend allows only moderation", () => {
+    render(
+      <ChatMessage
+        all={false}
+        guildName="Guild"
+        member={member}
+        message={makeChatMessage({
+          canEdit: false,
+          canDelete: true,
+        })}
+      />,
+    );
+
+    expect(screen.queryByText("Edytuj")).not.toBeInTheDocument();
+    expect(screen.getByText("Usuń")).toBeInTheDocument();
+  });
+
   it("renders reply preview snapshot when the message references another message", () => {
     render(
       <ChatMessage


### PR DESCRIPTION
## Summary
- split chat edit/delete permission checks so only message authors can edit
- keep admin/owner moderation delete permissions intact
- add API and game-client regression coverage for delete-without-edit behavior

## Why
Admins could edit other users' chat messages because editing and deletion shared one "manage message" permission check. That made moderation power also imply authorship-like editing power.

## Validation
- `pnpm --filter @lootlog/api test -- chat.service.spec.ts`
- `pnpm --filter @lootlog/game-client test -- chat-message.test.tsx`
- pre-commit hooks: staged formatting, lint for changed packages, tests for changed packages