### PR TITLE
[codex] Add Tab keyboard support for chat mention suggestions

### DIFF
--- a/apps/game-client/src/features/chat/components/chat-input.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-input.test.tsx
@@ -473,6 +473,24 @@ describe("ChatInput", () => {
     expect(mockSendChatMessage).not.toHaveBeenCalled();
   });
 
+  it("completes and cycles mention suggestions with Tab", async () => {
+    const user = userEvent.setup();
+    render(<ChatInput selectedGuildId="guild-1" />);
+
+    const editor = getEditor();
+    await user.type(editor, "@ra");
+
+    await user.keyboard("{Tab}");
+    expect(editor.textContent).toBe("@Raid Team ");
+    expect(mockSendChatMessage).not.toHaveBeenCalled();
+
+    await user.keyboard("{Tab}");
+    expect(editor.textContent).toBe("@Raider ");
+
+    await user.keyboard("{Tab}");
+    expect(editor.textContent).toBe("@Raid Team ");
+  });
+
   it("supports keyboard navigation, colored overlay for resolved mentions, and resets dismissed suggestions after the query changes", async () => {
     const user = userEvent.setup();
     const firstRender = render(<ChatInput selectedGuildId="guild-1" />);

--- a/apps/game-client/src/features/chat/components/chat-input.tsx
+++ b/apps/game-client/src/features/chat/components/chat-input.tsx
@@ -10,8 +10,10 @@ import {
   applyChatMentionSuggestion,
   getActiveChatMention,
   getChatMentionMemberSuggestions,
+  getChatMentionSuggestionDisplayLabel,
   getChatMentionRoleSuggestions,
   getChatMentionSuggestions,
+  type ActiveChatMention,
   type ChatMentionSuggestion,
 } from "@/features/chat/chat-mention-suggestions.helpers";
 import {
@@ -78,6 +80,11 @@ type ChatInputProps = {
   autofocus?: boolean;
 };
 
+type TabCompletionSession = {
+  insertedLabel: string;
+  mention: ActiveChatMention;
+};
+
 const REQUIRED_CLEAR_CHAT_PERMISSIONS = [Permission.OWNER, Permission.ADMIN];
 
 const CHAT_INPUT_SHELL_CLASS =
@@ -110,6 +117,8 @@ export const ChatInput: FC<ChatInputProps> = ({
   const [dismissedMentionKey, setDismissedMentionKey] = useState<string | null>(
     null,
   );
+  const [tabCompletionSession, setTabCompletionSession] =
+    useState<TabCompletionSession | null>(null);
   const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
   const pendingFocusCaretRef = useRef<number | null>(null);
   const isPending =
@@ -118,8 +127,23 @@ export const ChatInput: FC<ChatInputProps> = ({
     message: messageValue,
     caretIndex,
   });
-  const activeMentionKey = activeMention
-    ? `${activeMention.start}:${activeMention.end}:${activeMention.query}`
+  const isTabCompletionSessionActive =
+    tabCompletionSession !== null &&
+    caretIndex === tabCompletionSession.mention.end + 1 &&
+    /\s/.test(messageValue[tabCompletionSession.mention.end] ?? "") &&
+    messageValue.slice(
+      tabCompletionSession.mention.start,
+      tabCompletionSession.mention.end,
+    ) === tabCompletionSession.insertedLabel;
+  const activeMentionForSuggestions =
+    activeMention ??
+    (isTabCompletionSessionActive ? tabCompletionSession.mention : null);
+  const activeMentionSuggestionKey = activeMentionForSuggestions
+    ? [
+        activeMentionForSuggestions.start,
+        activeMentionForSuggestions.end,
+        activeMentionForSuggestions.query,
+      ].join(":")
     : null;
   const commandSuggestionKey = isCommandSuggestionsInput(messageValue)
     ? `command:${messageValue}`
@@ -128,7 +152,7 @@ export const ChatInput: FC<ChatInputProps> = ({
   const isCommandInput = commandSuggestionKey !== null;
   const activeSuggestionKey = isCommandInput
     ? commandSuggestionKey
-    : activeMentionKey;
+    : activeMentionSuggestionKey;
   const areSuggestionsDismissed =
     activeSuggestionKey !== null && dismissedMentionKey === activeSuggestionKey;
   const shouldLoadMentionData =
@@ -197,7 +221,7 @@ export const ChatInput: FC<ChatInputProps> = ({
   const mentionSuggestions = getChatMentionSuggestions({
     memberSuggestions,
     roleSuggestions,
-    query: activeMention?.query ?? "",
+    query: activeMentionForSuggestions?.query ?? "",
   });
   const mentionContext = buildChatMentionContext({
     currentCharacterNick: Game.hero.nick,
@@ -210,7 +234,9 @@ export const ChatInput: FC<ChatInputProps> = ({
     filteredCommandSuggestions.length > 0 &&
     !areSuggestionsDismissed;
   const isMentionSuggestionsOpen =
-    !isCommandInput && activeMention !== null && !areSuggestionsDismissed;
+    !isCommandInput &&
+    activeMentionForSuggestions !== null &&
+    !areSuggestionsDismissed;
   const suggestionMode = isCommandSuggestionsOpen
     ? "command"
     : isMentionSuggestionsOpen
@@ -297,18 +323,36 @@ export const ChatInput: FC<ChatInputProps> = ({
     });
   }, [isPending]);
 
-  const handleMentionSuggestionSelect = (suggestion: ChatMentionSuggestion) => {
-    if (!activeMention) {
+  const handleMentionSuggestionSelect = ({
+    keepTabCompletionSession = false,
+    mention,
+    suggestion,
+  }: {
+    keepTabCompletionSession?: boolean;
+    mention: ActiveChatMention | null;
+    suggestion: ChatMentionSuggestion;
+  }) => {
+    if (!mention) {
       return;
     }
 
     const { nextMessage, nextCaretIndex } = applyChatMentionSuggestion({
       message: messageValue,
-      mention: activeMention,
+      mention,
       suggestion,
     });
+    const insertedLabel = getChatMentionSuggestionDisplayLabel(suggestion);
 
     applySelectedMessageValue({
+      nextTabCompletionSession: keepTabCompletionSession
+        ? {
+            insertedLabel,
+            mention: {
+              ...mention,
+              end: mention.start + insertedLabel.length,
+            },
+          }
+        : null,
       nextCaretIndex,
       nextMessage,
     });
@@ -327,13 +371,16 @@ export const ChatInput: FC<ChatInputProps> = ({
   const applySelectedMessageValue = ({
     nextCaretIndex,
     nextMessage,
+    nextTabCompletionSession = null,
   }: {
     nextCaretIndex: number;
     nextMessage: string;
+    nextTabCompletionSession?: TabCompletionSession | null;
   }) => {
     setMessageValue(nextMessage);
     setCaretIndex(nextCaretIndex);
     setDismissedMentionKey(null);
+    setTabCompletionSession(nextTabCompletionSession);
     focusEditorCaret(nextCaretIndex);
   };
 
@@ -358,13 +405,17 @@ export const ChatInput: FC<ChatInputProps> = ({
       return;
     }
 
-    handleMentionSuggestionSelect(suggestion);
+    handleMentionSuggestionSelect({
+      mention: activeMentionForSuggestions,
+      suggestion,
+    });
   };
 
   const resetInputState = () => {
     setMessageValue("");
     setCaretIndex(0);
     setDismissedMentionKey(null);
+    setTabCompletionSession(null);
     clearReplyDraft();
     setIsClearConfirmOpen(false);
   };
@@ -390,7 +441,6 @@ export const ChatInput: FC<ChatInputProps> = ({
       focusEditorCaret(0);
     } catch {
       focusEditorCaret(caretIndex);
-      return;
     }
   };
 
@@ -455,7 +505,6 @@ export const ChatInput: FC<ChatInputProps> = ({
       focusEditorCaret(0);
     } catch {
       focusEditorCaret(currentCaretIndex);
-      return;
     }
   };
 
@@ -463,6 +512,7 @@ export const ChatInput: FC<ChatInputProps> = ({
     if (isClearConfirmOpen && event.key === "Escape") {
       event.preventDefault();
       setIsClearConfirmOpen(false);
+      setTabCompletionSession(null);
       focusEditorCaret(caretIndex);
       return;
     }
@@ -479,6 +529,7 @@ export const ChatInput: FC<ChatInputProps> = ({
     if (event.key === "Escape") {
       event.preventDefault();
       setDismissedMentionKey(activeSuggestionKey);
+      setTabCompletionSession(null);
       return;
     }
 
@@ -506,6 +557,33 @@ export const ChatInput: FC<ChatInputProps> = ({
         }
 
         return currentIndex + 1;
+      });
+      return;
+    }
+
+    if (event.key === "Tab" && suggestionMode === "mention") {
+      const selectedSuggestionIndex =
+        selectedMentionIndex >= 0 ? selectedMentionIndex : 0;
+      const selectedSuggestion = activeSuggestions[selectedSuggestionIndex];
+
+      if (selectedSuggestion?.type !== "mention") {
+        return;
+      }
+
+      event.preventDefault();
+      handleMentionSuggestionSelect({
+        keepTabCompletionSession: true,
+        mention: activeMentionForSuggestions,
+        suggestion: selectedSuggestion,
+      });
+      setSelectedMentionIndex((currentIndex) => {
+        const nextIndex = currentIndex >= 0 ? currentIndex + 1 : 1;
+
+        if (nextIndex >= activeSuggestions.length) {
+          return 0;
+        }
+
+        return nextIndex;
       });
       return;
     }
@@ -568,6 +646,7 @@ export const ChatInput: FC<ChatInputProps> = ({
                   setMessageValue(nextMessage);
                   setCaretIndex(nextCaretIndex);
                   setDismissedMentionKey(null);
+                  setTabCompletionSession(null);
                 }}
                 onCaretChange={setCaretIndex}
                 onKeyDown={handleInputKeyDown}


### PR DESCRIPTION
## Summary

- add Tab handling for chat mention suggestions in the game client chat input
- keep a small Tab completion session so repeated Tab presses cycle through the original mention suggestions and wrap back to the first item
- cover the role/member cycling behavior with a chat input test

## Linear

- LOO-5

## Validation

- `pnpm --filter @lootlog/game-client test -- src/features/chat/components/chat-input.test.tsx`
- `pnpm exec oxlint apps/game-client/src/features/chat/components/chat-input.tsx apps/game-client/src/features/chat/components/chat-input.test.tsx`
- pre-commit hook ran changed-package checks, including `@lootlog/game-client:test` with 108 files / 499 tests passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat input now supports Tab key completion for mention suggestions. Tab cycles through available mentions, inserts the highlighted selection, and allows continuing to cycle through additional matches while composing messages.

* **Tests**
  * Added test coverage for Tab key mention suggestion completion, verifying cycling through successive suggestions, inserting highlighted mentions, and preventing unintended message sends during the cycling process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->