### PR TITLE
[codex] Adjust whoIsHere Lootlog highlight

### DIFF
--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx
@@ -207,6 +207,12 @@ describe("useWhoIsHereLootlogHighlight", () => {
     expect(row.style.getPropertyValue("--ll-who-is-here-lootlog-color")).toBe(
       LOOTLOG_OTHER_GLOW_BLUE,
     );
+    const style = document.getElementById("ll-who-is-here-lootlog-style");
+    expect(style?.textContent).toContain(
+      "border: 1px solid var(--ll-who-is-here-lootlog-color)",
+    );
+    expect(style?.textContent).not.toContain("border-left");
+    expect(style?.textContent).not.toContain("inset 2px");
   });
 
   it("highlights a whoIsHere row red-orange when selected guild does not catch the player", async () => {

--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
@@ -76,8 +76,8 @@ function installStyle(): () => void {
   style.id = STYLE_ELEMENT_ID;
   style.textContent = `
     .${HIGHLIGHT_CLASS} {
-      border-left: 2px solid var(${WHO_IS_HERE_COLOR_PROPERTY});
-      box-shadow: inset 2px 0 0 var(${WHO_IS_HERE_COLOR_PROPERTY});
+      border: 1px solid var(${WHO_IS_HERE_COLOR_PROPERTY});
+      box-sizing: border-box;
     }
 
     .${HIGHLIGHT_CLASS} .center,


### PR DESCRIPTION
## Summary

Adjusts the Lootlog highlight in Margonem `whoIsHere` rows so it uses a thin border around the whole row instead of a thick-looking left-side marker.

The text color still follows the same Lootlog blue/red-orange status colors as before.

## Validation

- `pnpm --filter @lootlog/game-client exec vitest run src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx`
- `pnpm --filter @lootlog/game-client build`

Pre-commit also ran the changed game-client checks successfully.