### PR TITLE
[codex] Centralize battlelog page size defaults

### DIFF
--- a/apps/battlelog-service/src/battles/services/battle-analytics.service.spec.ts
+++ b/apps/battlelog-service/src/battles/services/battle-analytics.service.spec.ts
@@ -452,9 +452,10 @@ describe("BattleAnalyticsService", () => {
     it("should return empty records when no characters found", async () => {
       drizzleService.db.query.userCharacters.findMany.mockResolvedValue([]);
 
-      const result = await service.getHeadToHead({}, mockUserId);
+      const result = await service.getHeadToHead({ size: 5 }, mockUserId);
 
       expect(result.records).toEqual([]);
+      expect(result.pagination.size).toBe(5);
       expect(result.pagination.hasNext).toBe(false);
     });
 
@@ -542,11 +543,12 @@ describe("BattleAnalyticsService", () => {
       drizzleService.db.query.userCharacters.findMany.mockResolvedValue([]);
 
       const result = await service.getPlayerVsPlayerBattles(
-        { opponentId: "opponent-1" },
+        { opponentId: "opponent-1", size: 5 },
         mockUserId,
       );
 
       expect(result.battles).toEqual([]);
+      expect(result.pagination.size).toBe(5);
       expect(result.pagination.hasNext).toBe(false);
     });
   });

--- a/apps/battlelog-service/src/battles/services/battle-analytics.service.ts
+++ b/apps/battlelog-service/src/battles/services/battle-analytics.service.ts
@@ -288,7 +288,7 @@ export class BattleAnalyticsService {
       return {
         records: [],
         pagination: {
-          size: query.size || 20,
+          size: this.getPageSize(query),
           hasNext: false,
           hasPrev: false,
         },
@@ -434,8 +434,8 @@ export class BattleAnalyticsService {
       );
     }
 
-    const sortBy = query.sortBy || "totalBattles";
-    const sortOrder = query.sortOrder || "desc";
+    const sortBy = query.sortBy ?? "totalBattles";
+    const sortOrder = query.sortOrder ?? "desc";
     filteredRecords.sort((a, b) => {
       let compareResult = 0;
 
@@ -485,7 +485,7 @@ export class BattleAnalyticsService {
       }
     }
 
-    const size = query.size || 20;
+    const size = this.getPageSize(query);
     const endIndex = startIndex + size;
     const paginatedRecords = filteredRecords.slice(startIndex, endIndex);
 
@@ -1241,7 +1241,7 @@ export class BattleAnalyticsService {
       return {
         battles: [],
         pagination: {
-          size: query.size || 20,
+          size: this.getPageSize(query),
           hasNext: false,
           hasPrev: false,
         },
@@ -1306,7 +1306,7 @@ export class BattleAnalyticsService {
       }
     }
 
-    const size = query.size || 20;
+    const size = this.getPageSize(query);
     const endIndex = startIndex + size;
     const paginatedBattles = levelFilteredBattles.slice(startIndex, endIndex);
 
@@ -1395,5 +1395,9 @@ export class BattleAnalyticsService {
     }
 
     return maxLevel === undefined || opponentLevel <= maxLevel;
+  }
+
+  private getPageSize(query: QueryBattleStatisticsDto): number {
+    return query.size ?? 20;
   }
 }


### PR DESCRIPTION
## Summary
- centralize battlelog analytics pagination size fallback in `getPageSize`
- switch battle analytics sort defaults from `||` to `??`
- assert empty pagination paths preserve explicit page sizes

## Verification
- `pnpm --filter @lootlog/battlelog-service test src/battles/services/battle-analytics.service.spec.ts`
- `pnpm turbo run build --filter=@lootlog/battlelog-service...`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm exec oxfmt --check apps/battlelog-service/src/battles/services/battle-analytics.service.ts apps/battlelog-service/src/battles/services/battle-analytics.service.spec.ts`
- pre-commit hook: package lint and full `@lootlog/battlelog-service` test suite