### PR TITLE
[codex] Use nullish fallbacks in settings

### DIFF
--- a/apps/game-client/src/features/settings/components/catching/catching-settings-form.tsx
+++ b/apps/game-client/src/features/settings/components/catching/catching-settings-form.tsx
@@ -69,10 +69,10 @@ export const CatchingSettingsForm: FC<CatchingSettingsFormProps> = ({
 
   mutateRef.current = updateLootlogCharacterConfig;
   onSelectionChangeRef.current = onSelectionChange;
-  const selectedGuildIds = watch("catchingGuildIds") || [];
+  const selectedGuildIds = watch("catchingGuildIds") ?? [];
 
   useEffect(() => {
-    const nextCatchingGuildIds = configByCharacterId?.catchingGuildIds || [];
+    const nextCatchingGuildIds = configByCharacterId?.catchingGuildIds ?? [];
 
     isResettingRef.current = true;
     reset({
@@ -100,7 +100,7 @@ export const CatchingSettingsForm: FC<CatchingSettingsFormProps> = ({
       }
 
       debounceTimerRef.current = setTimeout(() => {
-        const catchingGuildIds = (value.catchingGuildIds || []).filter(
+        const catchingGuildIds = (value.catchingGuildIds ?? []).filter(
           (id): id is string => typeof id === "string",
         );
 

--- a/apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx
+++ b/apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx
@@ -34,7 +34,7 @@ export const HiddenColorsList: FC<HiddenColorsListProps> = ({
           >
             <div className="ll:flex-1 ll:flex ll:flex-col ll:justify-between ll:h-full">
               <span className="ll:text-xs ll:font-medium ll:truncate">
-                {colorNames[colorId] || getDefaultColorName(colorId)}
+                {colorNames[colorId] ?? getDefaultColorName(colorId)}
               </span>
               <Tile
                 color={colorId as keyof typeof TIMERS_COLORS}

--- a/apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx
+++ b/apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx
@@ -56,17 +56,17 @@ export const TimersSettingsColors: FC = () => {
 
   const handleEditDefaultColor = (colorId: string) => {
     const overridden = overriddenDefaultColors[colorId];
-    const defaultColors = TAILWIND_TO_HEX[colorId] || {
+    const defaultColors = TAILWIND_TO_HEX[colorId] ?? {
       border: "#3b82f6",
       background: "#3b82f620",
     };
 
-    const bgColor = overridden?.backgroundColor || defaultColors.background;
+    const bgColor = overridden?.backgroundColor ?? defaultColors.background;
 
     setEditingDefaultColor(colorId);
     setEditingDefaultColorData({
-      name: defaultColorNames[colorId] || getDefaultColorName(colorId) || "",
-      borderColor: overridden?.borderColor || defaultColors.border,
+      name: defaultColorNames[colorId] ?? getDefaultColorName(colorId) ?? "",
+      borderColor: overridden?.borderColor ?? defaultColors.border,
       backgroundColor: stripAlphaChannel(bgColor),
       backgroundAlpha: hexToAlpha(bgColor),
     });


### PR DESCRIPTION
## Summary
- Replaced truthy fallback checks with nullish coalescing in game-client catching settings.
- Applied the same fallback style to timer default color editing and hidden default color labels.

## Verification
- `pnpm exec oxfmt --check apps/game-client/src/features/settings/components/catching/catching-settings-form.tsx apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx`
- `pnpm exec oxlint apps/game-client/src/features/settings/components/catching/catching-settings-form.tsx apps/game-client/src/features/settings/components/timers/timers-settings-colors.tsx apps/game-client/src/features/settings/components/timers/components/hidden-colors-list.tsx`
- `pnpm turbo run build --filter=@lootlog/game-client...`
- `pnpm --filter @lootlog/game-client test`
- `pnpm format:check`
- Commit hooks passed, including lint-staged and the changed-package test path.