### PR TITLE
[codex] refactor service name defaults

### DIFF
--- a/apps/auth/src/instrumentation.ts
+++ b/apps/auth/src/instrumentation.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { initObservability } from "@lootlog/instrumentation";
 
 initObservability({
-  serviceName: process.env.SERVICE_NAME || "auth",
+  serviceName: process.env.SERVICE_NAME ?? "auth",
   otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   serviceEnvironment: process.env.ENV,

--- a/apps/battlelog-service/src/instrumentation.ts
+++ b/apps/battlelog-service/src/instrumentation.ts
@@ -2,7 +2,7 @@ import { initObservability } from "@lootlog/instrumentation";
 import "dotenv/config";
 
 initObservability({
-  serviceName: process.env.SERVICE_NAME || "battlelog-service",
+  serviceName: process.env.SERVICE_NAME ?? "battlelog-service",
   otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   serviceEnvironment: process.env.ENV,


### PR DESCRIPTION
## Summary

- Align `SERVICE_NAME` fallbacks in auth and battlelog-service instrumentation with the rest of the Nest service entrypoints.
- Use nullish coalescing so an intentionally empty `SERVICE_NAME` value is preserved instead of being replaced by the service default.

## Verification

- `corepack pnpm install`
- `corepack pnpm turbo run lint --filter=@lootlog/auth --filter=@lootlog/battlelog-service`
- `corepack pnpm format:check apps/auth/src/instrumentation.ts apps/battlelog-service/src/instrumentation.ts`
- `corepack pnpm --filter @lootlog/nest-shared build`
- `corepack pnpm --filter @lootlog/api-helpers build`
- `corepack pnpm turbo run test --filter=@lootlog/auth --filter=@lootlog/battlelog-service`
- `corepack pnpm turbo run build --filter=@lootlog/auth --filter=@lootlog/battlelog-service`
- `git commit` pre-commit hook: passed lint, format task lookup, and tests for changed packages

Note: the direct workspace package builds sync pnpm injected workspace dependency copies before consumer build/test resolution.
