### PR TITLE
[codex] Tighten battle processor fallbacks

### DIFF
--- a/apps/battlelog-service/src/battles/battle-processor.spec.ts
+++ b/apps/battlelog-service/src/battles/battle-processor.spec.ts
@@ -30,6 +30,27 @@ describe("BattleProcessor", () => {
       expect(result.duration).toBe(4000);
     });
 
+    it("should preserve zero timestamp when calculating duration", () => {
+      const battleData: CreateBattleDto = {
+        accountId: "test-account",
+        characterId: "char-1",
+        world: "test-world",
+        events: [
+          {
+            ev: 0,
+            f: { w: {} },
+          },
+          {
+            ev: 2500,
+            f: { w: {} },
+          },
+        ],
+      };
+
+      const result = processor.processBattle(battleData);
+      expect(result.duration).toBe(2500);
+    });
+
     it("should throw error when no events provided", () => {
       const battleData: CreateBattleDto = {
         accountId: "test-account",

--- a/packages/battle-processor/src/index.ts
+++ b/packages/battle-processor/src/index.ts
@@ -211,7 +211,7 @@ export class BattleProcessor {
   }
 
   public extractAndParseMoves(events: BattlePayload["events"]): ParsedMove[] {
-    const allMoves = events.flatMap((event) => event.f?.m || []);
+    const allMoves = events.flatMap((event) => event.f?.m ?? []);
 
     return allMoves.map((move) => {
       const [attackerPart, defenderPart, ...actions] = move.split(";");
@@ -276,7 +276,7 @@ export class BattleProcessor {
           attacker.spellsUsed++;
           const spellName = tspellAction.param || "unknown";
           attacker.spellsUsedMap[spellName] =
-            (attacker.spellsUsedMap[spellName] || 0) + 1;
+            (attacker.spellsUsedMap[spellName] ?? 0) + 1;
         }
       }
 
@@ -752,8 +752,8 @@ export class BattleProcessor {
       throw new Error("No events found in battle data");
     }
 
-    const firstTimestamp = events[0]?.ev || 0;
-    const lastTimestamp = events[events.length - 1]?.ev || 0;
+    const firstTimestamp = events[0]?.ev ?? 0;
+    const lastTimestamp = events[events.length - 1]?.ev ?? 0;
 
     return lastTimestamp - firstTimestamp;
   }


### PR DESCRIPTION
## Summary
- Use nullish fallback semantics for optional battle moves, spell usage counts, and battle duration timestamps.
- Add a regression test that preserves a zero-valued battle timestamp when calculating duration.

## Verification
- pnpm --filter @lootlog/battle-processor build
- pnpm --filter @lootlog/battlelog-service lint
- pnpm exec oxfmt --check packages/battle-processor/src/index.ts apps/battlelog-service/src/battles/battle-processor.spec.ts
- pnpm --filter @lootlog/types build
- pnpm --filter @lootlog/nest-shared build
- pnpm --filter @lootlog/instrumentation build
- pnpm --filter @lootlog/battlelog-service build
- pnpm --filter @lootlog/battlelog-service test
- pre-commit hook: passed

Note: initial verification required `pnpm install` because this fresh worktree had no node_modules; pnpm reported pending third-party build-script approvals, but the relevant checks passed after workspace package builds.