### PR TITLE
[codex] preserve nullish game client fallbacks

### DIFF
--- a/apps/game-client/src/features/online-players/online-players-list.helpers.test.ts
+++ b/apps/game-client/src/features/online-players/online-players-list.helpers.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ONLINE_PLAYERS_FILTERS,
   getFilteredAccountEntries,
   getFilteredMemberEntries,
+  getPresenceCharacter,
 } from "@/features/online-players/online-players-list.helpers";
 import type { PlayerPresence } from "@/features/online-players/hooks/use-players-presence";
 
@@ -35,6 +36,26 @@ const createPresence = ({
 });
 
 describe("online players list helpers", () => {
+  it("preserves explicit empty presence fields when creating character data", () => {
+    const character = getPresenceCharacter(
+      createPresence({
+        discordId: "discord-1",
+        name: "",
+        lvl: 0,
+        characterId: "0",
+        prof: "",
+      }),
+    );
+
+    expect(character).toMatchObject({
+      icon: ".gif",
+      lvl: 0,
+      nick: "",
+      prof: "",
+      world: "pandora",
+    });
+  });
+
   it("sorts account entries by level descending after filtering", () => {
     const entries = getFilteredAccountEntries(
       {

--- a/apps/game-client/src/features/online-players/online-players-list.helpers.ts
+++ b/apps/game-client/src/features/online-players/online-players-list.helpers.ts
@@ -50,11 +50,11 @@ export const getPresenceCharacter = (
     id: presence.player?.characterId
       ? Number.parseInt(presence.player.characterId, 10)
       : 0,
-    nick: presence.player?.name || t("states.unknownNeutral"),
-    icon: presence.player?.icon || "",
-    lvl: presence.player?.lvl || 0,
-    prof: presence.player?.prof || t("states.unknownNeutral"),
-    world: presence.player?.world || t("states.unknownNeutral"),
+    nick: presence.player?.name ?? t("states.unknownNeutral"),
+    icon: presence.player?.icon ?? "",
+    lvl: presence.player?.lvl ?? 0,
+    prof: presence.player?.prof ?? t("states.unknownNeutral"),
+    world: presence.player?.world ?? t("states.unknownNeutral"),
   };
 };
 

--- a/apps/game-client/src/features/timers/utils/color-statistics.spec.ts
+++ b/apps/game-client/src/features/timers/utils/color-statistics.spec.ts
@@ -94,6 +94,32 @@ describe("color-statistics", () => {
       expect(redStat?.name).toBe("My Red Name");
     });
 
+    it("should preserve empty default color names", () => {
+      const timersColors = {
+        Boss1: "red",
+      };
+
+      const sortedTimers: TimerWithTimeLeft[] = [
+        { npc: { id: 1, name: "Boss1" } } as unknown as TimerWithTimeLeft,
+      ];
+
+      const defaultColorNames = {
+        red: "",
+      };
+
+      const result = calculateColorStatistics(
+        timersColors,
+        sortedTimers,
+        {},
+        defaultColorNames,
+        {},
+      );
+
+      const redStat = result.find((s) => s.color === "red");
+
+      expect(redStat?.name).toBe("");
+    });
+
     it("should include overridden colors in statistics", () => {
       const timersColors = {
         Boss1: "red",

--- a/apps/game-client/src/features/timers/utils/color-statistics.ts
+++ b/apps/game-client/src/features/timers/utils/color-statistics.ts
@@ -44,7 +44,7 @@ export const calculateColorStatistics = (
     stats[color] = {
       total: 0,
       active: 0,
-      name: defaultColorNames[color] || getDefaultColorName(color) || color,
+      name: defaultColorNames[color] ?? getDefaultColorName(color),
       bgColor: overridden?.backgroundColor,
       borderColor: overridden?.borderColor,
     };


### PR DESCRIPTION
## Summary

- replace game-client fallback expressions with nullish coalescing where empty strings and zero values should be preserved
- add focused coverage for online player presence character mapping and timer color statistics fallback behavior

## Verification

- pnpm exec oxfmt --check apps/game-client/src/features/online-players/online-players-list.helpers.ts apps/game-client/src/features/online-players/online-players-list.helpers.test.ts apps/game-client/src/features/timers/utils/color-statistics.ts apps/game-client/src/features/timers/utils/color-statistics.spec.ts
- pnpm exec oxlint apps/game-client/src/features/online-players/online-players-list.helpers.ts apps/game-client/src/features/online-players/online-players-list.helpers.test.ts apps/game-client/src/features/timers/utils/color-statistics.ts apps/game-client/src/features/timers/utils/color-statistics.spec.ts
- pnpm --filter @lootlog/game-client exec vitest run src/features/online-players/online-players-list.helpers.test.ts src/features/timers/utils/color-statistics.spec.ts
- pnpm --filter @lootlog/game-client test
- pnpm exec turbo run build --filter=@lootlog/game-client...
- git commit pre-commit hook

Note: direct `pnpm --filter @lootlog/game-client build` failed before dependency packages were built because internal workspace package declarations were missing; rerunning through Turbo with dependencies included passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty values in player presence data to ensure explicitly set empty strings are preserved rather than replaced with defaults.
  * Fixed timer color statistics to preserve empty-string color names instead of applying unnecessary fallbacks.

* **Tests**
  * Added test cases to verify empty value preservation in character presence data and color statistics calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->