### PR TITLE
[codex] simplify web member color hook

### DIFF
--- a/apps/web/src/hooks/discord/use-member-color.ts
+++ b/apps/web/src/hooks/discord/use-member-color.ts
@@ -1,14 +1,13 @@
-import { useMemo } from "react";
-
 type Role = { position: number; color?: number | null };
 
-export const useMemberColor = (guildMember: { roles?: Role[] } | undefined) =>
-  useMemo(() => {
-    if (!guildMember?.roles?.length) return "inherit";
-    const topRole = guildMember.roles.reduce((prev, curr) =>
-      (curr.position ?? 0) > (prev.position ?? 0) ? curr : prev,
-    );
-    return !topRole.color
-      ? "inherit"
-      : `#${topRole.color.toString(16).padStart(6, "0")}`;
-  }, [guildMember]);
+export const useMemberColor = (guildMember: { roles?: Role[] } | undefined) => {
+  if (!guildMember?.roles?.length) return "inherit";
+
+  const topRole = guildMember.roles.reduce((prev, curr) =>
+    curr.position > prev.position ? curr : prev,
+  );
+
+  return !topRole.color
+    ? "inherit"
+    : `#${topRole.color.toString(16).padStart(6, "0")}`;
+};


### PR DESCRIPTION
## Summary
- removed the unnecessary `useMemo` wrapper from the web `useMemberColor` helper
- kept the existing role color fallback behavior while avoiding manual memoization

## Verification
- `pnpm --filter @lootlog/web lint`
- `pnpm exec oxfmt --check apps/web/src/hooks/discord/use-member-color.ts`
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/socket-parser build`
- `pnpm --filter @lootlog/web build`
- pre-commit hook: lint-staged, changed-package lint, format check task, changed-package tests

Note: `pnpm install` populated missing `node_modules` but exited with the existing ignored-builds approval guard; scoped checks succeeded after dependencies were present.