### PR TITLE
[codex] Refresh Lootlog tooltip after batch cache updates

### DIFF
--- a/apps/game-client/src/hooks/game-events/use-character-tooltip-catching-guilds.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-character-tooltip-catching-guilds.test.tsx
@@ -9,6 +9,7 @@ import { characterTooltipTransforms } from "@/lib/margonem-tooltips/registry";
 
 const mocks = vi.hoisted(() => ({
   getPlayerCatchingGuilds: vi.fn(),
+  refreshActiveOtherCanvasTooltip: vi.fn(),
 }));
 
 vi.mock(
@@ -18,6 +19,10 @@ vi.mock(
       mocks.getPlayerCatchingGuilds,
   }),
 );
+
+vi.mock("@/lib/margonem-tooltips/patcher", () => ({
+  refreshActiveOtherCanvasTooltip: mocks.refreshActiveOtherCanvasTooltip,
+}));
 
 import { useCharacterTooltipCatchingGuilds } from "./use-character-tooltip-catching-guilds";
 
@@ -81,6 +86,7 @@ describe("useCharacterTooltipCatchingGuilds", () => {
     useCharacterTooltipCatchingGuildsStore.getState().clear();
     useOnlineCharacterOwnersStore.getState().clearOwners();
     mocks.getPlayerCatchingGuilds.mockReset();
+    mocks.refreshActiveOtherCanvasTooltip.mockReset();
   });
 
   it("fetches catching guilds on shift for the active other and caches the result", async () => {
@@ -248,6 +254,40 @@ describe("useCharacterTooltipCatchingGuilds", () => {
         characterId: "617",
       });
     });
+  });
+
+  it("refreshes the active tooltip when batch cache updates without single fetch", async () => {
+    const other = createOther();
+    renderHook(() => useCharacterTooltipCatchingGuilds(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => {
+      setOnlineOwner();
+      useCharacterTooltipCatchingGuildsStore.getState().setActiveOther(other);
+      useCharacterTooltipCatchingGuildsStore
+        .getState()
+        .setLoading("player-discord:9822301:617");
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Shift" }));
+    });
+
+    await waitFor(() => {
+      expect(mocks.refreshActiveOtherCanvasTooltip).toHaveBeenCalled();
+    });
+    mocks.refreshActiveOtherCanvasTooltip.mockClear();
+
+    act(() => {
+      useCharacterTooltipCatchingGuildsStore
+        .getState()
+        .setSuccess("player-discord:9822301:617", [
+          { id: "guild-1", name: "Alpha" },
+        ]);
+    });
+
+    await waitFor(() => {
+      expect(mocks.refreshActiveOtherCanvasTooltip).toHaveBeenCalledOnce();
+    });
+    expect(mocks.getPlayerCatchingGuilds).not.toHaveBeenCalled();
   });
 
   it("resets shift state on window blur", () => {

--- a/apps/game-client/src/hooks/game-events/use-character-tooltip-catching-guilds.ts
+++ b/apps/game-client/src/hooks/game-events/use-character-tooltip-catching-guilds.ts
@@ -29,6 +29,9 @@ export function useCharacterTooltipCatchingGuilds(): void {
   const activeTarget = useCharacterTooltipCatchingGuildsStore(
     (state) => state.activeTarget,
   );
+  const activeEntry = useCharacterTooltipCatchingGuildsStore((state) =>
+    activeTarget ? state.entriesByKey[activeTarget.key] : undefined,
+  );
   const ownersByCharacterKey = useOnlineCharacterOwnersStore(
     (state) => state.ownersByCharacterKey,
   );
@@ -98,4 +101,10 @@ export function useCharacterTooltipCatchingGuilds(): void {
       refreshActiveOtherTooltipIfCurrent(activeTarget.key);
     });
   }, [activeOther, activeTarget, isShiftPressed, queryClient]);
+
+  useEffect(() => {
+    if (!isShiftPressed || !activeTarget || !activeEntry) return;
+
+    refreshActiveOtherTooltipIfCurrent(activeTarget.key);
+  }, [activeEntry, activeTarget, isShiftPressed]);
 }

