### PR TITLE
[codex] Normalize gateway auth headers

### DIFF
--- a/apps/gateway/src/gateway/services/connection.service.spec.ts
+++ b/apps/gateway/src/gateway/services/connection.service.spec.ts
@@ -36,6 +36,19 @@ describe("ConnectionService", () => {
     });
   });
 
+  it("normalizes repeated auth headers to the first value", () => {
+    const metadata = service.getConnectionMetadata({
+      headers: {
+        "x-auth-discord-id": ["discord-1", "discord-2"],
+        "x-auth-user-id": ["user-1", "user-2"],
+        origin: "https://alpha.margonem.pl",
+      },
+    } as never);
+
+    expect(metadata.discordId).toBe("discord-1");
+    expect(metadata.userId).toBe("user-1");
+  });
+
   it("ignores dev permission override auth when the gateway flag is disabled", () => {
     const metadata = service.getConnectionMetadata(
       {

--- a/apps/gateway/src/gateway/services/connection.service.ts
+++ b/apps/gateway/src/gateway/services/connection.service.ts
@@ -20,8 +20,8 @@ export class ConnectionService {
     request: Socket["request"],
     auth?: unknown,
   ): ConnectionMetadata {
-    const discordId = (request.headers["x-auth-discord-id"] as string) || null;
-    const userId = (request.headers["x-auth-user-id"] as string) || null;
+    const discordId = this.getHeaderValue(request.headers["x-auth-discord-id"]);
+    const userId = this.getHeaderValue(request.headers["x-auth-user-id"]);
     const platform = this.determineUserPlatform(request.headers.origin);
     const authDevPermissionOverride =
       this.isDevPermissionOverrideEnabled() &&
@@ -89,5 +89,15 @@ export class ConnectionService {
     }
 
     return env.DEV_PERMISSION_OVERRIDE_ENABLED === true;
+  }
+
+  private getHeaderValue(
+    headerValue: string | string[] | undefined,
+  ): string | null {
+    if (Array.isArray(headerValue)) {
+      return headerValue[0] ?? null;
+    }
+
+    return headerValue ?? null;
   }
 }


### PR DESCRIPTION
## Summary
- Added a small `ConnectionService` helper for auth header normalization.
- Replaced duplicated header casts/fallbacks with typed `string | string[] | undefined` handling.
- Covered repeated auth headers by asserting the first value is used.

## Verification
- `corepack pnpm --dir apps/gateway exec vitest run --config ./vitest.config.ts src/gateway/services/connection.service.spec.ts`
- `corepack pnpm --filter @lootlog/gateway lint`
- `corepack pnpm --filter @lootlog/gateway test`
- `corepack pnpm --filter @lootlog/gateway build`
- `corepack pnpm format:check apps/gateway/src/gateway/services/connection.service.ts apps/gateway/src/gateway/services/connection.service.spec.ts`
- pre-commit hook: lint-staged, changed-package lint, format check, changed-package tests

Note: the first build attempt failed because workspace dependency packages had not been built in this fresh worktree. Built `@lootlog/types`, `@lootlog/nest-shared`, `@lootlog/instrumentation`, and `@lootlog/socket-parser`, then reran the gateway build successfully.