### PR TITLE
fix: sync lootlog glow while others move

### DIFF
--- a/apps/game-client/src/lib/lootlog-other-glow-manager.test.ts
+++ b/apps/game-client/src/lib/lootlog-other-glow-manager.test.ts
@@ -53,6 +53,16 @@ function moveOther(
   runtimeOther.d.y = position.y;
 }
 
+function setOtherUpdate(
+  other: Other,
+  update: (this: Other, dt: number) => void,
+): void {
+  const runtimeOther = other as Other & {
+    update?: (this: Other, dt: number) => void;
+  };
+  runtimeOther.update = update;
+}
+
 function setRuntime(drawables: unknown[] = ["base"]): ReturnType<typeof vi.fn> {
   const getDrawableList = vi.fn(() => drawables);
 
@@ -148,6 +158,57 @@ describe("lootlogOtherGlowManager", () => {
       y: 14,
     });
     expect(lootlogOtherGlowManager.getGlowOrder("617")).toBe(14.1);
+  });
+
+  it("updates managed glow position after runtime Other.update movement", () => {
+    const other = createOther("617");
+    const originalUpdate = vi.fn(function (this: Other, dt: number) {
+      moveOther(this, { rx: 17 + dt, ry: 18 + dt, x: 17 + dt, y: 18 + dt });
+    });
+    setOtherUpdate(other, originalUpdate);
+
+    lootlogOtherGlowManager.install();
+    lootlogOtherGlowManager.setGlow(other, LOOTLOG_OTHER_GLOW_BLUE);
+
+    (
+      other as Other & {
+        update: (dt: number) => void;
+      }
+    ).update(2);
+
+    expect(originalUpdate).toHaveBeenCalledWith(2);
+    expect(lootlogOtherGlowManager.getGlowPosition("617")).toEqual({
+      x: 19,
+      y: 20,
+    });
+    expect(lootlogOtherGlowManager.getGlowOrder("617")).toBe(20.1);
+  });
+
+  it("restores runtime Other.update when managed glow is removed", () => {
+    const other = createOther("617");
+    const originalUpdate = vi.fn();
+    setOtherUpdate(other, originalUpdate);
+
+    lootlogOtherGlowManager.install();
+    lootlogOtherGlowManager.setGlow(other, LOOTLOG_OTHER_GLOW_BLUE);
+
+    expect(
+      (
+        other as Other & {
+          update: (dt: number) => void;
+        }
+      ).update,
+    ).not.toBe(originalUpdate);
+
+    lootlogOtherGlowManager.removeGlow("617");
+
+    expect(
+      (
+        other as Other & {
+          update: (dt: number) => void;
+        }
+      ).update,
+    ).toBe(originalUpdate);
   });
 
   it("draws managed glow using the latest runtime other position", () => {

--- a/apps/game-client/src/lib/lootlog-other-glow-manager.ts
+++ b/apps/game-client/src/lib/lootlog-other-glow-manager.ts
@@ -13,8 +13,11 @@ type RuntimeOther = Other & {
   imgLoaded?: boolean;
   rx?: number;
   ry?: number;
+  update?: RuntimeOtherUpdate;
   waterTopModify?: number;
 };
+
+type RuntimeOtherUpdate = (this: RuntimeOther, ...args: unknown[]) => unknown;
 
 type RuntimeWindow = Window &
   typeof globalThis & {
@@ -231,6 +234,10 @@ class LootlogOtherGlowManager {
   private readonly glowsByCharacterId = new Map<string, LootlogOtherGlow>();
   private nativeGlowSuppressed = false;
   private originalGetDrawableList: OriginalGetDrawableList | null = null;
+  private readonly originalOtherUpdates = new WeakMap<
+    RuntimeOther,
+    RuntimeOtherUpdate
+  >();
 
   install(): void {
     if (this.cleanupDrawableListPatch) return;
@@ -263,25 +270,41 @@ class LootlogOtherGlowManager {
 
   setGlow(other: Other, color: string): void {
     const characterId = String(other.d.id);
+    const runtimeOther = other as RuntimeOther;
     const existingGlow = this.glowsByCharacterId.get(characterId);
 
     if (existingGlow) {
-      existingGlow.master = other as RuntimeOther;
+      if (existingGlow.master !== runtimeOther) {
+        this.restoreOtherUpdate(existingGlow.master);
+      }
+
+      existingGlow.master = runtimeOther;
       existingGlow.updateColor(color);
+      this.patchOtherUpdate(runtimeOther);
+      existingGlow.update();
       return;
     }
 
+    this.patchOtherUpdate(runtimeOther);
     this.glowsByCharacterId.set(
       characterId,
-      new LootlogOtherGlow(other as RuntimeOther, color),
+      new LootlogOtherGlow(runtimeOther, color),
     );
   }
 
   removeGlow(characterId: string): void {
+    const glow = this.glowsByCharacterId.get(characterId);
+    if (!glow) return;
+
+    this.restoreOtherUpdate(glow.master);
     this.glowsByCharacterId.delete(characterId);
   }
 
   clear(): void {
+    for (const glow of this.glowsByCharacterId.values()) {
+      this.restoreOtherUpdate(glow.master);
+    }
+
     this.glowsByCharacterId.clear();
   }
 
@@ -332,6 +355,36 @@ class LootlogOtherGlowManager {
     for (const glow of this.glowsByCharacterId.values()) {
       glow.update();
     }
+  }
+
+  private patchOtherUpdate(other: RuntimeOther): void {
+    if (this.originalOtherUpdates.has(other) || !other.update) return;
+
+    const originalUpdate = other.update;
+    const manager = this;
+    this.originalOtherUpdates.set(other, originalUpdate);
+    other.update = function lootlogOtherUpdatePatch(...args) {
+      const result = originalUpdate.apply(this, args);
+      manager.updateGlowForOther(this);
+
+      return result;
+    };
+  }
+
+  private restoreOtherUpdate(other: RuntimeOther): void {
+    const originalUpdate = this.originalOtherUpdates.get(other);
+    if (!originalUpdate) return;
+
+    other.update = originalUpdate;
+    this.originalOtherUpdates.delete(other);
+  }
+
+  private updateGlowForOther(other: RuntimeOther): void {
+    const glow = this.glowsByCharacterId.get(String(other.d.id));
+    if (!glow) return;
+
+    glow.master = other;
+    glow.update();
   }
 }
 


### PR DESCRIPTION
## Summary
- patch managed runtime Other.update calls so Lootlog glow refreshes immediately after player movement
- keep getDrawableList/draw synchronization as fallback
- restore patched Other.update when managed glow is removed or cleaned up

## Validation
- pnpm --dir apps/game-client exec vitest run src/lib/lootlog-other-glow-manager.test.ts src/hooks/game-events/use-other-catching-guild-glow.test.tsx
- pnpm --filter @lootlog/game-client build
- pre-commit full @lootlog/game-client tests: 117 files, 554 tests passed