### PR TITLE
[codex] refactor guild context setter

### DIFF
--- a/apps/web/src/contexts/guild.context.tsx
+++ b/apps/web/src/contexts/guild.context.tsx
@@ -1,5 +1,5 @@
 import { useGuildId } from "@/hooks/context/use-guild-id";
-import React, { createContext, useState, useCallback } from "react";
+import React, { createContext, useState } from "react";
 
 type Props = {
   children: React.ReactNode;
@@ -43,13 +43,10 @@ const GuildContextProviderContent: React.FC<
     getStoredWorld(guildId),
   );
 
-  const setWorld = useCallback(
-    (newWorld: string) => {
-      setWorldState(newWorld);
-      saveWorld(guildId, newWorld);
-    },
-    [guildId],
-  );
+  const setWorld = (newWorld: string) => {
+    setWorldState(newWorld);
+    saveWorld(guildId, newWorld);
+  };
 
   return (
     <GuildContext.Provider value={{ world, setWorld }}>


### PR DESCRIPTION
## Summary

- remove manual `useCallback` memoization from the guild context `setWorld` setter
- keep the existing state update and localStorage persistence behavior unchanged

## Verification

- `pnpm --filter @lootlog/web lint`
- `pnpm format:check -- apps/web/src/contexts/guild.context.tsx`
- `pnpm turbo run build --filter=@lootlog/web...`
- pre-commit hook: changed-package lint, formatting check, and tests

## Notes

A direct `pnpm --filter @lootlog/web build` fails in a fresh worktree because workspace dependency build outputs are missing; the dependency-aware Turbo build succeeds.
