### PR TITLE
[codex] Import timer color names directly

### DIFF
--- a/apps/game-client/src/features/settings/components/timers/components/color-utils.ts
+++ b/apps/game-client/src/features/settings/components/timers/components/color-utils.ts
@@ -1,5 +1,3 @@
-export { getDefaultColorName } from "@/features/timers/utils/get-default-color-name";
-
 export const TAILWIND_TO_HEX: Record<
   string,
   { border: string; background: string }

--- a/apps/game-client/src/features/settings/components/timers/components/default-color-item.tsx
+++ b/apps/game-client/src/features/settings/components/timers/components/default-color-item.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@/components/ui/button";
 import { Tile } from "@/components/ui/tile";
 import type { TIMERS_COLORS } from "@/features/timers/constants/timer-colors";
+import { getDefaultColorName } from "@/features/timers/utils/get-default-color-name";
 import { Edit2, Trash2 } from "lucide-react";
 import type { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { ColorEditForm } from "./color-edit-form";
-import { getDefaultColorName, type ColorEditData } from "./color-utils";
+import type { ColorEditData } from "./color-utils";
 
 interface DefaultColorItemProps {
   colorId: string;

--- a/apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx
+++ b/apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { Tile } from "@/components/ui/tile";
 import type { TIMERS_COLORS } from "@/features/timers/constants/timer-colors";
+import { getDefaultColorName } from "@/features/timers/utils/get-default-color-name";
 import { RotateCcw } from "lucide-react";
 import type { FC } from "react";
 import { useTranslation } from "react-i18next";
-import { getDefaultColorName } from "./color-utils";
 
 interface HiddenColorsListProps {
   hiddenColors: string[];

--- a/apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx
+++ b/apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx
@@ -1,6 +1,7 @@
 import { SettingsSection } from "@/components/settings/settings-section";
 import { useTimersStore, type CustomTimerColor } from "@/store/timers.store";
 import { TIMERS_COLORS } from "@/features/timers/constants/timer-colors";
+import { getDefaultColorName } from "@/features/timers/utils/get-default-color-name";
 import { useState, type FC } from "react";
 import { useTranslation } from "react-i18next";
 import { DefaultColorItem } from "./components/default-color-item";
@@ -12,7 +13,6 @@ import {
   alphaToHex,
   hexToAlpha,
   TAILWIND_TO_HEX,
-  getDefaultColorName,
   type ColorEditData,
 } from "./components/color-utils";
 


### PR DESCRIPTION
## Summary

- Removed the forwarded `getDefaultColorName` export from the timer settings color helper module.
- Updated timer color settings consumers to import default color names from the canonical timers utility.

## Validation

- `pnpm exec oxfmt --check apps/game-client/src/features/settings/components/timers/components/color-utils.ts apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx apps/game-client/src/features/settings/components/timers/components/default-color-item.tsx apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx`
- `pnpm exec oxlint apps/game-client/src/features/settings/components/timers/components/color-utils.ts apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx apps/game-client/src/features/settings/components/timers/components/default-color-item.tsx apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx`
- `pnpm turbo run build --filter=@lootlog/game-client...`
- `pnpm --filter @lootlog/game-client test`
- Pre-commit hook passed for staged files and changed package tests.

Note: initial direct `pnpm --filter @lootlog/game-client build` and `test` runs failed in a fresh checkout before workspace dependency packages were built; the filtered Turbo build generated those dependency outputs and the rerun passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal import organization for improved code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->