### PR TITLE
[codex] Extract activity details mapper

### DIFF
--- a/apps/activity/src/activities/activities.service.ts
+++ b/apps/activity/src/activities/activities.service.ts
@@ -3,16 +3,7 @@ import { Injectable, Logger, NotFoundException } from "@nestjs/common";
 import { ActivityType, Prisma } from "src/generated/prisma/client";
 import { PrismaService } from "src/shared/db/prisma.service";
 import { CreateActivityDto } from "./dto/create-activity.dto";
-
-function mapActivityDetails(
-  details: unknown,
-): Record<string, unknown> | undefined {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
-    return undefined;
-  }
-
-  return details as Record<string, unknown>;
-}
+import { mapActivityDetails } from "./utils/map-activity-details";
 
 @Injectable()
 export class ActivitiesService {

--- a/apps/activity/src/activities/services/activities-query.service.ts
+++ b/apps/activity/src/activities/services/activities-query.service.ts
@@ -2,16 +2,7 @@ import { Injectable, NotFoundException } from "@nestjs/common";
 import type { Prisma } from "src/generated/prisma/client";
 import { PrismaService } from "src/shared/db/prisma.service";
 import type { QueryActivitiesDto } from "../dto/query-activities.dto";
-
-function mapActivityDetails(
-  details: unknown,
-): Record<string, unknown> | undefined {
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
-    return undefined;
-  }
-
-  return details as Record<string, unknown>;
-}
+import { mapActivityDetails } from "../utils/map-activity-details";
 
 @Injectable()
 export class ActivitiesQueryService {

--- a/apps/activity/src/activities/utils/map-activity-details.ts
+++ b/apps/activity/src/activities/utils/map-activity-details.ts
@@ -1,0 +1,9 @@
+export function mapActivityDetails(
+  details: unknown,
+): Record<string, unknown> | undefined {
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return undefined;
+  }
+
+  return details as Record<string, unknown>;
+}


### PR DESCRIPTION
## Summary
- extracted the duplicated activity details mapper into a shared activity utility
- updated create/query services to use the shared mapper without changing response behavior

## Verification
- pnpm --filter @lootlog/activity lint
- pnpm exec oxfmt --check apps/activity/src/activities/activities.service.ts apps/activity/src/activities/services/activities-query.service.ts apps/activity/src/activities/utils/map-activity-details.ts
- pnpm --filter @lootlog/nest-shared... build
- pnpm --filter @lootlog/activity test
- pnpm --filter @lootlog/activity build
- pre-commit hook: lint changed packages and test changed packages

Note: initial test run failed before suites executed because fresh workspace dependencies lacked built dist outputs for @lootlog/types and @lootlog/nest-shared; building @lootlog/nest-shared... resolved it.