### PR TITLE
[codex] refactor duration parsing

### DIFF
--- a/apps/game-client/src/features/timers/helpers/add-timer-form-helpers.test.ts
+++ b/apps/game-client/src/features/timers/helpers/add-timer-form-helpers.test.ts
@@ -9,6 +9,8 @@ describe("add-timer-form-helpers", () => {
       expect(parseDurationToSeconds("1h2m3s")).toBe(3723);
       expect(parseDurationToSeconds("15m")).toBe(900);
       expect(parseDurationToSeconds("45s")).toBe(45);
+      expect(parseDurationToSeconds("2H 5S")).toBe(7205);
+      expect(parseDurationToSeconds("1h 30s")).toBe(3630);
     });
 
     it("returns zero for empty or malformed values", () => {

--- a/apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts
+++ b/apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts
@@ -11,9 +11,9 @@ export const parseDurationToSeconds = (input: string): number => {
   const match = normalizedInput.match(regex);
   if (!match) return 0;
 
-  const [, hours, minutes, seconds] = match.map(Number);
+  const [, hours = "0", minutes = "0", seconds = "0"] = match;
   const totalSeconds =
-    (hours || 0) * 3600 + (minutes || 0) * 60 + (seconds || 0);
+    Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
 
   return Math.min(totalSeconds, MAX_DURATION_SECONDS);
 };


### PR DESCRIPTION
## Summary

- Simplify timer duration parsing by defaulting missing regex captures before numeric conversion.
- Add coverage for uppercase units and omitted middle units to document existing accepted formats.

## Verification

- `pnpm --dir apps/game-client exec vitest run src/features/timers/helpers/add-timer-form-helpers.test.ts`
- `pnpm exec oxfmt --check apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts apps/game-client/src/features/timers/helpers/add-timer-form-helpers.test.ts`
- `pnpm exec oxlint apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts apps/game-client/src/features/timers/helpers/add-timer-form-helpers.test.ts`
- `pnpm --filter @lootlog/game-client build`
- pre-commit hook: lint-staged, changed package checks, and full `@lootlog/game-client` tests (`119` files, `576` tests)

Notes: `pnpm install` initially populated dependencies but exited with pnpm's ignored-builds approval prompt. Building `@lootlog/types`, `@lootlog/margonem`, and `@lootlog/socket-parser` locally resolved missing workspace `dist` artifacts before package verification.