### PR TITLE
[codex] Remove nest-shared utils wrapper

### DIFF
--- a/apps/api/src/guilds/guilds.service.ts
+++ b/apps/api/src/guilds/guilds.service.ts
@@ -32,7 +32,7 @@ import { generateSlug } from "src/shared/utils/generate-slug";
 import { RESTRICTED_VANITY_URLS } from "src/guilds/constants/restricted-vanity-urls";
 import { DiscordService } from "src/discord/discord.service";
 import { RedisService } from "@lootlog/nest-shared/redis";
-import { isDiscordAdministrator } from "@lootlog/nest-shared/utils";
+import { isDiscordAdministrator } from "@lootlog/nest-shared";
 import {
   getPermissionsCachePattern,
   getGuildCacheKey,

--- a/apps/api/src/guilds/user-guild-access-resolver.service.ts
+++ b/apps/api/src/guilds/user-guild-access-resolver.service.ts
@@ -1,6 +1,6 @@
 import { HttpException, HttpStatus, Inject, Injectable } from "@nestjs/common";
 import type { APIGuild } from "discord-api-types/v10";
-import { isDiscordAdministrator } from "@lootlog/nest-shared/utils";
+import { isDiscordAdministrator } from "@lootlog/nest-shared";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import type { Logger } from "winston";
 import { DiscordService } from "src/discord/discord.service";

--- a/apps/discord-bot/src/bot/discord-sync.service.ts
+++ b/apps/discord-bot/src/bot/discord-sync.service.ts
@@ -11,7 +11,7 @@ import {
   type DiscordGuildSyncState,
   type DiscordGuildSyncStateUpdatedEvent,
 } from "@lootlog/types";
-import { isDiscordAdministrator } from "@lootlog/nest-shared/utils";
+import { isDiscordAdministrator } from "@lootlog/nest-shared";
 import {
   ChannelType,
   Client,

--- a/packages/nest-shared/package.json
+++ b/packages/nest-shared/package.json
@@ -31,10 +31,6 @@
       "types": "./dist/redis/index.d.ts",
       "default": "./dist/redis/index.js"
     },
-    "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "default": "./dist/utils/index.js"
-    },
     "./validators": {
       "types": "./dist/validators/index.d.ts",
       "default": "./dist/validators/index.js"

--- a/packages/nest-shared/src/utils/index.ts
+++ b/packages/nest-shared/src/utils/index.ts
@@ -1,1 +1,0 @@
-export { isDiscordAdministrator } from "./discord";


### PR DESCRIPTION
## Summary

- Remove the re-export-only `@lootlog/nest-shared/utils` wrapper.
- Import `isDiscordAdministrator` from the existing `@lootlog/nest-shared` root export in API and Discord bot consumers.
- Drop the now-unused `./utils` package export.

## Verification

- `pnpm exec oxfmt --check apps/api/src/guilds/guilds.service.ts apps/api/src/guilds/user-guild-access-resolver.service.ts apps/discord-bot/src/bot/discord-sync.service.ts packages/nest-shared/package.json`
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --filter @lootlog/api-helpers build`
- `pnpm --filter @lootlog/api build`
- `pnpm --filter @lootlog/discord-bot build`
- `pnpm --filter @lootlog/api lint` (existing warnings only, 0 errors)
- `pnpm --filter @lootlog/discord-bot lint`
- `pnpm --filter @lootlog/api test -- guilds`
- `pnpm --filter @lootlog/discord-bot test -- discord-sync`
- Pre-commit checks passed during `git commit`.
