### PR TITLE
[codex] Refactor battle analytics defaults

### DIFF
--- a/apps/battlelog-service/src/battles/services/battle-analytics.service.spec.ts
+++ b/apps/battlelog-service/src/battles/services/battle-analytics.service.spec.ts
@@ -452,9 +452,10 @@ describe("BattleAnalyticsService", () => {
     it("should return empty records when no characters found", async () => {
       drizzleService.db.query.userCharacters.findMany.mockResolvedValue([]);
 
-      const result = await service.getHeadToHead({}, mockUserId);
+      const result = await service.getHeadToHead({ size: 10 }, mockUserId);
 
       expect(result.records).toEqual([]);
+      expect(result.pagination.size).toBe(10);
       expect(result.pagination.hasNext).toBe(false);
     });
 
@@ -542,11 +543,12 @@ describe("BattleAnalyticsService", () => {
       drizzleService.db.query.userCharacters.findMany.mockResolvedValue([]);
 
       const result = await service.getPlayerVsPlayerBattles(
-        { opponentId: "opponent-1" },
+        { opponentId: "opponent-1", size: 10 },
         mockUserId,
       );
 
       expect(result.battles).toEqual([]);
+      expect(result.pagination.size).toBe(10);
       expect(result.pagination.hasNext).toBe(false);
     });
   });

--- a/apps/battlelog-service/src/battles/services/battle-analytics.service.ts
+++ b/apps/battlelog-service/src/battles/services/battle-analytics.service.ts
@@ -288,7 +288,7 @@ export class BattleAnalyticsService {
       return {
         records: [],
         pagination: {
-          size: query.size || 20,
+          size: query.size ?? 20,
           hasNext: false,
           hasPrev: false,
         },
@@ -356,7 +356,7 @@ export class BattleAnalyticsService {
 
       if (userWarrior && opponentWarrior) {
         const opponentId = opponentWarrior.originalId;
-        const stats = opponentStats.get(opponentId) || {
+        const stats = opponentStats.get(opponentId) ?? {
           name: opponentWarrior.name,
           icon: opponentWarrior.icon,
           prof: opponentWarrior.prof,
@@ -434,8 +434,8 @@ export class BattleAnalyticsService {
       );
     }
 
-    const sortBy = query.sortBy || "totalBattles";
-    const sortOrder = query.sortOrder || "desc";
+    const sortBy = query.sortBy ?? "totalBattles";
+    const sortOrder = query.sortOrder ?? "desc";
     filteredRecords.sort((a, b) => {
       let compareResult = 0;
 
@@ -485,7 +485,7 @@ export class BattleAnalyticsService {
       }
     }
 
-    const size = query.size || 20;
+    const size = query.size ?? 20;
     const endIndex = startIndex + size;
     const paginatedRecords = filteredRecords.slice(startIndex, endIndex);
 
@@ -1162,7 +1162,7 @@ export class BattleAnalyticsService {
 
       if (userWarrior && opponentWarrior && battle.ratingDelta !== null) {
         const opponentId = opponentWarrior.originalId;
-        const stats = opponentStats.get(opponentId) || {
+        const stats = opponentStats.get(opponentId) ?? {
           name: opponentWarrior.name,
           icon: opponentWarrior.icon,
           prof: opponentWarrior.prof,
@@ -1241,7 +1241,7 @@ export class BattleAnalyticsService {
       return {
         battles: [],
         pagination: {
-          size: query.size || 20,
+          size: query.size ?? 20,
           hasNext: false,
           hasPrev: false,
         },
@@ -1306,7 +1306,7 @@ export class BattleAnalyticsService {
       }
     }
 
-    const size = query.size || 20;
+    const size = query.size ?? 20;
     const endIndex = startIndex + size;
     const paginatedBattles = levelFilteredBattles.slice(startIndex, endIndex);
 


### PR DESCRIPTION
## Summary
- Replace truthy fallback defaults in battle analytics pagination/sorting with nullish coalescing.
- Keep existing opponent accumulator objects while avoiding falsy checks on stored map values.
- Add pagination assertions for empty-result head-to-head and player-vs-player responses.

## Verification
- pnpm --filter @lootlog/battlelog-service format
- pnpm --filter @lootlog/battlelog-service test -- src/battles/services/battle-analytics.service.spec.ts
- pnpm --filter @lootlog/battlelog-service lint
- pnpm --filter @lootlog/battlelog-service build
- pnpm turbo run lint '--filter=[HEAD]'
- pnpm turbo run format:check '--filter=[HEAD]' (no package task configured)
- pnpm turbo run test '--filter=[HEAD]'
- pnpm turbo run build '--filter=[HEAD]'
