### PR TITLE
[codex] Type battlelog R2 payloads

### DIFF
--- a/apps/battlelog-service/src/battles/battles.service.ts
+++ b/apps/battlelog-service/src/battles/battles.service.ts
@@ -224,7 +224,8 @@ export class BattlesService implements IBattlesService {
         await this.checkBattleAccess(battleId, requestingUserId);
       }
 
-      const rawData = await this.r2Service.getBattleData(battleId);
+      const rawData =
+        await this.r2Service.getBattleData<RawBattleData>(battleId);
       return rawData;
     } catch (error) {
       this.logger.error(

--- a/apps/battlelog-service/src/shared/modules/r2/r2.service.ts
+++ b/apps/battlelog-service/src/shared/modules/r2/r2.service.ts
@@ -37,7 +37,7 @@ export class R2Service {
     );
   }
 
-  async uploadBattleData(battleId: string, data: any): Promise<void> {
+  async uploadBattleData(battleId: string, data: unknown): Promise<void> {
     try {
       const key = `battles/${battleId}.json`;
       const jsonString = JSON.stringify(data);
@@ -66,7 +66,7 @@ export class R2Service {
     }
   }
 
-  async getBattleData(battleId: string): Promise<any> {
+  async getBattleData<TData = unknown>(battleId: string): Promise<TData> {
     try {
       const cacheKey = `${this.CACHE_PREFIX}:${battleId}`;
 
@@ -74,7 +74,7 @@ export class R2Service {
       if (cachedData) {
         this.logger.debug(`Cache hit for battle ${battleId}`);
         await this.updateLRU(battleId);
-        return JSON.parse(cachedData);
+        return JSON.parse(cachedData) as TData;
       }
 
       this.logger.debug(`Cache miss for battle ${battleId}, fetching from R2`);
@@ -116,7 +116,7 @@ export class R2Service {
         `Battle data retrieved from R2 and cached for battle ${battleId}`,
       );
 
-      return parsedData;
+      return parsedData as TData;
     } catch (error) {
       this.logger.error(
         `Failed to retrieve battle data for ${battleId}:`,


### PR DESCRIPTION
## Summary
- tighten `R2Service` battle payload storage from `any` to `unknown`
- make `getBattleData` generic so callers specify the JSON payload shape they own
- type the raw battle data read in `BattlesService` as `RawBattleData`

## Verification
- `pnpm exec oxfmt --check apps/battlelog-service/src/shared/modules/r2/r2.service.ts apps/battlelog-service/src/battles/battles.service.ts`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm turbo run build --filter=@lootlog/battlelog-service...`
- `pnpm turbo run test --filter=@lootlog/battlelog-service`
- pre-commit hook passed changed-package lint, formatting, and tests

Note: initial isolated package build/test failed until `@lootlog/nest-shared` was built locally, because its subpath exports resolve to `dist/*` files.
