### PR TITLE
[codex] Extract Meilisearch string filter helper

### DIFF
--- a/apps/search/src/meilisearch/meilisearch.utils.spec.ts
+++ b/apps/search/src/meilisearch/meilisearch.utils.spec.ts
@@ -1,4 +1,7 @@
-import { getMeilisearchErrorCode } from "./meilisearch.utils";
+import {
+  buildMeilisearchStringInFilter,
+  getMeilisearchErrorCode,
+} from "./meilisearch.utils";
 
 describe("getMeilisearchErrorCode", () => {
   it("returns the string code from the error cause", () => {
@@ -15,5 +18,19 @@ describe("getMeilisearchErrorCode", () => {
     expect(getMeilisearchErrorCode(new Error("boom"))).toBeNull();
     expect(getMeilisearchErrorCode({ cause: { code: 404 } })).toBeNull();
     expect(getMeilisearchErrorCode(null)).toBeNull();
+  });
+});
+
+describe("buildMeilisearchStringInFilter", () => {
+  it("formats string values for a Meilisearch IN filter", () => {
+    expect(buildMeilisearchStringInFilter("name", ["Hero", "Villain"])).toBe(
+      'name IN ["Hero", "Villain"]',
+    );
+  });
+
+  it("quotes values using JSON string escaping", () => {
+    expect(buildMeilisearchStringInFilter("name", ['Hero "The One"'])).toBe(
+      'name IN ["Hero \\"The One\\""]',
+    );
   });
 });

--- a/apps/search/src/meilisearch/meilisearch.utils.ts
+++ b/apps/search/src/meilisearch/meilisearch.utils.ts
@@ -9,3 +9,12 @@ export function getMeilisearchErrorCode(error: unknown): string | null {
 
   return typeof code === "string" ? code : null;
 }
+
+export function buildMeilisearchStringInFilter(
+  fieldName: string,
+  values: string[],
+): string {
+  const formattedValues = values.map((value) => JSON.stringify(value));
+
+  return `${fieldName} IN [${formattedValues.join(", ")}]`;
+}

--- a/apps/search/src/npcs/npcs.service.ts
+++ b/apps/search/src/npcs/npcs.service.ts
@@ -2,9 +2,10 @@ import { NpcTypeEnum, getNpcTypeByWt } from "@lootlog/types";
 import { Inject, Injectable } from "@nestjs/common";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import type { Logger } from "winston";
-import { Meilisearch, type SearchParams } from "meilisearch";
+import type { Meilisearch, SearchParams } from "meilisearch";
 import type { z } from "zod";
 import { MEILISEARCH_CLIENT } from "src/meilisearch/meilisearch.constants";
+import { buildMeilisearchStringInFilter } from "src/meilisearch/meilisearch.utils";
 import type { GetNpcsDto } from "./dto/get-npcs.dto";
 import { NPCS_INDEX } from "./constants/meilisearch";
 import type { IndexNpcsDto } from "./dto/index-npcs.dto";
@@ -27,9 +28,7 @@ export class NpcsService {
     const filters: string[] = [];
 
     if (hasMultipleSearchTerms) {
-      filters.push(
-        `name IN [${search.map((name) => JSON.stringify(name)).join(", ")}]`,
-      );
+      filters.push(buildMeilisearchStringInFilter("name", search));
     }
 
     if (ids && ids.length > 0) {
@@ -103,7 +102,6 @@ export class NpcsService {
       return await index.addDocuments(npcsWithUid, { primaryKey: "uid" });
     } catch (error) {
       this.logger.error("Error indexing npcs", { error });
-      return;
     }
   }
 }

--- a/apps/search/src/players/players.service.ts
+++ b/apps/search/src/players/players.service.ts
@@ -1,9 +1,10 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import type { Logger } from "winston";
-import { Meilisearch, type SearchParams } from "meilisearch";
+import type { Meilisearch, SearchParams } from "meilisearch";
 import type { z } from "zod";
 import { MEILISEARCH_CLIENT } from "src/meilisearch/meilisearch.constants";
+import { buildMeilisearchStringInFilter } from "src/meilisearch/meilisearch.utils";
 import type { GetPlayersDto } from "./dto/get-players.dto";
 import { PLAYERS_INDEX } from "./constants/meilisearch";
 import type { IndexPlayersDto } from "./dto/index-players.dto";
@@ -26,9 +27,7 @@ export class PlayersService {
     const filters: string[] = [];
 
     if (hasMultipleSearchTerms) {
-      filters.push(
-        `name IN [${search.map((name) => JSON.stringify(name)).join(", ")}]`,
-      );
+      filters.push(buildMeilisearchStringInFilter("name", search));
     }
 
     if (world) {
@@ -84,7 +83,6 @@ export class PlayersService {
       return await index.addDocuments(playersWithUid, { primaryKey: "uid" });
     } catch (error) {
       this.logger.error("Error indexing players", { error });
-      return;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extract shared Meilisearch string `IN` filter formatting into `buildMeilisearchStringInFilter`.
- Reuse it from player and NPC exact-name searches.
- Clean touched services by using type-only Meilisearch imports and removing redundant catch returns.

## Verification
- `pnpm --filter @lootlog/search test`
- `pnpm exec oxfmt --check apps/search/src/meilisearch/meilisearch.utils.ts apps/search/src/meilisearch/meilisearch.utils.spec.ts apps/search/src/players/players.service.ts apps/search/src/npcs/npcs.service.ts`
- `pnpm exec oxlint apps/search/src/meilisearch/meilisearch.utils.ts apps/search/src/meilisearch/meilisearch.utils.spec.ts apps/search/src/players/players.service.ts apps/search/src/npcs/npcs.service.ts`
- `pnpm turbo run build --filter=@lootlog/search`
- pre-commit hook passed during commit

Note: initial `pnpm install` exited with the ignored-build-scripts guard after installing dependencies; no workspace config changes were kept.