### PR TITLE
[codex] simplify filter popover selection

### DIFF
--- a/packages/ui/src/components/filter-popover.tsx
+++ b/packages/ui/src/components/filter-popover.tsx
@@ -44,6 +44,18 @@ interface FilterPopoverProps<T = string> {
   renderTriggerLabel?: (selectedCount: number) => string;
 }
 
+function getSelectedValues<T>(value: T | T[] | undefined): T[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (!value) {
+    return [];
+  }
+
+  return [value];
+}
+
 export function FilterPopover<T extends string = string>({
   options,
   value,
@@ -64,7 +76,7 @@ export function FilterPopover<T extends string = string>({
 }: FilterPopoverProps<T>) {
   const [open, setOpen] = useState(false);
 
-  const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
+  const selectedValues = getSelectedValues(value);
   const isSelected = (optionValue: T) => selectedValues.includes(optionValue);
 
   const handleSelect = (optionValue: T) => {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     //"outDir": "dist"
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@lootlog/ui/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

- Extract selected-value normalization in `FilterPopover` into a small helper to avoid a chained ternary and clarify single vs multi-select handling.
- Add the existing TypeScript 6 `ignoreDeprecations` setting to the UI package config so its `baseUrl` setting no longer blocks package typecheck startup.

## Verification

- `pnpm --filter @lootlog/ui lint` passes with an existing warning in `src/components/npc-tile.tsx` about `<img>` usage.
- `pnpm exec oxfmt --check packages/ui/src/components/filter-popover.tsx packages/ui/tsconfig.json` passes.
- `pnpm format:check` passes.
- `.husky/pre-commit` passes.
- `pnpm --filter @lootlog/ui exec tsc --noEmit` still fails on unrelated existing UI package issues in `src/components/aurora.tsx` (`ogl` exported members) and `src/components/bento.tsx` (`NodeJS` namespace).
