### PR TITLE
[codex] refactor search Meilisearch query setup

### DIFF
--- a/apps/search/src/meilisearch/meilisearch.utils.spec.ts
+++ b/apps/search/src/meilisearch/meilisearch.utils.spec.ts
@@ -1,4 +1,5 @@
 import {
+  buildMeilisearchSearchTermFilter,
   buildMeilisearchStringInFilter,
   getMeilisearchErrorCode,
 } from "./meilisearch.utils";
@@ -32,5 +33,28 @@ describe("buildMeilisearchStringInFilter", () => {
     expect(buildMeilisearchStringInFilter("name", ['Hero "The One"'])).toBe(
       'name IN ["Hero \\"The One\\""]',
     );
+  });
+});
+
+describe("buildMeilisearchSearchTermFilter", () => {
+  it("uses the search string as the Meilisearch term", () => {
+    expect(buildMeilisearchSearchTermFilter("name", "Hero")).toEqual({
+      searchTerm: "Hero",
+    });
+  });
+
+  it("uses an IN filter for multiple exact search values", () => {
+    expect(
+      buildMeilisearchSearchTermFilter("name", ["Hero", "Villain"]),
+    ).toEqual({
+      searchTerm: "",
+      filter: 'name IN ["Hero", "Villain"]',
+    });
+  });
+
+  it("uses an empty search term when search is omitted", () => {
+    expect(buildMeilisearchSearchTermFilter("name", undefined)).toEqual({
+      searchTerm: "",
+    });
   });
 });

--- a/apps/search/src/meilisearch/meilisearch.utils.ts
+++ b/apps/search/src/meilisearch/meilisearch.utils.ts
@@ -18,3 +18,19 @@ export function buildMeilisearchStringInFilter(
 
   return `${fieldName} IN [${formattedValues.join(", ")}]`;
 }
+
+export function buildMeilisearchSearchTermFilter(
+  fieldName: string,
+  search: string | string[] | undefined,
+): { searchTerm: string; filter?: string } {
+  if (Array.isArray(search)) {
+    return {
+      searchTerm: "",
+      filter: buildMeilisearchStringInFilter(fieldName, search),
+    };
+  }
+
+  return {
+    searchTerm: search ?? "",
+  };
+}

--- a/apps/search/src/npcs/npcs.service.ts
+++ b/apps/search/src/npcs/npcs.service.ts
@@ -5,7 +5,7 @@ import type { Logger } from "winston";
 import type { Meilisearch, SearchParams } from "meilisearch";
 import type { z } from "zod";
 import { MEILISEARCH_CLIENT } from "src/meilisearch/meilisearch.constants";
-import { buildMeilisearchStringInFilter } from "src/meilisearch/meilisearch.utils";
+import { buildMeilisearchSearchTermFilter } from "src/meilisearch/meilisearch.utils";
 import type { GetNpcsDto } from "./dto/get-npcs.dto";
 import { NPCS_INDEX } from "./constants/meilisearch";
 import type { IndexNpcsDto } from "./dto/index-npcs.dto";
@@ -22,13 +22,13 @@ export class NpcsService {
 
   async getNpcs({ ids, limit, search, world }: GetNpcsDto) {
     const index = this.meilisearch.index<NpcHit>(NPCS_INDEX);
-    const hasMultipleSearchTerms = Array.isArray(search);
-    const searchTerm = hasMultipleSearchTerms ? "" : (search ?? "");
+    const { filter: searchFilter, searchTerm } =
+      buildMeilisearchSearchTermFilter("name", search);
 
     const filters: string[] = [];
 
-    if (hasMultipleSearchTerms) {
-      filters.push(buildMeilisearchStringInFilter("name", search));
+    if (searchFilter) {
+      filters.push(searchFilter);
     }
 
     if (ids && ids.length > 0) {

--- a/apps/search/src/players/players.service.ts
+++ b/apps/search/src/players/players.service.ts
@@ -4,7 +4,7 @@ import type { Logger } from "winston";
 import type { Meilisearch, SearchParams } from "meilisearch";
 import type { z } from "zod";
 import { MEILISEARCH_CLIENT } from "src/meilisearch/meilisearch.constants";
-import { buildMeilisearchStringInFilter } from "src/meilisearch/meilisearch.utils";
+import { buildMeilisearchSearchTermFilter } from "src/meilisearch/meilisearch.utils";
 import type { GetPlayersDto } from "./dto/get-players.dto";
 import { PLAYERS_INDEX } from "./constants/meilisearch";
 import type { IndexPlayersDto } from "./dto/index-players.dto";
@@ -21,13 +21,13 @@ export class PlayersService {
 
   async getPlayers({ limit, search, world }: GetPlayersDto) {
     const index = this.meilisearch.index<PlayerHit>(PLAYERS_INDEX);
-    const hasMultipleSearchTerms = Array.isArray(search);
-    const searchTerm = hasMultipleSearchTerms ? "" : (search ?? "");
+    const { filter: searchFilter, searchTerm } =
+      buildMeilisearchSearchTermFilter("name", search);
 
     const filters: string[] = [];
 
-    if (hasMultipleSearchTerms) {
-      filters.push(buildMeilisearchStringInFilter("name", search));
+    if (searchFilter) {
+      filters.push(searchFilter);
     }
 
     if (world) {


### PR DESCRIPTION
## Summary

- Extracted shared Meilisearch search term/filter setup into `buildMeilisearchSearchTermFilter`.
- Updated NPC and player search services to use the shared helper while preserving existing query behavior.
- Added utility tests for single-term, multi-term, and omitted search input handling.

## Verification

- `pnpm exec oxfmt --check apps/search/src/meilisearch/meilisearch.utils.ts apps/search/src/meilisearch/meilisearch.utils.spec.ts apps/search/src/players/players.service.ts apps/search/src/npcs/npcs.service.ts`
- `pnpm --filter @lootlog/search test`
- `pnpm --filter @lootlog/search build`
- `pnpm exec oxlint apps/search/src/meilisearch/meilisearch.utils.ts apps/search/src/meilisearch/meilisearch.utils.spec.ts apps/search/src/players/players.service.ts apps/search/src/npcs/npcs.service.ts`
- pre-commit hook: passed