### PR TITLE
[codex] Reuse notification target display name updates

### DIFF
--- a/apps/api/src/notifications/notification-target.service.ts
+++ b/apps/api/src/notifications/notification-target.service.ts
@@ -118,15 +118,11 @@ export class NotificationTargetService {
     data: UpdateNotificationTargetDto,
   ) {
     await this.ensureTarget(DbNotificationOwnerType.GUILD, guildId, targetId);
-    const hasDisplayName = Object.prototype.hasOwnProperty.call(
-      data,
-      "displayName",
-    );
 
     const updated = await this.prisma.notificationTarget.update({
       where: { id: targetId },
       data: {
-        ...(hasDisplayName ? { displayName: data.displayName ?? null } : {}),
+        ...this.getDisplayNameUpdate(data),
         active: data.active,
       },
     });
@@ -219,15 +215,10 @@ export class NotificationTargetService {
   ) {
     await this.ensureTarget(DbNotificationOwnerType.USER, discordId, targetId);
 
-    const hasDisplayName = Object.prototype.hasOwnProperty.call(
-      data,
-      "displayName",
-    );
-
     return this.prisma.notificationTarget.update({
       where: { id: targetId },
       data: {
-        ...(hasDisplayName ? { displayName: data.displayName ?? null } : {}),
+        ...this.getDisplayNameUpdate(data),
         active: data.active,
       },
     });
@@ -424,6 +415,16 @@ export class NotificationTargetService {
         where: { id: { in: singleTargetRuleIds } },
       });
     }
+  }
+
+  private getDisplayNameUpdate(
+    data: Pick<UpdateNotificationTargetDto, "displayName">,
+  ): Pick<Prisma.NotificationTargetUpdateInput, "displayName"> {
+    if (!Object.prototype.hasOwnProperty.call(data, "displayName")) {
+      return {};
+    }
+
+    return { displayName: data.displayName ?? null };
   }
 
   private async getOrCreateUserDmTestRule(discordId: string, targetId: number) {


### PR DESCRIPTION
## Summary
- Extract the optional notification target displayName update payload into a private helper.
- Reuse the helper for both guild and user target update paths so omitted displayName continues to avoid a database write.

## Verification
- pnpm --filter @lootlog/api format
- pnpm --filter @lootlog/api lint
- pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/notifications/notifications.service.spec.ts
- pnpm --filter @lootlog/api build
- pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts
- pre-commit hook during git commit: lint-staged, changed-package lint, build, test