### PR TITLE
[codex] Fix search item results

### DIFF
--- a/apps/search/src/items/items.service.spec.ts
+++ b/apps/search/src/items/items.service.spec.ts
@@ -73,10 +73,10 @@ describe("ItemsService", () => {
           "lvl",
           "rarity",
           "type",
+          "world",
           "worlds",
         ],
-        distinct: "id",
-        filter: 'worlds = "Berufs"',
+        filter: '(worlds = "Berufs" OR world = "Berufs")',
       });
     });
 
@@ -135,11 +135,11 @@ describe("ItemsService", () => {
           "lvl",
           "rarity",
           "type",
+          "world",
           "worlds",
         ],
-        distinct: "id",
         filter:
-          'numericStats.dmg >= 40 AND requiredProfessions = "w" AND worlds = "Berufs"',
+          'numericStats.dmg >= 40 AND requiredProfessions = "w" AND (worlds = "Berufs" OR world = "Berufs")',
         facets: ["rarity", "requiredProfessions"],
         sort: ["lvl:desc"],
       });
@@ -214,9 +214,9 @@ describe("ItemsService", () => {
           "lvl",
           "rarity",
           "type",
+          "world",
           "worlds",
         ],
-        distinct: "id",
       });
       expect(indexMock.search).toHaveBeenNthCalledWith(2, "sword", {
         limit: 10,
@@ -230,9 +230,9 @@ describe("ItemsService", () => {
           "lvl",
           "rarity",
           "type",
+          "world",
           "worlds",
         ],
-        distinct: "id",
       });
       expect(loggerMock.warn).toHaveBeenCalledWith(
         "Items index settings are stale, retrying search without stat attribute",

--- a/apps/search/src/items/items.service.ts
+++ b/apps/search/src/items/items.service.ts
@@ -33,8 +33,15 @@ const itemAttributesToRetrieve = [
   "lvl",
   "rarity",
   "type",
+  "world",
   "worlds",
 ];
+
+const buildItemWorldFilter = (world: string) => {
+  const formattedWorld = JSON.stringify(world);
+
+  return `(worlds = ${formattedWorld} OR world = ${formattedWorld})`;
+};
 
 @Injectable()
 export class ItemsService {
@@ -64,7 +71,7 @@ export class ItemsService {
 
     const filters = [
       ...incomingFilters,
-      ...(world ? [`worlds = ${JSON.stringify(world)}`] : []),
+      ...(world ? [buildItemWorldFilter(world)] : []),
     ];
 
     const query: SearchParams = {
@@ -72,7 +79,6 @@ export class ItemsService {
       offset,
       attributesToSearchOn: ["name", "stat"],
       attributesToRetrieve: itemAttributesToRetrieve,
-      distinct: "id",
       ...(facets && facets.length > 0 ? { facets } : {}),
       ...(filters.length > 0 ? { filter: filters.join(" AND ") } : {}),
       ...(sort && sort.length > 0 ? { sort } : {}),

--- a/apps/search/src/meilisearch/meilisearch-indexes.service.spec.ts
+++ b/apps/search/src/meilisearch/meilisearch-indexes.service.spec.ts
@@ -136,6 +136,7 @@ describe("MeilisearchIndexesService", () => {
         "world",
       ]);
       expect(itemsIndexMock.updateFilterableAttributes).toHaveBeenCalledWith([
+        "world",
         "worlds",
         "type",
         "rarity",

--- a/apps/search/src/meilisearch/meilisearch-indexes.service.ts
+++ b/apps/search/src/meilisearch/meilisearch-indexes.service.ts
@@ -13,6 +13,7 @@ import { MEILISEARCH_CLIENT } from "./meilisearch.constants";
 import { getMeilisearchErrorCode } from "./meilisearch.utils";
 
 const itemFilterableAttributes = [
+  "world",
   "worlds",
   "type",
   "rarity",

--- a/apps/search/src/scripts/seed.ts
+++ b/apps/search/src/scripts/seed.ts
@@ -154,6 +154,7 @@ async function setupIndexes() {
 
   const itemsIndex = meilisearch.index(ITEMS_INDEX);
   const itemsFilterTask = await itemsIndex.updateFilterableAttributes([
+    "world",
     "worlds",
     "type",
     "rarity",


### PR DESCRIPTION
## Summary

Fixes item search returning empty results from the search service even when Meilisearch has matching item documents.

## Root Cause

`ItemsService` passed `distinct: "id"` in per-query search params. Meilisearch rejects that because `id` is not filterable, and the service caught the error and returned an empty fallback response. This made `/items` and `/all` look like they had no item matches.

## Changes

- Removed per-query `distinct` from item search; the index already uses `distinctAttribute: "id"`.
- Kept item world filtering compatible with both `worlds` and older `world` document shapes.
- Added `world` to item filterable attributes in bootstrap and seed setup.
- Updated search service tests to cover the corrected query shape.

## Validation

- `pnpm --filter @lootlog/search test -- items.service.spec.ts meilisearch-indexes.service.spec.ts all.service.spec.ts`
- `pnpm --filter @lootlog/search build`
- Pre-commit hook ran full `@lootlog/search` test suite: 15 files, 62 tests passed.
- Verified locally that `http://localhost:4002/all?search=sk&world=gordion` returns item results.