### PR TITLE
[codex] refactor cli seed fallbacks

### DIFF
--- a/packages/cli/src/commands/seed/generators/battles-generator.ts
+++ b/packages/cli/src/commands/seed/generators/battles-generator.ts
@@ -1,6 +1,6 @@
-import { readFile } from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +9,7 @@ type BattlePayload = {
   accountId: string;
   characterId: string;
   world: string;
-  events: any[];
+  events: unknown[];
 };
 
 export class BattlesGenerator {
@@ -21,7 +21,7 @@ export class BattlesGenerator {
       "../../../../../../example-data/sample-battlelog-payload.json",
     );
     const sampleData = await readFile(samplePath, "utf-8");
-    this.samplePayload = JSON.parse(sampleData);
+    this.samplePayload = JSON.parse(sampleData) as BattlePayload;
   }
 
   generateSingle(characterId: string, accountId: string): BattlePayload {
@@ -35,7 +35,7 @@ export class BattlesGenerator {
     return {
       accountId,
       characterId,
-      world: randomWorld || "gordion",
+      world: randomWorld ?? "gordion",
       events: this.samplePayload.events,
     };
   }

--- a/packages/cli/src/commands/seed/generators/guild-generator.ts
+++ b/packages/cli/src/commands/seed/generators/guild-generator.ts
@@ -79,7 +79,7 @@ export class GuildGenerator {
     return {
       id,
       name,
-      color: color || 0,
+      color: color ?? 0,
       position,
       permissions,
       lvlRangeFrom,


### PR DESCRIPTION
## Summary
- Use nullish coalescing for CLI seed generator fallbacks so valid falsy values are not treated as missing.
- Tighten the battle seed payload type from any[] to unknown[] and switch Node built-in imports to node: specifiers.

## Verification
- pnpm --filter @lootlog/cli test
- pnpm exec oxlint packages/cli/src/commands/seed/generators/battles-generator.ts packages/cli/src/commands/seed/generators/guild-generator.ts
- pnpm exec oxfmt --check packages/cli/src/commands/seed/generators/battles-generator.ts packages/cli/src/commands/seed/generators/guild-generator.ts
- git diff --check
- git commit hook: lint-staged, turbo lint/format:test filters, and @lootlog/cli test

## Notes
- pnpm install was needed because node_modules was missing in this worktree; pnpm reported ignored dependency build scripts per workspace policy, but required JS tooling installed and verification completed.