### PR TITLE
[codex] remove gateway services barrel

### DIFF
--- a/apps/gateway/src/gateway/gateway.module.ts
+++ b/apps/gateway/src/gateway/gateway.module.ts
@@ -7,12 +7,10 @@ import { GatewayQueueHandler } from "src/gateway/gateway-queue.handler";
 import { GuildsModule } from "src/guilds/guilds.module";
 import { RedisModule } from "src/lib/redis/redis.module";
 import { RetryService } from "src/gateway/retry.service";
-import {
-  ConnectionService,
-  PresenceService,
-  SubscriptionService,
-  ActivityService,
-} from "./services";
+import { ActivityService } from "./services/activity.service";
+import { ConnectionService } from "./services/connection.service";
+import { PresenceService } from "./services/presence.service";
+import { SubscriptionService } from "./services/subscription.service";
 import { rabbitmqConfig } from "src/config/rabbitmq.config";
 
 @Module({

--- a/apps/gateway/src/gateway/gateway.ts
+++ b/apps/gateway/src/gateway/gateway.ts
@@ -19,11 +19,9 @@ import type {
   Socket,
   PlayerPresence,
 } from "src/gateway/types/socket-user.type";
-import {
-  ConnectionService,
-  PresenceService,
-  SubscriptionService,
-} from "./services";
+import { ConnectionService } from "./services/connection.service";
+import { PresenceService } from "./services/presence.service";
+import { SubscriptionService } from "./services/subscription.service";
 
 @WebSocketGateway({
   pingInterval: GatewayConfig.SOCKET_PING_INTERVAL_MS,

--- a/apps/gateway/src/gateway/services/index.ts
+++ b/apps/gateway/src/gateway/services/index.ts
@@ -1,4 +1,0 @@
-export { ConnectionService } from "./connection.service";
-export { PresenceService } from "./presence.service";
-export { SubscriptionService } from "./subscription.service";
-export { ActivityService } from "./activity.service";


### PR DESCRIPTION
## Summary
- Replace gateway service barrel imports with direct service module imports.
- Delete the now-unused `apps/gateway/src/gateway/services/index.ts` re-export-only wrapper.

## Verification
- `pnpm exec oxfmt --check apps/gateway/src/gateway/gateway.module.ts apps/gateway/src/gateway/gateway.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway test`
- `pnpm --filter @lootlog/gateway build`
- Normal `git commit` pre-commit hooks passed.

## Notes
- Initial verification needed `pnpm install` and explicit workspace dependency builds because this worktree did not have `node_modules`; no dependency/config changes were committed.