### PR TITLE
feat: add loot item profession filters

### DIFF
--- a/apps/api/src/loots/dto/fetch-loots-params.dto.ts
+++ b/apps/api/src/loots/dto/fetch-loots-params.dto.ts
@@ -13,6 +13,7 @@ const FetchLootsParamsSchema = z.object({
   npcs: commaSeparatedArray(z.string()).optional(),
   players: commaSeparatedArray(z.string()).optional(),
   rarities: commaSeparatedArray(z.string()).optional(),
+  professions: commaSeparatedArray(z.string()).optional(),
   npcTypes: commaSeparatedArray(z.string()).optional(),
   world: z.string().optional(),
   npcLevelMin: optionalFromQuery(intFromString({ min: 0, max: 500 })),

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -43,6 +43,7 @@ describe("LootsService", () => {
       update: Mock;
       findFirst: Mock;
       findMany: Mock;
+      count: Mock;
     };
     lootSubmission: {
       createMany: Mock;
@@ -156,6 +157,7 @@ describe("LootsService", () => {
         update: mockFn(),
         findFirst: mockFn(),
         findMany: mockFn(),
+        count: mockFn(),
       },
       lootSubmission: {
         createMany: mockFn(),
@@ -1379,6 +1381,121 @@ describe("LootsService", () => {
                 createdAt: {
                   gte: new Date("2024-01-01T00:00:00.000Z"),
                   lte: new Date("2024-01-31T23:59:59.999Z"),
+                },
+              },
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("should apply item profession filters to the Prisma query", async () => {
+      prismaService.loot.findMany.mockResolvedValue([]);
+
+      await service.fetchLootsByGuildId(mockGuild, [], [], {
+        ...params,
+        professions: [Profession.HUNTER, Profession.TRACKER, "INVALID"],
+      });
+
+      expect(prismaService.loot.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              {
+                lootItems: {
+                  some: {
+                    itemSnapshot: {
+                      OR: [
+                        {
+                          statRaw: {
+                            not: {
+                              contains: "reqp=",
+                            },
+                          },
+                        },
+                        {
+                          statsSnapshot: {
+                            path: ["reqp"],
+                            string_contains: "h",
+                          },
+                        },
+                        {
+                          statsSnapshot: {
+                            path: ["reqp"],
+                            string_contains: "t",
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("should ignore invalid item profession filters", async () => {
+      prismaService.loot.findMany.mockResolvedValue([]);
+
+      await service.fetchLootsByGuildId(mockGuild, [], [], {
+        ...params,
+        professions: ["INVALID"],
+      });
+
+      expect(prismaService.loot.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({
+            AND: expect.arrayContaining([
+              expect.objectContaining({
+                lootItems: expect.objectContaining({
+                  some: expect.objectContaining({
+                    itemSnapshot: expect.objectContaining({
+                      OR: expect.any(Array),
+                    }),
+                  }),
+                }),
+              }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    it("should use item profession filters when counting loots", async () => {
+      prismaService.loot.count.mockResolvedValue(0);
+
+      await service.countLootsByGuildId(mockGuild, [], [], {
+        ...params,
+        professions: [Profession.HUNTER],
+      });
+
+      expect(prismaService.loot.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              {
+                lootItems: {
+                  some: {
+                    itemSnapshot: {
+                      OR: [
+                        {
+                          statRaw: {
+                            not: {
+                              contains: "reqp=",
+                            },
+                          },
+                        },
+                        {
+                          statsSnapshot: {
+                            path: ["reqp"],
+                            string_contains: "h",
+                          },
+                        },
+                      ],
+                    },
+                  },
                 },
               },
             ]),

--- a/apps/api/src/loots/services/loot-query.service.ts
+++ b/apps/api/src/loots/services/loot-query.service.ts
@@ -16,7 +16,10 @@ import type { LootQueryResult } from "src/loots/dto/loot-query-result.dto";
 import { LootShareResponseSchema } from "src/shared/dto/loot-response.dto";
 import { DEFAULT_PAGE_LIMIT } from "../config/pagination";
 import { isAdministrativeUser } from "src/shared/permissions/is-administrative-user";
-import { getProfByShortname } from "src/shared/utils/get-prof-by-shortname";
+import {
+  getProfByShortname,
+  getShortnameByProf,
+} from "src/shared/utils/get-prof-by-shortname";
 
 type LootItemWithSnapshot = Prisma.LootItemGetPayload<{
   include: { itemSnapshot: true };
@@ -29,15 +32,6 @@ type LootPlayerWithSnapshot = Prisma.LootPlayerGetPayload<{
 type LootNpcWithSnapshot = Prisma.LootNpcGetPayload<{
   include: { npcSnapshot: true };
 }>;
-
-const PROFESSION_SHORTNAMES: Record<Profession, string> = {
-  [Profession.BLADE_DANCER]: "b",
-  [Profession.HUNTER]: "h",
-  [Profession.MAGE]: "m",
-  [Profession.PALADIN]: "p",
-  [Profession.TRACKER]: "t",
-  [Profession.WARRIOR]: "w",
-};
 
 @Injectable()
 export class LootQueryService {
@@ -622,7 +616,7 @@ export class LootQueryService {
               ...allowedProfessions.map((profession) => ({
                 statsSnapshot: {
                   path: ["reqp"],
-                  string_contains: PROFESSION_SHORTNAMES[profession],
+                  string_contains: getShortnameByProf(profession),
                 },
               })),
             ],

--- a/apps/api/src/loots/services/loot-query.service.ts
+++ b/apps/api/src/loots/services/loot-query.service.ts
@@ -30,6 +30,15 @@ type LootNpcWithSnapshot = Prisma.LootNpcGetPayload<{
   include: { npcSnapshot: true };
 }>;
 
+const PROFESSION_SHORTNAMES: Record<Profession, string> = {
+  [Profession.BLADE_DANCER]: "b",
+  [Profession.HUNTER]: "h",
+  [Profession.MAGE]: "m",
+  [Profession.PALADIN]: "p",
+  [Profession.TRACKER]: "t",
+  [Profession.WARRIOR]: "w",
+};
+
 @Injectable()
 export class LootQueryService {
   constructor(private readonly prisma: PrismaService) {}
@@ -45,6 +54,7 @@ export class LootQueryService {
       npcs = [],
       players = [],
       rarities = [],
+      professions = [],
       npcLevelMin,
       npcLevelMax,
       itemLevelMin,
@@ -64,6 +74,7 @@ export class LootQueryService {
       npcs,
       players,
       rarities,
+      professions,
       npcLevelMin,
       npcLevelMax,
       itemLevelMin,
@@ -154,6 +165,7 @@ export class LootQueryService {
       npcs = [],
       players = [],
       rarities = [],
+      professions = [],
       npcLevelMin,
       npcLevelMax,
       itemLevelMin,
@@ -173,6 +185,7 @@ export class LootQueryService {
       npcs,
       players,
       rarities,
+      professions,
       npcLevelMin,
       npcLevelMax,
       itemLevelMin,
@@ -281,6 +294,7 @@ export class LootQueryService {
       npcs = [],
       players = [],
       rarities = [],
+      professions = [],
       npcLevelMin,
       npcLevelMax,
       itemLevelMin,
@@ -299,6 +313,7 @@ export class LootQueryService {
       npcs?: string[];
       players?: string[];
       rarities?: string[];
+      professions?: string[];
       npcLevelMin?: number;
       npcLevelMax?: number;
       itemLevelMin?: number;
@@ -327,6 +342,8 @@ export class LootQueryService {
     const npcsCondition = this.buildNpcsCondition(npcs);
     const npcTypesCondition = this.buildNpcTypesCondition(npcTypes);
     const raritiesCondition = this.buildRaritiesCondition(rarities);
+    const itemProfessionsCondition =
+      this.buildItemProfessionsCondition(professions);
     const npcLevelsCondition = this.buildNpcLevelsCondition(
       npcLevelMin,
       npcLevelMax,
@@ -366,6 +383,7 @@ export class LootQueryService {
       npcsCondition,
       npcTypesCondition,
       raritiesCondition,
+      itemProfessionsCondition,
       npcLevelsCondition,
       itemLevelsCondition,
       playerLevelsCondition,
@@ -575,6 +593,39 @@ export class LootQueryService {
             rarity: {
               in: allowedRarities,
             },
+          },
+        },
+      },
+    };
+  }
+
+  private buildItemProfessionsCondition(
+    professions: string[],
+  ): Prisma.LootWhereInput | null {
+    const allowedProfessions = this.filterEnumValues(professions, Profession);
+    if (allowedProfessions.length === 0) {
+      return null;
+    }
+
+    return {
+      lootItems: {
+        some: {
+          itemSnapshot: {
+            OR: [
+              {
+                statRaw: {
+                  not: {
+                    contains: "reqp=",
+                  },
+                },
+              },
+              ...allowedProfessions.map((profession) => ({
+                statsSnapshot: {
+                  path: ["reqp"],
+                  string_contains: PROFESSION_SHORTNAMES[profession],
+                },
+              })),
+            ],
           },
         },
       },

--- a/apps/api/src/shared/utils/get-prof-by-shortname.ts
+++ b/apps/api/src/shared/utils/get-prof-by-shortname.ts
@@ -1,6 +1,6 @@
 import { Profession } from "src/generated/prisma/client";
 
-const PROFESSIONS_SHORTNAMES = {
+const PROFESSION_BY_SHORTNAME = {
   b: Profession.BLADE_DANCER,
   h: Profession.HUNTER,
   m: Profession.MAGE,
@@ -9,6 +9,17 @@ const PROFESSIONS_SHORTNAMES = {
   w: Profession.WARRIOR,
 };
 
+const SHORTNAME_BY_PROFESSION = Object.fromEntries(
+  Object.entries(PROFESSION_BY_SHORTNAME).map(([shortname, profession]) => [
+    profession,
+    shortname,
+  ]),
+) as Record<Profession, string>;
+
 export const getProfByShortname = (shortname: string): Profession => {
-  return PROFESSIONS_SHORTNAMES[shortname];
+  return PROFESSION_BY_SHORTNAME[shortname];
+};
+
+export const getShortnameByProf = (profession: Profession): string => {
+  return SHORTNAME_BY_PROFESSION[profession];
 };

--- a/apps/web/src/features/guild/loots-list/components/loots-filters/loots-filters-sidebar.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-filters/loots-filters-sidebar.tsx
@@ -63,6 +63,7 @@ type SavedFilter = {
     players?: string[];
     npcs?: string[];
     rarities?: string[];
+    professions?: string[];
     npcTypes?: string[];
     npcLevelMin?: string;
     npcLevelMax?: string;
@@ -83,8 +84,12 @@ export const LootsFiltersSidebar: FC<LootsFiltersSidebarProps> = ({
   className,
 }) => {
   const { t } = useTranslation();
-  const { defaultQuickFilters, npcTypeOptions, rarityOptions } =
-    useLootFilterOptions();
+  const {
+    defaultQuickFilters,
+    npcTypeOptions,
+    professionOptions,
+    rarityOptions,
+  } = useLootFilterOptions();
   const { world } = useGuildContext();
   const guildId = useGuildId();
   const { filters, setFilters, hasActiveFilters, clearFilters } =
@@ -219,6 +224,10 @@ export const LootsFiltersSidebar: FC<LootsFiltersSidebarProps> = ({
         npcLevelMax: mergedFilters.npcLevelMax || null,
         rarities:
           mergedFilters.rarities.length > 0 ? mergedFilters.rarities : null,
+        professions:
+          mergedFilters.professions.length > 0
+            ? mergedFilters.professions
+            : null,
         itemLevelMin: mergedFilters.itemLevelMin || null,
         itemLevelMax: mergedFilters.itemLevelMax || null,
         hid: mergedFilters.hid || null,
@@ -237,6 +246,8 @@ export const LootsFiltersSidebar: FC<LootsFiltersSidebarProps> = ({
       players: filters.players.length > 0 ? filters.players : undefined,
       npcs: filters.npcs.length > 0 ? filters.npcs : undefined,
       rarities: filters.rarities.length > 0 ? filters.rarities : undefined,
+      professions:
+        filters.professions.length > 0 ? filters.professions : undefined,
       npcTypes: filters.npcTypes.length > 0 ? filters.npcTypes : undefined,
       npcLevelMin: filters.npcLevelMin || undefined,
       npcLevelMax: filters.npcLevelMax || undefined,
@@ -538,6 +549,45 @@ export const LootsFiltersSidebar: FC<LootsFiltersSidebarProps> = ({
                                 className="text-sm cursor-pointer"
                               >
                                 {rarity.label}
+                              </Label>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+
+                      <div>
+                        <Label className="text-xs text-muted-foreground mb-2 block">
+                          {t("loots.filtersPanel.itemSection.professionsLabel")}
+                        </Label>
+                        <div className="grid grid-cols-2 gap-2">
+                          {professionOptions.map((profession) => (
+                            <div
+                              key={profession.value}
+                              className="flex items-center gap-2"
+                            >
+                              <Checkbox
+                                id={`itemProfession-${profession.value}`}
+                                checked={filters.professions?.includes(
+                                  profession.value,
+                                )}
+                                onCheckedChange={(checked) => {
+                                  const currentProfessions =
+                                    filters.professions ?? [];
+                                  const newProfessions = checked
+                                    ? [...currentProfessions, profession.value]
+                                    : currentProfessions.filter(
+                                        (prof) => prof !== profession.value,
+                                      );
+                                  updateFilters({
+                                    professions: newProfessions,
+                                  });
+                                }}
+                              />
+                              <Label
+                                htmlFor={`itemProfession-${profession.value}`}
+                                className="text-sm cursor-pointer"
+                              >
+                                {profession.label}
                               </Label>
                             </div>
                           ))}

--- a/apps/web/src/features/guild/loots-list/components/loots-filters/use-loot-filter-options.ts
+++ b/apps/web/src/features/guild/loots-list/components/loots-filters/use-loot-filter-options.ts
@@ -1,6 +1,18 @@
-import { NpcType } from "@/lib/api/generated/main/model";
+import {
+  LootItemResponseDtoProfItem,
+  NpcType,
+} from "@/lib/api/generated/main/model";
 import { ItemRarity } from "@/lib/loots/loot-types";
 import { useTranslation } from "react-i18next";
+
+const PROFESSION_TRANSLATION_KEYS = {
+  [LootItemResponseDtoProfItem.BLADE_DANCER]: "b",
+  [LootItemResponseDtoProfItem.HUNTER]: "h",
+  [LootItemResponseDtoProfItem.MAGE]: "m",
+  [LootItemResponseDtoProfItem.PALADIN]: "p",
+  [LootItemResponseDtoProfItem.TRACKER]: "t",
+  [LootItemResponseDtoProfItem.WARRIOR]: "w",
+};
 
 type LootQuickFilter = {
   id: string;
@@ -32,6 +44,18 @@ export function useLootFilterOptions() {
     { value: NpcType.ELITE2, label: t("npcType.ELITE2") },
     { value: NpcType.ELITE, label: t("npcType.ELITE") },
   ];
+
+  const professionOptions = [
+    LootItemResponseDtoProfItem.WARRIOR,
+    LootItemResponseDtoProfItem.PALADIN,
+    LootItemResponseDtoProfItem.HUNTER,
+    LootItemResponseDtoProfItem.MAGE,
+    LootItemResponseDtoProfItem.BLADE_DANCER,
+    LootItemResponseDtoProfItem.TRACKER,
+  ].map((profession) => ({
+    value: profession,
+    label: t(`professions.${PROFESSION_TRANSLATION_KEYS[profession]}`),
+  }));
 
   const defaultQuickFilters: LootQuickFilter[] = [
     {
@@ -81,6 +105,7 @@ export function useLootFilterOptions() {
       npcTypesPlaceholder: t("loots.filtersPanel.npcTypesPlaceholder"),
     },
     npcTypeOptions,
+    professionOptions,
     rarityOptions,
   };
 }

--- a/apps/web/src/features/guild/loots-list/components/loots-list/loots-list.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-list/loots-list.tsx
@@ -131,6 +131,12 @@ const lootMatchesParams = (
   }
 
   if (
+    !loot.items.some((item) => includesAll(params.professions, item.prof ?? []))
+  ) {
+    return false;
+  }
+
+  if (
     !includesAll(
       params.itemNames,
       loot.items.map((item) => item.name),
@@ -312,6 +318,8 @@ export const LootsList: FC = () => {
     npcs: filters.npcs.length > 0 ? filters.npcs : undefined,
     npcTypes: filters.npcTypes.length > 0 ? filters.npcTypes : undefined,
     rarities: filters.rarities.length > 0 ? filters.rarities : undefined,
+    professions:
+      filters.professions.length > 0 ? filters.professions : undefined,
     players: filters.players.length > 0 ? filters.players : undefined,
     npcLevelMin: parseOptionalNumber(filters.npcLevelMin),
     npcLevelMax: parseOptionalNumber(filters.npcLevelMax),

--- a/apps/web/src/hooks/use-loots-filters.ts
+++ b/apps/web/src/hooks/use-loots-filters.ts
@@ -8,6 +8,7 @@ export const useLootsFilters = createQueryFilters({
   npcLevelMin: parseAsString.withDefault(""),
   npcLevelMax: parseAsString.withDefault(""),
   rarities: parseAsArrayOf(parseAsString).withDefault([]),
+  professions: parseAsArrayOf(parseAsString).withDefault([]),
   itemLevelMin: parseAsString.withDefault(""),
   itemLevelMax: parseAsString.withDefault(""),
   hid: parseAsString.withDefault(""),

--- a/apps/web/src/i18n/translations/loots.json
+++ b/apps/web/src/i18n/translations/loots.json
@@ -67,6 +67,7 @@
     "itemSection": {
       "title": "Filtry przedmiotów",
       "raritiesLabel": "Rzadkość",
+      "professionsLabel": "Profesje",
       "itemsLabel": "Przedmioty",
       "itemsPlaceholder": "Wybierz przedmioty",
       "filteredItemLabel": "Filtrowany przedmiot (ID)"

--- a/apps/web/src/lib/api/generated/main/model/loots-controller-count-loots-by-guild-id-params.ts
+++ b/apps/web/src/lib/api/generated/main/model/loots-controller-count-loots-by-guild-id-params.ts
@@ -20,6 +20,7 @@ cursor?: number;
 npcs?: string[];
 players?: string[];
 rarities?: string[];
+professions?: string[];
 npcTypes?: string[];
 world?: string;
 /**

--- a/apps/web/src/lib/api/generated/main/model/loots-controller-fetch-loots-by-guild-id-params.ts
+++ b/apps/web/src/lib/api/generated/main/model/loots-controller-fetch-loots-by-guild-id-params.ts
@@ -20,6 +20,7 @@ cursor?: number;
 npcs?: string[];
 players?: string[];
 rarities?: string[];
+professions?: string[];
 npcTypes?: string[];
 world?: string;
 /**


### PR DESCRIPTION
## Summary
- Adds `professions` query param for loot list/count.
- Adds profession checkboxes to loot item filters.
- Persists selected professions in URL and saved filters.
- Keeps backend filtering without schema changes.
- Includes focused API coverage for profession filter query behavior.

## Verification
- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/loots/loots.service.spec.ts` passed.
- `pnpm --filter @lootlog/web lint` passed.
- `pnpm --filter @lootlog/web build` passed.
- `pnpm --filter @lootlog/api build` passed.
- `pnpm --filter @lootlog/api lint` had 0 errors with existing unrelated warnings.
- Pre-commit checks passed, including the full `@lootlog/api` test suite: 76 files, 829 tests.

## Notes
- `pnpm api:client:generate` was attempted but blocked by local OpenAPI env propagation; generated loots param types were updated manually.
- No schema migration is included.
