### PR TITLE
[codex] Use shadow outline for whoIsHere highlight

### DIFF
--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx
@@ -209,10 +209,13 @@ describe("useWhoIsHereLootlogHighlight", () => {
     );
     const style = document.getElementById("ll-who-is-here-lootlog-style");
     expect(style?.textContent).toContain(
-      "border: 1px solid var(--ll-who-is-here-lootlog-color)",
+      "0 0 0 1px var(--ll-who-is-here-lootlog-color) inset",
     );
+    expect(style?.textContent).toContain(
+      "0 0 0 1px var(--ll-who-is-here-lootlog-color)",
+    );
+    expect(style?.textContent).not.toContain("border:");
     expect(style?.textContent).not.toContain("border-left");
-    expect(style?.textContent).not.toContain("inset 2px");
   });
 
   it("highlights a whoIsHere row red-orange when selected guild does not catch the player", async () => {

--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
@@ -76,8 +76,9 @@ function installStyle(): () => void {
   style.id = STYLE_ELEMENT_ID;
   style.textContent = `
     .${HIGHLIGHT_CLASS} {
-      border: 1px solid var(${WHO_IS_HERE_COLOR_PROPERTY});
-      box-sizing: border-box;
+      box-shadow:
+        0 0 0 1px var(${WHO_IS_HERE_COLOR_PROPERTY}) inset,
+        0 0 0 1px var(${WHO_IS_HERE_COLOR_PROPERTY});
     }
 
     .${HIGHLIGHT_CLASS} .center,


### PR DESCRIPTION
## Summary

Updates the Lootlog highlight in Margonem whoIsHere rows to use the same outline mechanism as the native UI: a box-shadow-based outline around the whole row instead of a CSS border.

The text color still follows the existing Lootlog blue/red-orange status color.

## Validation

- `pnpm --filter @lootlog/game-client exec vitest run src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx`
- `pnpm --filter @lootlog/game-client build`

Pre-commit also ran the changed game-client checks successfully.