### PR TITLE
[codex] Remove timer color name wrapper

### DIFF
--- a/apps/game-client/src/features/timers/components/timer-color-picker.tsx
+++ b/apps/game-client/src/features/timers/components/timer-color-picker.tsx
@@ -6,7 +6,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { FC } from "react";
 import { TIMERS_COLORS } from "../constants/timer-colors";
-import { getDefaultColorName } from "../constants/color-names";
+import { getDefaultColorName } from "../utils/get-default-color-name";
 
 type CustomColor = {
   id: string;

--- a/apps/game-client/src/features/timers/constants/color-names.ts
+++ b/apps/game-client/src/features/timers/constants/color-names.ts
@@ -1,1 +1,0 @@
-export { getDefaultColorName } from "@/features/timers/utils/get-default-color-name";

--- a/apps/game-client/src/features/timers/utils/color-statistics.ts
+++ b/apps/game-client/src/features/timers/utils/color-statistics.ts
@@ -1,5 +1,5 @@
 import { TIMERS_COLORS } from "@/features/timers/constants/timer-colors";
-import { getDefaultColorName } from "@/features/timers/constants/color-names";
+import { getDefaultColorName } from "@/features/timers/utils/get-default-color-name";
 import type { TimerWithTimeLeft } from "./timers-utils";
 
 type ColorStat = {


### PR DESCRIPTION
## Summary
- Removed the re-export-only `color-names.ts` wrapper in game-client timer color constants.
- Updated the two consumers to import `getDefaultColorName` directly from the real utility module.

## Verification
- `pnpm --filter @lootlog/game-client test`
- `pnpm --filter @lootlog/game-client build`
- `pnpm format:check`
- `pnpm turbo run lint format:check test '--filter=[HEAD]'`
- `pnpm turbo run build '--filter=[HEAD]'`
- Pre-commit hook passed during `git commit`.

Notes: initial focused checks failed before workspace dependency packages had generated `dist` output; building `@lootlog/types`, `@lootlog/margonem`, and `@lootlog/socket-parser` resolved that local setup issue. Game-client build still emits existing Vite warnings about `.all:b` and unresolved cursor assets, but completes successfully.