--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx
@@ -209,11 +209,9 @@ describe("useWhoIsHereLootlogHighlight", () => {
     );
     const style = document.getElementById("ll-who-is-here-lootlog-style");
     expect(style?.textContent).toContain(
-      "0 0 0 1px var(--ll-who-is-here-lootlog-color) inset",
+      "color: var(--ll-who-is-here-lootlog-color) !important",
     );
-    expect(style?.textContent).toContain(
-      "0 0 0 1px var(--ll-who-is-here-lootlog-color)",
-    );
+    expect(style?.textContent).not.toContain("box-shadow");
     expect(style?.textContent).not.toContain("border:");
     expect(style?.textContent).not.toContain("border-left");
   });

--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
@@ -75,12 +75,6 @@ function installStyle(): () => void {
   const style = document.createElement("style");
   style.id = STYLE_ELEMENT_ID;
   style.textContent = `
-    .${HIGHLIGHT_CLASS} {
-      box-shadow:
-        0 0 0 1px var(${WHO_IS_HERE_COLOR_PROPERTY}) inset,
-        0 0 0 1px var(${WHO_IS_HERE_COLOR_PROPERTY});
-    }
-
     .${HIGHLIGHT_CLASS} .center,
     .${HIGHLIGHT_CLASS} .name .inner,
     .${HIGHLIGHT_CLASS} .lvl {

--- a/apps/game-client/src/lib/margonem-tooltips/catching-guilds.test.ts
+++ b/apps/game-client/src/lib/margonem-tooltips/catching-guilds.test.ts
@@ -79,9 +79,25 @@ describe("appendCatchingGuildsTooltipSection", () => {
     ).toBe("<div>Other</div>");
   });
 
-  it("shows loading state before guilds are loaded", () => {
+  it("shows unavailable state before a cache entry exists", () => {
     useCharacterTooltipCatchingGuildsStore.getState().setShiftPressed(true);
     setOnlineOwner();
+
+    expect(
+      appendCatchingGuildsTooltipSection({
+        baseHtml: "<div>Other</div>",
+        character: createOther(),
+        currentHtml: "<div>Other</div>",
+        kind: "other",
+      }),
+    ).toContain("Brak informacji o graczu online");
+  });
+
+  it("shows loading state when the cache entry is loading", () => {
+    const store = useCharacterTooltipCatchingGuildsStore.getState();
+    store.setShiftPressed(true);
+    setOnlineOwner();
+    store.setLoading("player-discord:9822301:617");
 
     expect(
       appendCatchingGuildsTooltipSection({

--- a/apps/game-client/src/lib/margonem-tooltips/catching-guilds.ts
+++ b/apps/game-client/src/lib/margonem-tooltips/catching-guilds.ts
@@ -26,7 +26,11 @@ function buildCatchingGuildsBody(status: string, guildNames: string[]): string {
     return guildNames.map(escapeTooltipHtml).join(", ");
   }
 
-  return escapeTooltipHtml(t("characterTooltip.catchingGuilds.loading"));
+  if (status === "loading") {
+    return escapeTooltipHtml(t("characterTooltip.catchingGuilds.loading"));
+  }
+
+  return escapeTooltipHtml(t("characterTooltip.catchingGuilds.unavailable"));
 }
 
 function appendCatchingGuildsSection(


### PR DESCRIPTION
## Summary

Fixes the Lootlog SHIFT tooltip getting stuck on `Ładowanie...` when the batch request has already resolved and updated the shared cache. The active player tooltip now refreshes when its cached entry changes, so batch-only `loading -> success/error` transitions update the visible HTML without relying on the single-player endpoint.

Also removes the visual outline from native `whoIsHere` rows and keeps only the existing Lootlog text color indicator.

## Validation

- `pnpm --filter @lootlog/game-client exec vitest run src/hooks/game-events/use-character-tooltip-catching-guilds.test.tsx src/lib/margonem-tooltips/catching-guilds.test.ts src/hooks/game-events/use-who-is-here-lootlog-highlight.test.tsx`
- `pnpm --filter @lootlog/game-client test -- src/hooks/game-events src/lib/margonem-tooltips src/store`
- `pnpm --filter @lootlog/game-client build`

Pre-commit also ran the changed game-client checks successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed character tooltip refresh behavior when guild catching information updates.
  * Improved handling of loading states in guild catching tooltips—now displays appropriate messages during data retrieval.

* **Tests**
  * Enhanced test coverage for tooltip state transitions and CSS styling verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->