### PR TITLE
[codex] refactor: reuse role color formatting

### DIFF
--- a/apps/web/src/features/guild/settings/roles/roles.tsx
+++ b/apps/web/src/features/guild/settings/roles/roles.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Shield } from "lucide-react";
 import { Card } from "@lootlog/ui/components/card";
 import { Permission } from "@lootlog/types";
+import { getColorFromRoleColor } from "@/utils/get-color-from-role";
 import { RolePanelContent } from "@/features/guild/settings/roles/components/roles-panel";
 import { RoleListItem } from "@/features/guild/settings/roles/components/role-list-item";
 import {
@@ -62,10 +63,7 @@ const RolesSettingsContent = () => {
       return a.name.localeCompare(b.name);
     });
 
-  const selectedRoleColor =
-    (selectedRole?.color ?? 0) === 0
-      ? "FFF"
-      : (selectedRole?.color ?? 0).toString(16).padStart(6, "0");
+  const selectedRoleColor = getColorFromRoleColor(selectedRole?.color);
 
   return (
     <SelectorPanel<GuildRole>
@@ -109,7 +107,7 @@ const RolesSettingsContent = () => {
           <div
             className="size-4 rounded-full"
             style={{
-              backgroundColor: `#${(role.color ?? 0) === 0 ? "FFF" : (role.color ?? 0).toString(16).padStart(6, "0")}`,
+              backgroundColor: `#${getColorFromRoleColor(role.color)}`,
             }}
           />
           <span>{role.name}</span>

--- a/apps/web/src/utils/get-color-from-role.ts
+++ b/apps/web/src/utils/get-color-from-role.ts
@@ -1,6 +1,11 @@
 import type { MemberResponseDto as GuildMember } from "@/lib/api/generated/main/model";
 
+export const getColorFromRoleColor = (color: number | null | undefined) => {
+  return color === 0 || color == null
+    ? "FFF"
+    : color.toString(16).padStart(6, "0");
+};
+
 export const getColorFromRole = (roles: GuildMember["roles"]) => {
-  const color = roles?.[0]?.color ?? 0;
-  return color === 0 ? "FFF" : color?.toString(16).padStart(6, "0");
+  return getColorFromRoleColor(roles?.[0]?.color);
 };


### PR DESCRIPTION
## Summary
- Extracted numeric role color formatting into `getColorFromRoleColor`.
- Reused the shared helper in roles settings for selected panel and mobile drawer role colors.
- Kept the existing member role color helper as a wrapper around the new helper.

## Verification
- `pnpm --filter @lootlog/web lint`
- `pnpm exec oxfmt --check apps/web/src/utils/get-color-from-role.ts apps/web/src/features/guild/settings/roles/roles.tsx`
- `pnpm turbo run build --filter=@lootlog/web...`
- Pre-commit hook: lint-staged formatting/lint, changed-package lint, changed-package format check, changed-package tests

Note: `pnpm install` initially returned an ignored-builds approval warning, but installed dependencies sufficiently for the targeted checks above. The generated workspace YAML suggestion was not included in this PR.