### PR TITLE
[codex] remove api auth error barrel

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -4,12 +4,10 @@ import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import type { Logger } from "winston";
 import { firstValueFrom } from "rxjs";
 import type { GetIdpTokenResponse } from "src/auth/types/get-idp-token-response.type";
-import {
-  TokenExpiredError,
-  AuthServiceUnavailableError,
-  AccountNotFoundError,
-  AuthBadRequestError,
-} from "src/auth/errors";
+import { AccountNotFoundError } from "src/auth/errors/account-not-found.error";
+import { AuthBadRequestError } from "src/auth/errors/auth-bad-request.error";
+import { AuthServiceUnavailableError } from "src/auth/errors/auth-service-unavailable.error";
+import { TokenExpiredError } from "src/auth/errors/token-expired.error";
 import { authConfig } from "src/config/auth.config";
 import { RedisService } from "@lootlog/nest-shared/redis";
 import {

--- a/apps/api/src/auth/errors/index.ts
+++ b/apps/api/src/auth/errors/index.ts
@@ -1,5 +1,0 @@
-export { TokenExpiredError } from "./token-expired.error";
-export { AuthServiceUnavailableError } from "./auth-service-unavailable.error";
-export { InvalidScopesError } from "./invalid-scopes.error";
-export { AccountNotFoundError } from "./account-not-found.error";
-export { AuthBadRequestError } from "./auth-bad-request.error";

--- a/apps/api/src/discord/discord-rest-client.factory.ts
+++ b/apps/api/src/discord/discord-rest-client.factory.ts
@@ -8,13 +8,11 @@ import {
 import { createHash } from "node:crypto";
 import { DISCORD_AUTH_SCOPES } from "@lootlog/types";
 import { AuthService } from "src/auth/auth.service";
-import {
-  AccountNotFoundError,
-  AuthBadRequestError,
-  AuthServiceUnavailableError,
-  InvalidScopesError,
-  TokenExpiredError,
-} from "src/auth/errors";
+import { AccountNotFoundError } from "src/auth/errors/account-not-found.error";
+import { AuthBadRequestError } from "src/auth/errors/auth-bad-request.error";
+import { AuthServiceUnavailableError } from "src/auth/errors/auth-service-unavailable.error";
+import { InvalidScopesError } from "src/auth/errors/invalid-scopes.error";
+import { TokenExpiredError } from "src/auth/errors/token-expired.error";
 
 interface CachedDiscordRestClient {
   expiresAt: number;

--- a/apps/api/src/discord/discord.service.spec.ts
+++ b/apps/api/src/discord/discord.service.spec.ts
@@ -18,11 +18,9 @@ import { RedisService } from "@lootlog/nest-shared/redis";
 import { DiscordRateLimiterService } from "./discord-rate-limiter.service";
 import { DiscordSyncDiagnosticsService } from "./discord-sync-diagnostics.service";
 import { RedlockService } from "src/lib/redlock/redlock.service";
-import {
-  TokenExpiredError,
-  AuthServiceUnavailableError,
-  InvalidScopesError,
-} from "src/auth/errors";
+import { AuthServiceUnavailableError } from "src/auth/errors/auth-service-unavailable.error";
+import { InvalidScopesError } from "src/auth/errors/invalid-scopes.error";
+import { TokenExpiredError } from "src/auth/errors/token-expired.error";
 import type { APIGuild, APIGuildMember } from "discord-api-types/v10";
 import { DISCORD_AUTH_SCOPES } from "@lootlog/types";
 


### PR DESCRIPTION
## Summary

- Removed the re-export-only `apps/api/src/auth/errors/index.ts` wrapper.
- Updated API auth and Discord imports to reference the concrete auth error modules directly.

## Validation

- `pnpm --filter @lootlog/api format`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm --filter @lootlog/api test`
- `pnpm --filter @lootlog/api build`
- Pre-commit changed-package checks passed during commit.