### PR TITLE
[codex] Persist online player filters per server

### DIFF
--- a/apps/game-client/src/features/online-players/components/online-players-list.test.tsx
+++ b/apps/game-client/src/features/online-players/components/online-players-list.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OnlinePlayersList } from "./online-players-list";
-import { useWindowsStore } from "@/store/windows.store";
+import { useOnlinePlayersStore } from "@/store/online-players.store";
 
 const mockUsePlayersPresence = vi.fn();
 const mockUseGuildMembersSummary = vi.fn();
@@ -112,16 +112,11 @@ describe("OnlinePlayersList", () => {
       vi.fn(),
     ]);
 
-    useWindowsStore.setState((state) => ({
-      "online-players": {
-        ...state["online-players"],
-        state: {
-          viewMode: "accounts",
-          filtersVisible: true,
-          filtersByGuildId: {},
-        },
-      },
-    }));
+    useOnlinePlayersStore.setState({
+      viewMode: "accounts",
+      filtersVisible: true,
+      filtersByGuildId: {},
+    });
   });
 
   it("renders account entries with locations in accounts view", () => {
@@ -335,9 +330,7 @@ describe("OnlinePlayersList", () => {
 
     expect(screen.getByText("Hero (123w)")).toBeVisible();
     expect(screen.queryByText("Scout (80h)")).not.toBeInTheDocument();
-    expect(
-      useWindowsStore.getState()["online-players"].state.filtersByGuildId,
-    ).toMatchObject({
+    expect(useOnlinePlayersStore.getState().filtersByGuildId).toMatchObject({
       "guild-1": {
         minLvl: 100,
         maxLvl: 500,
@@ -367,9 +360,7 @@ describe("OnlinePlayersList", () => {
       },
     });
 
-    expect(
-      useWindowsStore.getState()["online-players"].state.filtersByGuildId,
-    ).toMatchObject({
+    expect(useOnlinePlayersStore.getState().filtersByGuildId).toMatchObject({
       "guild-1": {
         minLvl: 100,
         maxLvl: 500,

--- a/apps/game-client/src/features/online-players/components/online-players-list.test.tsx
+++ b/apps/game-client/src/features/online-players/components/online-players-list.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OnlinePlayersList } from "./online-players-list";
+import { useWindowsStore } from "@/store/windows.store";
 
 const mockUsePlayersPresence = vi.fn();
 const mockUseGuildMembersSummary = vi.fn();
@@ -110,6 +111,17 @@ describe("OnlinePlayersList", () => {
       false,
       vi.fn(),
     ]);
+
+    useWindowsStore.setState((state) => ({
+      "online-players": {
+        ...state["online-players"],
+        state: {
+          viewMode: "accounts",
+          filtersVisible: true,
+          filtersByGuildId: {},
+        },
+      },
+    }));
   });
 
   it("renders account entries with locations in accounts view", () => {
@@ -308,6 +320,67 @@ describe("OnlinePlayersList", () => {
 
     expect(screen.getByLabelText("Minimalny poziom")).toHaveValue(90);
     expect(screen.getByLabelText("Maksymalny poziom")).toHaveValue(90);
+  });
+
+  it("stores level filters separately for each guild", () => {
+    const { rerender } = render(
+      <OnlinePlayersList viewMode="accounts" filtersVisible />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Minimalny poziom"), {
+      target: {
+        value: "100",
+      },
+    });
+
+    expect(screen.getByText("Hero (123w)")).toBeVisible();
+    expect(screen.queryByText("Scout (80h)")).not.toBeInTheDocument();
+    expect(
+      useWindowsStore.getState()["online-players"].state.filtersByGuildId,
+    ).toMatchObject({
+      "guild-1": {
+        minLvl: 100,
+        maxLvl: 500,
+        selectedProfession: "all",
+      },
+    });
+
+    mockUseSettingsStore.mockReturnValue({
+      allowWorldSelection: false,
+      guildIdByCharId: {
+        "10": "guild-2",
+      },
+      worldByGuildId: {
+        "guild-2": "pandora",
+      },
+    });
+
+    rerender(<OnlinePlayersList viewMode="accounts" filtersVisible />);
+
+    expect(screen.getByLabelText("Minimalny poziom")).toHaveValue(0);
+    expect(screen.getByText("Hero (123w)")).toBeVisible();
+    expect(screen.getByText("Scout (80h)")).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Maksymalny poziom"), {
+      target: {
+        value: "90",
+      },
+    });
+
+    expect(
+      useWindowsStore.getState()["online-players"].state.filtersByGuildId,
+    ).toMatchObject({
+      "guild-1": {
+        minLvl: 100,
+        maxLvl: 500,
+        selectedProfession: "all",
+      },
+      "guild-2": {
+        minLvl: 0,
+        maxLvl: 90,
+        selectedProfession: "all",
+      },
+    });
   });
 
   it("filters account entries by profession", async () => {

--- a/apps/game-client/src/features/online-players/components/online-players-list.tsx
+++ b/apps/game-client/src/features/online-players/components/online-players-list.tsx
@@ -6,8 +6,8 @@ import { OnlinePlayersFilters } from "@/features/online-players/components/onlin
 import { OnlinePlayersListEntry } from "@/features/online-players/components/online-players-list-entry";
 import { usePlayersPresence } from "@/features/online-players/hooks/use-players-presence";
 import type { OnlinePlayersViewMode } from "@/features/online-players/online-players.types";
+import { useOnlinePlayersStore } from "@/store/online-players.store";
 import { useSettingsStore } from "@/store/settings.store";
-import { useWindowsStore } from "@/store/windows.store";
 import { useGuildMembersSummary } from "@/hooks/api/guild-members-summary-query";
 import { useMemberInvalidation } from "@/hooks/api/use-member-invalidation";
 import { mapGuildMembersByUserId } from "@/lib/api/generated-helpers";
@@ -40,12 +40,10 @@ export const OnlinePlayersList: FC<OnlinePlayersListProps> = ({
   const guildId = guildIdByCharId[characterId];
   const world = guildId ? worldByGuildId[guildId] : undefined;
   const [onlinePlayers] = usePlayersPresence(guildId, world || defaultWorld);
-  const filtersByGuildId = useWindowsStore(
-    (state) => state["online-players"].state.filtersByGuildId,
+  const filtersByGuildId = useOnlinePlayersStore(
+    (state) => state.filtersByGuildId,
   );
-  const setOnlinePlayersFilters = useWindowsStore(
-    (state) => state.setOnlinePlayersFilters,
-  );
+  const setFilters = useOnlinePlayersStore((state) => state.setFilters);
   const { data: guildMembers } = useGuildMembersSummary(
     { guildId: guildId ?? "" },
     {
@@ -69,7 +67,7 @@ export const OnlinePlayersList: FC<OnlinePlayersListProps> = ({
 
     const minLvl = clampOnlinePlayerLevel(numericValue);
 
-    setOnlinePlayersFilters(guildId, {
+    setFilters(guildId, {
       ...filters,
       minLvl,
       maxLvl: minLvl > filters.maxLvl ? minLvl : filters.maxLvl,
@@ -85,7 +83,7 @@ export const OnlinePlayersList: FC<OnlinePlayersListProps> = ({
 
     const maxLvl = clampOnlinePlayerLevel(numericValue);
 
-    setOnlinePlayersFilters(guildId, {
+    setFilters(guildId, {
       ...filters,
       minLvl: maxLvl < filters.minLvl ? maxLvl : filters.minLvl,
       maxLvl,
@@ -95,7 +93,7 @@ export const OnlinePlayersList: FC<OnlinePlayersListProps> = ({
   const handleProfessionChange = (profession: ProfessionFilterValue) => {
     if (!guildId) return;
 
-    setOnlinePlayersFilters(guildId, {
+    setFilters(guildId, {
       ...filters,
       selectedProfession: profession,
     });

--- a/apps/game-client/src/features/online-players/components/online-players-list.tsx
+++ b/apps/game-client/src/features/online-players/components/online-players-list.tsx
@@ -7,10 +7,11 @@ import { OnlinePlayersListEntry } from "@/features/online-players/components/onl
 import { usePlayersPresence } from "@/features/online-players/hooks/use-players-presence";
 import type { OnlinePlayersViewMode } from "@/features/online-players/online-players.types";
 import { useSettingsStore } from "@/store/settings.store";
+import { useWindowsStore } from "@/store/windows.store";
 import { useGuildMembersSummary } from "@/hooks/api/guild-members-summary-query";
 import { useMemberInvalidation } from "@/hooks/api/use-member-invalidation";
 import { mapGuildMembersByUserId } from "@/lib/api/generated-helpers";
-import { useState, type FC, type ReactNode } from "react";
+import { useState, type ChangeEvent, type FC, type ReactNode } from "react";
 import { Game } from "@/lib/game";
 import { useTranslation } from "react-i18next";
 import {
@@ -39,6 +40,12 @@ export const OnlinePlayersList: FC<OnlinePlayersListProps> = ({
   const guildId = guildIdByCharId[characterId];
   const world = guildId ? worldByGuildId[guildId] : undefined;
   const [onlinePlayers] = usePlayersPresence(guildId, world || defaultWorld);
+  const filtersByGuildId = useWindowsStore(
+    (state) => state["online-players"].state.filtersByGuildId,
+  );
+  const setOnlinePlayersFilters = useWindowsStore(
+    (state) => state.setOnlinePlayersFilters,
+  );
   const { data: guildMembers } = useGuildMembersSummary(
     { guildId: guildId ?? "" },
     {
@@ -49,41 +56,49 @@ export const OnlinePlayersList: FC<OnlinePlayersListProps> = ({
     },
   );
   const [searchQuery, setSearchQuery] = useState("");
-  const [filters, setFilters] = useState(DEFAULT_ONLINE_PLAYERS_FILTERS);
+  const filters = guildId
+    ? (filtersByGuildId[guildId] ?? DEFAULT_ONLINE_PLAYERS_FILTERS)
+    : DEFAULT_ONLINE_PLAYERS_FILTERS;
 
-  const handleMinLvlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleMinLvlChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!guildId) return;
+
     const numericValue = Number(event.target.value);
 
     if (Number.isNaN(numericValue)) return;
 
     const minLvl = clampOnlinePlayerLevel(numericValue);
 
-    setFilters((currentFilters) => ({
-      ...currentFilters,
+    setOnlinePlayersFilters(guildId, {
+      ...filters,
       minLvl,
-      maxLvl: minLvl > currentFilters.maxLvl ? minLvl : currentFilters.maxLvl,
-    }));
+      maxLvl: minLvl > filters.maxLvl ? minLvl : filters.maxLvl,
+    });
   };
 
-  const handleMaxLvlChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleMaxLvlChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!guildId) return;
+
     const numericValue = Number(event.target.value);
 
     if (Number.isNaN(numericValue)) return;
 
     const maxLvl = clampOnlinePlayerLevel(numericValue);
 
-    setFilters((currentFilters) => ({
-      ...currentFilters,
-      minLvl: maxLvl < currentFilters.minLvl ? maxLvl : currentFilters.minLvl,
+    setOnlinePlayersFilters(guildId, {
+      ...filters,
+      minLvl: maxLvl < filters.minLvl ? maxLvl : filters.minLvl,
       maxLvl,
-    }));
+    });
   };
 
   const handleProfessionChange = (profession: ProfessionFilterValue) => {
-    setFilters((currentFilters) => ({
-      ...currentFilters,
+    if (!guildId) return;
+
+    setOnlinePlayersFilters(guildId, {
+      ...filters,
       selectedProfession: profession,
-    }));
+    });
   };
 
   const missingMemberIds = guildMembers

--- a/apps/game-client/src/features/online-players/online-players.tsx
+++ b/apps/game-client/src/features/online-players/online-players.tsx
@@ -2,28 +2,23 @@ import { DraggableWindow } from "@/components/draggable-window";
 import { AnimatedWindow } from "@/components/animated-window";
 import { OnlinePlayersActions } from "@/features/online-players/components/online-players-actions";
 import { OnlinePlayersList } from "@/features/online-players/components/online-players-list";
+import { useOnlinePlayersStore } from "@/store/online-players.store";
 import { useWindowsStore } from "@/store/windows.store";
 import { useTranslation } from "react-i18next";
 
 export const OnlinePlayers = () => {
   const { t } = useTranslation("onlinePlayers");
   const open = useWindowsStore((state) => state["online-players"].open);
-  const viewMode = useWindowsStore(
-    (state) => state["online-players"].state.viewMode,
-  );
-  const filtersVisible = useWindowsStore(
-    (state) => state["online-players"].state.filtersVisible,
-  );
   const setOpen = useWindowsStore((state) => state.setOpen);
-  const setOnlinePlayersViewMode = useWindowsStore(
-    (state) => state.setOnlinePlayersViewMode,
-  );
-  const toggleOnlinePlayersFiltersVisible = useWindowsStore(
-    (state) => state.toggleOnlinePlayersFiltersVisible,
+  const viewMode = useOnlinePlayersStore((state) => state.viewMode);
+  const filtersVisible = useOnlinePlayersStore((state) => state.filtersVisible);
+  const setViewMode = useOnlinePlayersStore((state) => state.setViewMode);
+  const toggleFiltersVisible = useOnlinePlayersStore(
+    (state) => state.toggleFiltersVisible,
   );
 
   const toggleViewMode = () => {
-    setOnlinePlayersViewMode(viewMode === "members" ? "accounts" : "members");
+    setViewMode(viewMode === "members" ? "accounts" : "members");
   };
 
   return (
@@ -39,7 +34,7 @@ export const OnlinePlayers = () => {
           viewMode={viewMode}
           toggleViewMode={toggleViewMode}
           filtersVisible={filtersVisible}
-          toggleFiltersVisible={toggleOnlinePlayersFiltersVisible}
+          toggleFiltersVisible={toggleFiltersVisible}
         />
       >
         <OnlinePlayersList

--- a/apps/game-client/src/store/online-players.store.test.ts
+++ b/apps/game-client/src/store/online-players.store.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  migrateOnlinePlayersState,
+  useOnlinePlayersStore,
+} from "./online-players.store";
+
+describe("migrateOnlinePlayersState", () => {
+  it("adds defaults for missing online players feature state", () => {
+    expect(migrateOnlinePlayersState({})).toEqual({
+      viewMode: "accounts",
+      filtersVisible: true,
+      filtersByGuildId: {},
+    });
+  });
+
+  it("keeps valid persisted online players feature state", () => {
+    expect(
+      migrateOnlinePlayersState({
+        viewMode: "members",
+        filtersVisible: false,
+        filtersByGuildId: {
+          "guild-1": {
+            minLvl: 100,
+            maxLvl: 200,
+            selectedProfession: "w",
+          },
+        },
+      }),
+    ).toEqual({
+      viewMode: "members",
+      filtersVisible: false,
+      filtersByGuildId: {
+        "guild-1": {
+          minLvl: 100,
+          maxLvl: 200,
+          selectedProfession: "w",
+        },
+      },
+    });
+  });
+
+  it("drops invalid persisted online players filters by guild", () => {
+    expect(
+      migrateOnlinePlayersState({
+        viewMode: "members",
+        filtersVisible: false,
+        filtersByGuildId: {
+          "guild-1": {
+            minLvl: 100,
+            maxLvl: 200,
+            selectedProfession: "invalid",
+          },
+        },
+      }),
+    ).toEqual({
+      viewMode: "members",
+      filtersVisible: false,
+      filtersByGuildId: {},
+    });
+  });
+});
+
+describe("useOnlinePlayersStore", () => {
+  it("stores filters separately for each guild", () => {
+    useOnlinePlayersStore.setState({
+      viewMode: "accounts",
+      filtersVisible: true,
+      filtersByGuildId: {},
+    });
+
+    useOnlinePlayersStore.getState().setFilters("guild-1", {
+      minLvl: 100,
+      maxLvl: 500,
+      selectedProfession: "all",
+    });
+    useOnlinePlayersStore.getState().setFilters("guild-2", {
+      minLvl: 0,
+      maxLvl: 90,
+      selectedProfession: "h",
+    });
+
+    expect(useOnlinePlayersStore.getState().filtersByGuildId).toEqual({
+      "guild-1": {
+        minLvl: 100,
+        maxLvl: 500,
+        selectedProfession: "all",
+      },
+      "guild-2": {
+        minLvl: 0,
+        maxLvl: 90,
+        selectedProfession: "h",
+      },
+    });
+  });
+});

--- a/apps/game-client/src/store/online-players.store.ts
+++ b/apps/game-client/src/store/online-players.store.ts
@@ -1,0 +1,114 @@
+import {
+  ALL_PROFESSIONS_VALUE,
+  type OnlinePlayersFiltersValue,
+} from "@/features/online-players/online-players-list.helpers";
+import type { OnlinePlayersViewMode } from "@/features/online-players/online-players.types";
+import { storageKey } from "@/lib/storage-key";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+const STORAGE_KEY = storageKey("ll-online-players-state");
+const DEFAULT_VIEW_MODE: OnlinePlayersViewMode = "accounts";
+const DEFAULT_FILTERS_VISIBLE = true;
+const VALID_PROFESSIONS = ["all", "p", "w", "h", "m", "b", "t"];
+
+type OnlinePlayersState = {
+  viewMode: OnlinePlayersViewMode;
+  filtersVisible: boolean;
+  filtersByGuildId: Record<string, OnlinePlayersFiltersValue | undefined>;
+  setViewMode: (viewMode: OnlinePlayersViewMode) => void;
+  toggleFiltersVisible: () => void;
+  setFilters: (guildId: string, filters: OnlinePlayersFiltersValue) => void;
+};
+
+const isViewMode = (viewMode: unknown): viewMode is OnlinePlayersViewMode => {
+  return viewMode === "members" || viewMode === "accounts";
+};
+
+const isOnlinePlayersFiltersValue = (
+  filters: unknown,
+): filters is OnlinePlayersFiltersValue => {
+  if (typeof filters !== "object" || filters === null) {
+    return false;
+  }
+
+  const candidate = filters as Record<string, unknown>;
+
+  return (
+    typeof candidate.minLvl === "number" &&
+    typeof candidate.maxLvl === "number" &&
+    typeof candidate.selectedProfession === "string" &&
+    VALID_PROFESSIONS.includes(candidate.selectedProfession)
+  );
+};
+
+const sanitizeFiltersByGuildId = (
+  filtersByGuildId: unknown,
+): Record<string, OnlinePlayersFiltersValue | undefined> => {
+  if (typeof filtersByGuildId !== "object" || filtersByGuildId === null) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(filtersByGuildId).filter(([, filters]) =>
+      isOnlinePlayersFiltersValue(filters),
+    ),
+  );
+};
+
+export const migrateOnlinePlayersState = (
+  persisted: unknown,
+): Pick<
+  OnlinePlayersState,
+  "viewMode" | "filtersVisible" | "filtersByGuildId"
+> => {
+  const state =
+    typeof persisted === "object" && persisted !== null
+      ? (persisted as Record<string, unknown>)
+      : {};
+
+  return {
+    viewMode: isViewMode(state.viewMode) ? state.viewMode : DEFAULT_VIEW_MODE,
+    filtersVisible:
+      typeof state.filtersVisible === "boolean"
+        ? state.filtersVisible
+        : DEFAULT_FILTERS_VISIBLE,
+    filtersByGuildId: sanitizeFiltersByGuildId(state.filtersByGuildId),
+  };
+};
+
+export const useOnlinePlayersStore = create<OnlinePlayersState>()(
+  persist(
+    (set) => ({
+      viewMode: DEFAULT_VIEW_MODE,
+      filtersVisible: DEFAULT_FILTERS_VISIBLE,
+      filtersByGuildId: {},
+      setViewMode: (viewMode) => set({ viewMode }),
+      toggleFiltersVisible: () =>
+        set((state) => ({ filtersVisible: !state.filtersVisible })),
+      setFilters: (guildId, filters) =>
+        set((state) => ({
+          filtersByGuildId: {
+            ...state.filtersByGuildId,
+            [guildId]: {
+              minLvl: filters.minLvl,
+              maxLvl: filters.maxLvl,
+              selectedProfession:
+                filters.selectedProfession ?? ALL_PROFESSIONS_VALUE,
+            },
+          },
+        })),
+    }),
+    {
+      name: STORAGE_KEY,
+      partialize: (state) => ({
+        viewMode: state.viewMode,
+        filtersVisible: state.filtersVisible,
+        filtersByGuildId: state.filtersByGuildId,
+      }),
+      storage: createJSONStorage(() => localStorage),
+      version: 1,
+      migrate: migrateOnlinePlayersState,
+    },
+  ),
+);

--- a/apps/game-client/src/store/windows.store.test.ts
+++ b/apps/game-client/src/store/windows.store.test.ts
@@ -89,132 +89,16 @@ describe("migrateWindowsState", () => {
     expect(migrated["add-timer"].state).toEqual({});
   });
 
-  it("adds default online players location view state for persisted windows", () => {
+  it("removes old online players feature state from persisted windows", () => {
     const migrated = migrateWindowsState(
       {
         "online-players": {
-          open: false,
-          position: { x: 0, y: 0 },
-          hasDefinedPosition: false,
-          size: { width: 242, height: 240 },
-          opacity: 4,
-          locked: false,
-        },
-        windowFocusHistory: [],
-      },
-      6,
-    );
-
-    expect(migrated["online-players"].state).toEqual({
-      viewMode: "accounts",
-      filtersVisible: true,
-      filtersByGuildId: {},
-    });
-  });
-
-  it("keeps valid persisted online players view mode", () => {
-    const migrated = migrateWindowsState(
-      {
-        "online-players": {
-          open: false,
-          position: { x: 0, y: 0 },
-          hasDefinedPosition: false,
-          size: { width: 242, height: 240 },
-          opacity: 4,
-          locked: false,
-          state: {
-            viewMode: "members",
-          },
-        },
-        windowFocusHistory: [],
-      },
-      7,
-    );
-
-    expect(migrated["online-players"].state).toEqual({
-      viewMode: "members",
-      filtersVisible: true,
-      filtersByGuildId: {},
-    });
-  });
-
-  it("keeps valid persisted online players filters visibility", () => {
-    const migrated = migrateWindowsState(
-      {
-        "online-players": {
-          open: false,
-          position: { x: 0, y: 0 },
-          hasDefinedPosition: false,
-          size: { width: 242, height: 240 },
-          opacity: 4,
-          locked: false,
-          state: {
-            viewMode: "members",
-            filtersVisible: false,
-          },
-        },
-        windowFocusHistory: [],
-      },
-      7,
-    );
-
-    expect(migrated["online-players"].state).toEqual({
-      viewMode: "members",
-      filtersVisible: false,
-      filtersByGuildId: {},
-    });
-  });
-
-  it("keeps valid persisted online players filters by guild", () => {
-    const migrated = migrateWindowsState(
-      {
-        "online-players": {
-          open: false,
-          position: { x: 0, y: 0 },
-          hasDefinedPosition: false,
-          size: { width: 242, height: 240 },
-          opacity: 4,
-          locked: false,
-          state: {
-            viewMode: "members",
-            filtersVisible: false,
-            filtersByGuildId: {
-              "guild-1": {
-                minLvl: 100,
-                maxLvl: 200,
-                selectedProfession: "w",
-              },
-            },
-          },
-        },
-        windowFocusHistory: [],
-      },
-      8,
-    );
-
-    expect(migrated["online-players"].state).toEqual({
-      viewMode: "members",
-      filtersVisible: false,
-      filtersByGuildId: {
-        "guild-1": {
-          minLvl: 100,
-          maxLvl: 200,
-          selectedProfession: "w",
-        },
-      },
-    });
-  });
-
-  it("drops invalid persisted online players filters by guild", () => {
-    const migrated = migrateWindowsState(
-      {
-        "online-players": {
-          open: false,
-          position: { x: 0, y: 0 },
-          hasDefinedPosition: false,
-          size: { width: 242, height: 240 },
-          opacity: 4,
-          locked: false,
+          open: true,
+          position: { x: 50, y: 60 },
+          hasDefinedPosition: true,
+          size: { width: 280, height: 340 },
+          opacity: 2,
+          locked: true,
           state: {
             viewMode: "members",
             filtersVisible: false,
@@ -229,17 +113,20 @@ describe("migrateWindowsState", () => {
         },
         windowFocusHistory: [],
       },
-      8,
+      7,
     );
 
-    expect(migrated["online-players"].state).toEqual({
-      viewMode: "members",
-      filtersVisible: false,
-      filtersByGuildId: {},
+    expect(migrated["online-players"]).toEqual({
+      open: true,
+      position: { x: 50, y: 60 },
+      hasDefinedPosition: true,
+      size: { width: 280, height: 340 },
+      opacity: 2,
+      locked: true,
     });
   });
 
-  it("adds online players view mode without changing other persisted window settings", () => {
+  it("keeps online players window settings without feature state", () => {
     const migrated = migrateWindowsState(
       {
         chat: {
@@ -297,11 +184,6 @@ describe("migrateWindowsState", () => {
       size: { width: 280, height: 340 },
       opacity: 2,
       locked: false,
-      state: {
-        viewMode: "accounts",
-        filtersVisible: true,
-        filtersByGuildId: {},
-      },
     });
     expect(migrated.currentWindowFocus).toBe("online-players");
     expect(migrated.windowFocusHistory).toEqual(["online-players", "chat"]);

--- a/apps/game-client/src/store/windows.store.test.ts
+++ b/apps/game-client/src/store/windows.store.test.ts
@@ -108,6 +108,7 @@ describe("migrateWindowsState", () => {
     expect(migrated["online-players"].state).toEqual({
       viewMode: "accounts",
       filtersVisible: true,
+      filtersByGuildId: {},
     });
   });
 
@@ -133,6 +134,7 @@ describe("migrateWindowsState", () => {
     expect(migrated["online-players"].state).toEqual({
       viewMode: "members",
       filtersVisible: true,
+      filtersByGuildId: {},
     });
   });
 
@@ -159,6 +161,81 @@ describe("migrateWindowsState", () => {
     expect(migrated["online-players"].state).toEqual({
       viewMode: "members",
       filtersVisible: false,
+      filtersByGuildId: {},
+    });
+  });
+
+  it("keeps valid persisted online players filters by guild", () => {
+    const migrated = migrateWindowsState(
+      {
+        "online-players": {
+          open: false,
+          position: { x: 0, y: 0 },
+          hasDefinedPosition: false,
+          size: { width: 242, height: 240 },
+          opacity: 4,
+          locked: false,
+          state: {
+            viewMode: "members",
+            filtersVisible: false,
+            filtersByGuildId: {
+              "guild-1": {
+                minLvl: 100,
+                maxLvl: 200,
+                selectedProfession: "w",
+              },
+            },
+          },
+        },
+        windowFocusHistory: [],
+      },
+      8,
+    );
+
+    expect(migrated["online-players"].state).toEqual({
+      viewMode: "members",
+      filtersVisible: false,
+      filtersByGuildId: {
+        "guild-1": {
+          minLvl: 100,
+          maxLvl: 200,
+          selectedProfession: "w",
+        },
+      },
+    });
+  });
+
+  it("drops invalid persisted online players filters by guild", () => {
+    const migrated = migrateWindowsState(
+      {
+        "online-players": {
+          open: false,
+          position: { x: 0, y: 0 },
+          hasDefinedPosition: false,
+          size: { width: 242, height: 240 },
+          opacity: 4,
+          locked: false,
+          state: {
+            viewMode: "members",
+            filtersVisible: false,
+            filtersByGuildId: {
+              "guild-1": {
+                minLvl: 100,
+                maxLvl: 200,
+                selectedProfession: "invalid",
+              },
+            },
+          },
+        },
+        windowFocusHistory: [],
+      },
+      8,
+    );
+
+    expect(migrated["online-players"].state).toEqual({
+      viewMode: "members",
+      filtersVisible: false,
+      filtersByGuildId: {},
     });
   });
 
@@ -223,6 +300,7 @@ describe("migrateWindowsState", () => {
       state: {
         viewMode: "accounts",
         filtersVisible: true,
+        filtersByGuildId: {},
       },
     });
     expect(migrated.currentWindowFocus).toBe("online-players");

--- a/apps/game-client/src/store/windows.store.ts
+++ b/apps/game-client/src/store/windows.store.ts
@@ -3,8 +3,6 @@ import {
   APP_ERROR_WINDOW_DEFAULT_HEIGHT,
   APP_ERROR_WINDOW_WIDTH,
 } from "@/features/error-boundary/error-boundary.constants";
-import type { OnlinePlayersFiltersValue } from "@/features/online-players/online-players-list.helpers";
-import type { OnlinePlayersViewMode } from "@/features/online-players/online-players.types";
 import type { GameNpc } from "@lootlog/margonem";
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
@@ -22,12 +20,6 @@ type SettingsWindowState = {
 
 type AddTimerWindowState = {
   guildId?: string;
-};
-
-type OnlinePlayersWindowState = {
-  viewMode: OnlinePlayersViewMode;
-  filtersVisible: boolean;
-  filtersByGuildId: Record<string, OnlinePlayersFiltersValue | undefined>;
 };
 
 export type WindowId =
@@ -77,7 +69,7 @@ interface WindowsState {
   timers: WindowData;
   chat: WindowData;
   command: WindowData;
-  "online-players": WindowData & { state: OnlinePlayersWindowState };
+  "online-players": WindowData;
   "add-timer": WindowData & { state: AddTimerWindowState };
   "npc-detector": WindowData;
   notifications: WindowData;
@@ -100,20 +92,11 @@ interface WindowsState {
   toggleOpen: (window: WindowId, autofocus?: boolean) => void;
   setAutofocus: (window: WindowId, autofocus: boolean) => void;
   setSettingsActiveTab: (activeTab?: SettingsTabValue) => void;
-  setOnlinePlayersViewMode: (viewMode: OnlinePlayersViewMode) => void;
-  setOnlinePlayersFilters: (
-    guildId: string,
-    filters: OnlinePlayersFiltersValue,
-  ) => void;
-  toggleOnlinePlayersFiltersVisible: () => void;
 }
 
 const DEFAULT_OPACITY: WindowOpacity = 4;
 const DEFAULT_POSITION: WindowPositionState = { x: 0, y: 0 };
 const DEFAULT_SIZE: WindowSizeState = { width: 242, height: 240 };
-const DEFAULT_ONLINE_PLAYERS_VIEW_MODE: OnlinePlayersViewMode = "accounts";
-const DEFAULT_ONLINE_PLAYERS_FILTERS_VISIBLE = true;
-const VALID_ONLINE_PLAYERS_PROFESSIONS = ["all", "p", "w", "h", "m", "b", "t"];
 
 const sanitizeMaxContentHeight = (height: number) => {
   if (!Number.isFinite(height)) {
@@ -149,37 +132,6 @@ const inferLegacyDefinedPosition = (
   }
 
   return typeof position === "object" && position !== null;
-};
-
-const isOnlinePlayersFiltersValue = (
-  filters: unknown,
-): filters is OnlinePlayersFiltersValue => {
-  if (typeof filters !== "object" || filters === null) {
-    return false;
-  }
-
-  const candidate = filters as Record<string, unknown>;
-
-  return (
-    typeof candidate.minLvl === "number" &&
-    typeof candidate.maxLvl === "number" &&
-    typeof candidate.selectedProfession === "string" &&
-    VALID_ONLINE_PLAYERS_PROFESSIONS.includes(candidate.selectedProfession)
-  );
-};
-
-const sanitizeOnlinePlayersFiltersByGuildId = (
-  filtersByGuildId: unknown,
-): Record<string, OnlinePlayersFiltersValue | undefined> => {
-  if (typeof filtersByGuildId !== "object" || filtersByGuildId === null) {
-    return {};
-  }
-
-  return Object.fromEntries(
-    Object.entries(filtersByGuildId).filter(([, filters]) =>
-      isOnlinePlayersFiltersValue(filters),
-    ),
-  );
 };
 
 export const migrateWindowsState = (
@@ -261,32 +213,9 @@ export const migrateWindowsState = (
   const onlinePlayers = state["online-players"] as
     | Record<string, unknown>
     | undefined;
-  const onlinePlayersState = onlinePlayers?.state as
-    | Record<string, unknown>
-    | undefined;
-  const onlinePlayersViewMode = onlinePlayersState?.viewMode;
-  const onlinePlayersFiltersVisible = onlinePlayersState?.filtersVisible;
-  const onlinePlayersFiltersByGuildId = onlinePlayersState?.filtersByGuildId;
-
   if (onlinePlayers && typeof onlinePlayers === "object") {
-    state["online-players"] = {
-      ...onlinePlayers,
-      state: {
-        ...onlinePlayersState,
-        viewMode:
-          onlinePlayersViewMode === "members" ||
-          onlinePlayersViewMode === "accounts"
-            ? onlinePlayersViewMode
-            : DEFAULT_ONLINE_PLAYERS_VIEW_MODE,
-        filtersVisible:
-          typeof onlinePlayersFiltersVisible === "boolean"
-            ? onlinePlayersFiltersVisible
-            : DEFAULT_ONLINE_PLAYERS_FILTERS_VISIBLE,
-        filtersByGuildId: sanitizeOnlinePlayersFiltersByGuildId(
-          onlinePlayersFiltersByGuildId,
-        ),
-      },
-    };
+    const { state: _, ...windowState } = onlinePlayers;
+    state["online-players"] = windowState;
   }
 
   return state as unknown as WindowsState;
@@ -351,11 +280,6 @@ export const useWindowsStore = create<WindowsState>()(
         size: { width: 242, height: 240 },
         opacity: DEFAULT_OPACITY,
         locked: false,
-        state: {
-          viewMode: DEFAULT_ONLINE_PLAYERS_VIEW_MODE,
-          filtersVisible: DEFAULT_ONLINE_PLAYERS_FILTERS_VISIBLE,
-          filtersByGuildId: {},
-        },
       },
       "add-timer": {
         open: false,
@@ -517,39 +441,6 @@ export const useWindowsStore = create<WindowsState>()(
             state: {
               ...state.settings.state,
               activeTab,
-            },
-          },
-        })),
-      setOnlinePlayersViewMode: (viewMode) =>
-        set((state) => ({
-          "online-players": {
-            ...state["online-players"],
-            state: {
-              ...state["online-players"].state,
-              viewMode,
-            },
-          },
-        })),
-      setOnlinePlayersFilters: (guildId, filters) =>
-        set((state) => ({
-          "online-players": {
-            ...state["online-players"],
-            state: {
-              ...state["online-players"].state,
-              filtersByGuildId: {
-                ...state["online-players"].state.filtersByGuildId,
-                [guildId]: filters,
-              },
-            },
-          },
-        })),
-      toggleOnlinePlayersFiltersVisible: () =>
-        set((state) => ({
-          "online-players": {
-            ...state["online-players"],
-            state: {
-              ...state["online-players"].state,
-              filtersVisible: !state["online-players"].state.filtersVisible,
             },
           },
         })),

--- a/apps/game-client/src/store/windows.store.ts
+++ b/apps/game-client/src/store/windows.store.ts
@@ -3,6 +3,7 @@ import {
   APP_ERROR_WINDOW_DEFAULT_HEIGHT,
   APP_ERROR_WINDOW_WIDTH,
 } from "@/features/error-boundary/error-boundary.constants";
+import type { OnlinePlayersFiltersValue } from "@/features/online-players/online-players-list.helpers";
 import type { OnlinePlayersViewMode } from "@/features/online-players/online-players.types";
 import type { GameNpc } from "@lootlog/margonem";
 import { create } from "zustand";
@@ -26,6 +27,7 @@ type AddTimerWindowState = {
 type OnlinePlayersWindowState = {
   viewMode: OnlinePlayersViewMode;
   filtersVisible: boolean;
+  filtersByGuildId: Record<string, OnlinePlayersFiltersValue | undefined>;
 };
 
 export type WindowId =
@@ -99,6 +101,10 @@ interface WindowsState {
   setAutofocus: (window: WindowId, autofocus: boolean) => void;
   setSettingsActiveTab: (activeTab?: SettingsTabValue) => void;
   setOnlinePlayersViewMode: (viewMode: OnlinePlayersViewMode) => void;
+  setOnlinePlayersFilters: (
+    guildId: string,
+    filters: OnlinePlayersFiltersValue,
+  ) => void;
   toggleOnlinePlayersFiltersVisible: () => void;
 }
 
@@ -107,6 +113,7 @@ const DEFAULT_POSITION: WindowPositionState = { x: 0, y: 0 };
 const DEFAULT_SIZE: WindowSizeState = { width: 242, height: 240 };
 const DEFAULT_ONLINE_PLAYERS_VIEW_MODE: OnlinePlayersViewMode = "accounts";
 const DEFAULT_ONLINE_PLAYERS_FILTERS_VISIBLE = true;
+const VALID_ONLINE_PLAYERS_PROFESSIONS = ["all", "p", "w", "h", "m", "b", "t"];
 
 const sanitizeMaxContentHeight = (height: number) => {
   if (!Number.isFinite(height)) {
@@ -142,6 +149,37 @@ const inferLegacyDefinedPosition = (
   }
 
   return typeof position === "object" && position !== null;
+};
+
+const isOnlinePlayersFiltersValue = (
+  filters: unknown,
+): filters is OnlinePlayersFiltersValue => {
+  if (typeof filters !== "object" || filters === null) {
+    return false;
+  }
+
+  const candidate = filters as Record<string, unknown>;
+
+  return (
+    typeof candidate.minLvl === "number" &&
+    typeof candidate.maxLvl === "number" &&
+    typeof candidate.selectedProfession === "string" &&
+    VALID_ONLINE_PLAYERS_PROFESSIONS.includes(candidate.selectedProfession)
+  );
+};
+
+const sanitizeOnlinePlayersFiltersByGuildId = (
+  filtersByGuildId: unknown,
+): Record<string, OnlinePlayersFiltersValue | undefined> => {
+  if (typeof filtersByGuildId !== "object" || filtersByGuildId === null) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(filtersByGuildId).filter(([, filters]) =>
+      isOnlinePlayersFiltersValue(filters),
+    ),
+  );
 };
 
 export const migrateWindowsState = (
@@ -228,6 +266,7 @@ export const migrateWindowsState = (
     | undefined;
   const onlinePlayersViewMode = onlinePlayersState?.viewMode;
   const onlinePlayersFiltersVisible = onlinePlayersState?.filtersVisible;
+  const onlinePlayersFiltersByGuildId = onlinePlayersState?.filtersByGuildId;
 
   if (onlinePlayers && typeof onlinePlayers === "object") {
     state["online-players"] = {
@@ -243,6 +282,9 @@ export const migrateWindowsState = (
           typeof onlinePlayersFiltersVisible === "boolean"
             ? onlinePlayersFiltersVisible
             : DEFAULT_ONLINE_PLAYERS_FILTERS_VISIBLE,
+        filtersByGuildId: sanitizeOnlinePlayersFiltersByGuildId(
+          onlinePlayersFiltersByGuildId,
+        ),
       },
     };
   }
@@ -312,6 +354,7 @@ export const useWindowsStore = create<WindowsState>()(
         state: {
           viewMode: DEFAULT_ONLINE_PLAYERS_VIEW_MODE,
           filtersVisible: DEFAULT_ONLINE_PLAYERS_FILTERS_VISIBLE,
+          filtersByGuildId: {},
         },
       },
       "add-timer": {
@@ -487,6 +530,19 @@ export const useWindowsStore = create<WindowsState>()(
             },
           },
         })),
+      setOnlinePlayersFilters: (guildId, filters) =>
+        set((state) => ({
+          "online-players": {
+            ...state["online-players"],
+            state: {
+              ...state["online-players"].state,
+              filtersByGuildId: {
+                ...state["online-players"].state.filtersByGuildId,
+                [guildId]: filters,
+              },
+            },
+          },
+        })),
       toggleOnlinePlayersFiltersVisible: () =>
         set((state) => ({
           "online-players": {
@@ -541,7 +597,7 @@ export const useWindowsStore = create<WindowsState>()(
         "create-party-gathering": state["create-party-gathering"],
       }),
       storage: createJSONStorage(() => localStorage),
-      version: 7,
+      version: 8,
       migrate: migrateWindowsState,
     },
   ),


### PR DESCRIPTION
## Summary
- Add a dedicated persisted `online-players.store` for Online Players feature state.
- Move Online Players view mode, filter visibility, and per-guild filters out of `windows.store`.
- Read and update the current guild's filter state from `filtersByGuildId` so level/profession filters do not leak between servers.
- Keep `windows.store` focused on window layout/open state and migrate away stale Online Players feature state.

## Why
LOO-6 asks for the Online Players level filter to behave like Timers filters: changing the level range on one server should not apply the same range to every server. Keeping this in a dedicated feature store avoids mixing feature behavior into window layout state.

## Validation
- `pnpm --filter @lootlog/game-client test -- src/store/windows.store.test.ts src/store/online-players.store.test.ts src/features/online-players/components/online-players-list.test.tsx`
- `pnpm --filter @lootlog/game-client build`
- Pre-commit hook also ran `@lootlog/game-client` tests successfully.

Linear: https://linear.app/lootlog/issue/LOO-6/make-online-players-level-filter-server-specific