### PR TITLE
fix: sync lootlog other glow position

### DIFF
--- a/apps/game-client/src/lib/lootlog-other-glow-manager.test.ts
+++ b/apps/game-client/src/lib/lootlog-other-glow-manager.test.ts
@@ -37,6 +37,22 @@ function createOther(id: string): Other {
   } as unknown as Other;
 }
 
+function moveOther(
+  other: Other,
+  position: { rx: number; ry: number; x: number; y: number },
+): void {
+  const runtimeOther = other as Other & {
+    d: Other["d"] & { x?: number; y?: number };
+    rx?: number;
+    ry?: number;
+  };
+
+  runtimeOther.rx = position.rx;
+  runtimeOther.ry = position.ry;
+  runtimeOther.d.x = position.x;
+  runtimeOther.d.y = position.y;
+}
+
 function setRuntime(drawables: unknown[] = ["base"]): ReturnType<typeof vi.fn> {
   const getDrawableList = vi.fn(() => drawables);
 
@@ -74,6 +90,7 @@ describe("lootlogOtherGlowManager", () => {
 
   afterEach(() => {
     lootlogOtherGlowManager.cleanup();
+    vi.restoreAllMocks();
     Object.defineProperty(window, "Engine", {
       configurable: true,
       value: originalWindowEngine,
@@ -115,6 +132,55 @@ describe("lootlogOtherGlowManager", () => {
     lootlogOtherGlowManager.clear();
 
     expect(getRuntimeDrawableList()).toEqual(["base"]);
+  });
+
+  it("updates managed glow position before returning Engine.others drawable list", () => {
+    const other = createOther("617");
+
+    lootlogOtherGlowManager.install();
+    lootlogOtherGlowManager.setGlow(other, LOOTLOG_OTHER_GLOW_BLUE);
+
+    moveOther(other, { rx: 13, ry: 14, x: 13, y: 14 });
+    getRuntimeDrawableList();
+
+    expect(lootlogOtherGlowManager.getGlowPosition("617")).toEqual({
+      x: 13,
+      y: 14,
+    });
+    expect(lootlogOtherGlowManager.getGlowOrder("617")).toBe(14.1);
+  });
+
+  it("draws managed glow using the latest runtime other position", () => {
+    const other = createOther("617");
+    const drawImage = vi.fn();
+    const context = {
+      drawImage,
+      fillRect: vi.fn(),
+      fillStyle: "",
+      globalCompositeOperation: "",
+    } as unknown as CanvasRenderingContext2D;
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+      context,
+    );
+
+    lootlogOtherGlowManager.install();
+    lootlogOtherGlowManager.setGlow(other, LOOTLOG_OTHER_GLOW_BLUE);
+    const glow = getRuntimeDrawableList()[1] as {
+      draw: (ctx: CanvasRenderingContext2D) => void;
+    };
+
+    drawImage.mockClear();
+    moveOther(other, { rx: 20, ry: 21, x: 20, y: 21 });
+
+    glow.draw(context);
+
+    expect(drawImage).toHaveBeenLastCalledWith(
+      expect.any(HTMLCanvasElement),
+      637,
+      652,
+      36,
+      52,
+    );
   });
 
   it("suppresses native Margonem other glows while keeping other drawables and Lootlog glows", () => {

--- a/apps/game-client/src/lib/lootlog-other-glow-manager.ts
+++ b/apps/game-client/src/lib/lootlog-other-glow-manager.ts
@@ -133,6 +133,8 @@ class LootlogOtherGlow {
   }
 
   draw(ctx: CanvasRenderingContext2D): void {
+    this.update();
+
     const runtimeWindow = getRuntimeWindow();
     const engine = runtimeWindow.Engine;
     if (!this.maskLoaded || !this.createMaskColor() || !engine?.map) return;
@@ -237,10 +239,14 @@ class LootlogOtherGlowManager {
     if (!others?.getDrawableList) return;
 
     this.originalGetDrawableList = others.getDrawableList;
-    others.getDrawableList = () => [
-      ...this.getBaseDrawableList(others),
-      ...this.glowsByCharacterId.values(),
-    ];
+    others.getDrawableList = () => {
+      this.updateGlows();
+
+      return [
+        ...this.getBaseDrawableList(others),
+        ...this.glowsByCharacterId.values(),
+      ];
+    };
     this.cleanupDrawableListPatch = () => {
       if (this.originalGetDrawableList) {
         others.getDrawableList = this.originalGetDrawableList;
@@ -289,6 +295,20 @@ class LootlogOtherGlowManager {
     return this.glowsByCharacterId.get(characterId)?.getColor();
   }
 
+  getGlowPosition(characterId: string): { x?: number; y?: number } | undefined {
+    const glow = this.glowsByCharacterId.get(characterId);
+    if (!glow) return undefined;
+
+    return {
+      x: glow.d.x,
+      y: glow.d.y,
+    };
+  }
+
+  getGlowOrder(characterId: string): number | undefined {
+    return this.glowsByCharacterId.get(characterId)?.getOrder();
+  }
+
   getGlowCount(): number {
     return this.glowsByCharacterId.size;
   }
@@ -306,6 +326,12 @@ class LootlogOtherGlowManager {
     }
 
     return drawables.filter((drawable) => !isNativeOtherGlowDrawable(drawable));
+  }
+
+  private updateGlows(): void {
+    for (const glow of this.glowsByCharacterId.values()) {
+      glow.update();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- sync Lootlog-managed Other glow position with the runtime `Other` before drawable listing
- refresh glow position again at draw time so existing drawables do not lag behind moving players
- add regression coverage for movement-driven position updates

## Why
The native Margonem glow follows moving players because `Other.update()` refreshes `whoIsHereGlow`. Lootlog's custom glow only captured `rx/ry` when the glow was created or recolored, so it could visually trail behind a moving player.

## Validation
- `pnpm --dir apps/game-client exec vitest run src/lib/lootlog-other-glow-manager.test.ts src/hooks/game-events/use-other-catching-guild-glow.test.tsx`
- `pnpm --filter @lootlog/game-client build`
- pre-commit checks: format, lint, full `@lootlog/game-client` tests
