### PR TITLE
[codex] fix cancelled route loader handling

### DIFF
--- a/apps/web/src/lib/router/route-errors.spec.ts
+++ b/apps/web/src/lib/router/route-errors.spec.ts
@@ -4,26 +4,43 @@ import { withRouteLoaderCancellation } from "./route-errors";
 
 describe("withRouteLoaderCancellation", () => {
   it("returns the loader result when the loader succeeds", async () => {
+    const abortController = new AbortController();
+
     await expect(
-      withRouteLoaderCancellation(async () => {
+      withRouteLoaderCancellation(abortController, async () => {
         return "ok";
       }),
     ).resolves.toBe("ok");
   });
 
-  it("returns undefined for cancelled route loaders", async () => {
+  it("throws AbortError for cancelled route loaders when the route is aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
     await expect(
-      withRouteLoaderCancellation(async () => {
+      withRouteLoaderCancellation(abortController, async () => {
         throw new CancelledError();
       }),
-    ).resolves.toBeUndefined();
+    ).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("rethrows cancelled route loader errors when the route is not aborted", async () => {
+    const abortController = new AbortController();
+    const error = new CancelledError();
+
+    await expect(
+      withRouteLoaderCancellation(abortController, async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
   });
 
   it("rethrows non-cancelled errors", async () => {
+    const abortController = new AbortController();
     const error = new Error("boom");
 
     await expect(
-      withRouteLoaderCancellation(async () => {
+      withRouteLoaderCancellation(abortController, async () => {
         throw error;
       }),
     ).rejects.toBe(error);

--- a/apps/web/src/lib/router/route-errors.ts
+++ b/apps/web/src/lib/router/route-errors.ts
@@ -25,14 +25,25 @@ const isRouteLoaderCancelledError = (error: unknown) => {
   return isCancelledError(error);
 };
 
+const createRouteLoaderAbortError = () => {
+  const error = new Error("Route loader was cancelled");
+  error.name = "AbortError";
+  return error;
+};
+
 export const withRouteLoaderCancellation = async <T>(
+  abortController: AbortController,
   loader: () => Promise<T>,
 ) => {
   try {
     return await loader();
   } catch (error) {
     if (isRouteLoaderCancelledError(error)) {
-      return undefined;
+      if (abortController.signal.aborted) {
+        throw createRouteLoaderAbortError();
+      }
+
+      throw error;
     }
 
     throw error;

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -41,8 +41,8 @@ export const Route = createFileRoute("/_authenticated")({
       session,
     };
   },
-  loader: ({ context }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       await Promise.all([
         context.queryClient.ensureQueryData(authScopesQueryOptions()),
         prefetchUsersControllerGetCurrentUserAccessibleGuildsQuery(

--- a/apps/web/src/routes/_authenticated/$guildId.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId.tsx
@@ -26,8 +26,8 @@ export const Route = createFileRoute("/_authenticated/$guildId")({
       guildId: params.guildId,
     };
   },
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       try {
         const guild = await context.queryClient.ensureQueryData(
           getGuildsControllerGetGuildByIdQueryOptions(

--- a/apps/web/src/routes/_authenticated/$guildId/activity-logs.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/activity-logs.tsx
@@ -15,8 +15,8 @@ const getSearchParamValues = (searchParams: URLSearchParams, key: string) => {
 };
 
 export const Route = createFileRoute("/_authenticated/$guildId/activity-logs")({
-  loader: ({ context, location, params, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location, params, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/$guildId/events.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/events.tsx
@@ -7,8 +7,8 @@ import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 export const Route = createFileRoute("/_authenticated/$guildId/events")({
   component: Events,
   pendingComponent: EventsPageSkeleton,
-  loader: ({ context, params, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.tsx
@@ -13,8 +13,8 @@ export const Route = createFileRoute(
   "/_authenticated/$guildId/events_/$eventId_",
 )({
   component: EventRouteLayout,
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       try {
         const [event, rankings] = await Promise.all([
           context.queryClient.ensureQueryData(

--- a/apps/web/src/routes/_authenticated/$guildId/notifications.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/notifications.tsx
@@ -16,8 +16,8 @@ function GuildNotificationsLayout() {
 }
 
 export const Route = createFileRoute("/_authenticated/$guildId/notifications")({
-  loader: ({ context, params, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/$guildId/notifications/$ruleId.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/notifications/$ruleId.tsx
@@ -9,8 +9,8 @@ export const Route = createFileRoute(
 )({
   component: NotificationRuleFormPage,
   pendingComponent: NotificationCreateSkeleton,
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       await context.queryClient.ensureQueryData(
         getRolesControllerGetGuildRolesQueryOptions({
           guildId: params.guildId,

--- a/apps/web/src/routes/_authenticated/$guildId/notifications/create.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/notifications/create.tsx
@@ -9,8 +9,8 @@ export const Route = createFileRoute(
 )({
   component: NotificationRuleFormPage,
   pendingComponent: NotificationCreateSkeleton,
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       await context.queryClient.ensureQueryData(
         getRolesControllerGetGuildRolesQueryOptions({
           guildId: params.guildId,

--- a/apps/web/src/routes/_authenticated/$guildId/reservations.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/reservations.tsx
@@ -8,8 +8,8 @@ import { getMembersControllerGetGuildMemberReferencesQueryOptions } from "@/lib/
 import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 
 export const Route = createFileRoute("/_authenticated/$guildId/reservations")({
-  loader: ({ context, params, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/$guildId/settings.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/settings.tsx
@@ -11,8 +11,8 @@ import {
 } from "@/lib/router/route-errors";
 
 export const Route = createFileRoute("/_authenticated/$guildId/settings")({
-  loader: ({ context, params, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/$guildId/settings/reservations.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/settings/reservations.tsx
@@ -14,8 +14,8 @@ import {
 export const Route = createFileRoute(
   "/_authenticated/$guildId/settings/reservations",
 )({
-  loader: ({ context, params, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/$guildId/stats/members.$memberId.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/stats/members.$memberId.tsx
@@ -15,8 +15,8 @@ import {
 export const Route = createFileRoute(
   "/_authenticated/$guildId/stats/members/$memberId",
 )({
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const memberId = Number.parseInt(params.memberId, 10);
 
       if (Number.isNaN(memberId)) {

--- a/apps/web/src/routes/_authenticated/$guildId/stats/npcs.$npcId.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/stats/npcs.$npcId.tsx
@@ -12,8 +12,8 @@ import {
 export const Route = createFileRoute(
   "/_authenticated/$guildId/stats/npcs/$npcId",
 )({
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const npcId = Number.parseInt(params.npcId, 10);
 
       if (Number.isNaN(npcId)) {

--- a/apps/web/src/routes/_authenticated/@me/battle-panel.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel.tsx
@@ -4,8 +4,8 @@ import { getBattlesControllerGetUserCharactersQueryOptions } from "@/lib/api/gen
 import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 
 export const Route = createFileRoute("/_authenticated/@me/battle-panel")({
-  loader: ({ context, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/battles.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/battles.tsx
@@ -11,8 +11,8 @@ import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 export const Route = createFileRoute(
   "/_authenticated/@me/battle-panel/battles",
 )({
-  loader: ({ context, location }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const search = loadBattlePanelBattlesSearch(location.searchStr);
 
       await Promise.all([

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx
@@ -13,8 +13,8 @@ import {
 export const Route = createFileRoute(
   "/_authenticated/@me/battle-panel/battles_/$battleId",
 )({
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       try {
         await Promise.all([
           context.queryClient.ensureQueryData(

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/index.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/index.tsx
@@ -11,8 +11,8 @@ import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 
 export const Route = createFileRoute("/_authenticated/@me/battle-panel/")({
   validateSearch: battlePanelStatisticsSearchSchema,
-  loader: ({ context, location, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/statistics.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/statistics.tsx
@@ -22,8 +22,8 @@ export const Route = createFileRoute(
   "/_authenticated/@me/battle-panel/statistics",
 )({
   validateSearch: battlePanelStatisticsSearchSchema,
-  loader: ({ context, location }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const search = loadBattlePanelStatisticsSearch(location.searchStr);
       const normalizedCharacterId = normalizeBattlePanelCharacterId(
         search.characterId,

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/statistics_.h2h.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/statistics_.h2h.tsx
@@ -14,8 +14,8 @@ export const Route = createFileRoute(
   "/_authenticated/@me/battle-panel/statistics_/h2h",
 )({
   validateSearch: battlePanelHeadToHeadSearchSchema,
-  loader: ({ context, location }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const search = loadBattlePanelHeadToHeadSearch(location.searchStr);
       const characterId = await ensureBattlePanelCharacterId({
         queryClient: context.queryClient,

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/statistics_.matchmaking-h2h.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/statistics_.matchmaking-h2h.tsx
@@ -14,8 +14,8 @@ export const Route = createFileRoute(
   "/_authenticated/@me/battle-panel/statistics_/matchmaking-h2h",
 )({
   validateSearch: battlePanelHeadToHeadSearchSchema,
-  loader: ({ context, location }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const search = loadBattlePanelHeadToHeadSearch(location.searchStr);
       const characterId = await ensureBattlePanelCharacterId({
         queryClient: context.queryClient,

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/statistics_.player-vs-player.$myId.$opponentId.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/statistics_.player-vs-player.$myId.$opponentId.tsx
@@ -14,8 +14,8 @@ export const Route = createFileRoute(
   "/_authenticated/@me/battle-panel/statistics_/player-vs-player/$myId/$opponentId",
 )({
   validateSearch: battlePanelPlayerVsPlayerSearchSchema,
-  loader: ({ context, location, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const search = loadBattlePanelPlayerVsPlayerSearch(location.searchStr);
       const characterId =
         (await ensureBattlePanelCharacterId({

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/stats.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/stats.tsx
@@ -11,8 +11,8 @@ import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 
 export const Route = createFileRoute("/_authenticated/@me/battle-panel/stats")({
   validateSearch: battlePanelStatisticsSearchSchema,
-  loader: ({ context, location }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, location }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       const search = loadBattlePanelStatisticsSearch(location.searchStr);
 
       await context.queryClient.ensureQueryData(

--- a/apps/web/src/routes/_authenticated/@me/notifications.tsx
+++ b/apps/web/src/routes/_authenticated/@me/notifications.tsx
@@ -11,8 +11,8 @@ import { withRouteLoaderCancellation } from "@/lib/router/route-errors";
 export const Route = createFileRoute("/_authenticated/@me/notifications")({
   component: UserNotifications,
   pendingComponent: UserNotificationsPageSkeleton,
-  loader: ({ context, preload }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, preload }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       if (preload) {
         return null;
       }

--- a/apps/web/src/routes/battles.$id.tsx
+++ b/apps/web/src/routes/battles.$id.tsx
@@ -11,8 +11,8 @@ import {
 } from "@/lib/router/route-errors";
 
 export const Route = createFileRoute("/battles/$id")({
-  loader: ({ context, params }) =>
-    withRouteLoaderCancellation(async () => {
+  loader: ({ abortController, context, params }) =>
+    withRouteLoaderCancellation(abortController, async () => {
       try {
         await Promise.all([
           context.queryClient.ensureQueryData(


### PR DESCRIPTION
## What changed

- Updated `withRouteLoaderCancellation` so React Query `CancelledError`s no longer resolve route loaders with `undefined`.
- Converted cancelled loader work into an `AbortError` when TanStack Router has aborted the navigation.
- Passed the route `abortController` through every route loader that uses the helper.
- Updated router cancellation tests for aborted and non-aborted cancellation paths.

## Why

Fast navigation between guild routes could cancel React Query work. The old helper swallowed that cancellation and returned `undefined`, which let TanStack Router mark the match as successful without loader data. In production timing this could crash the app when navigating to stats pages like `/$guildId/stats/kills`.

## Validation

- `pnpm --filter @lootlog/web exec vitest run src/lib/router/route-errors.spec.ts`
- `pnpm --filter @lootlog/web build`
- `pnpm --filter @lootlog/web lint`
- Pre-commit hooks passed during `git commit`.

Build still emits the existing `lottie-web` direct `eval` warning; it is unrelated to this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request cancellation handling during route navigation to prevent stale data and ensure proper cleanup of in-flight requests when users navigate away from pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->