### PR TITLE
[codex] Remove API helpers permissions wrapper

### DIFF
--- a/apps/api/vitest.config.e2e.ts
+++ b/apps/api/vitest.config.e2e.ts
@@ -14,7 +14,7 @@ const nestConfig = createNestVitestConfig({
   include: ["test/**/*.e2e-spec.ts"],
   alias: {
     "@lootlog/api-helpers/permissions":
-      "../../packages/api-helpers/src/permissions.ts",
+      "../../packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts",
   },
   fileParallelism: false,
   setupFiles: ["./test/vitest.setup.ts"],

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     include: ["src/**/*.spec.ts"],
     alias: {
       "@lootlog/api-helpers/permissions":
-        "../../packages/api-helpers/src/permissions.ts",
+        "../../packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts",
       "prisma/generated/client": "./prisma/generated/client.ts",
     },
     setupFiles: ["./test/vitest.setup.ts"],

--- a/packages/api-helpers/src/permissions.ts
+++ b/packages/api-helpers/src/permissions.ts
@@ -1,1 +1,0 @@
-export * from "./lib/permissions/can-view-npc-timer";

--- a/packages/api-helpers/tsdown.config.ts
+++ b/packages/api-helpers/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "tsdown";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
-    permissions: "src/permissions.ts",
+    permissions: "src/lib/permissions/can-view-npc-timer.ts",
   },
   format: ["esm", "cjs"],
   outExtensions: ({ format }) => ({


### PR DESCRIPTION
## Summary
- remove the re-export-only `packages/api-helpers/src/permissions.ts` wrapper
- point the `permissions` build entry at `can-view-npc-timer.ts` directly
- update API Vitest aliases to target the implementation file

## Verification
- `pnpm exec oxfmt --check apps/api/vitest.config.ts apps/api/vitest.config.e2e.ts packages/api-helpers/tsdown.config.ts`
- `pnpm exec oxlint apps/api/vitest.config.ts apps/api/vitest.config.e2e.ts packages/api-helpers/tsdown.config.ts`
- `pnpm turbo run build --filter=@lootlog/api-helpers`
- `pnpm turbo run test --filter=@lootlog/api`
- pre-commit checks during `git commit`