### PR TITLE
[codex] refactor gateway room range check

### DIFF
--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -150,10 +150,8 @@ export function getNpcTier(npc?: NpcRoutingData): TierName {
   return getNpcRoutingTier(npc);
 }
 
-export function checkLevelRange(roles: GuildRole[], npcLevel: number): boolean {
-  return roles.some(
-    (role) => role.lvlRangeFrom <= npcLevel && role.lvlRangeTo >= npcLevel,
-  );
+function isLevelWithinRoleRange(role: GuildRole, npcLevel: number): boolean {
+  return role.lvlRangeFrom <= npcLevel && role.lvlRangeTo >= npcLevel;
 }
 
 export function hasFeatureRoomAccess(
@@ -173,7 +171,7 @@ export function hasFeatureRoomAccess(
       return true;
     }
 
-    return role.lvlRangeFrom <= npcLevel && role.lvlRangeTo >= npcLevel;
+    return isLevelWithinRoleRange(role, npcLevel);
   });
 }
 


### PR DESCRIPTION
## Summary
- Replace the unused exported `checkLevelRange` helper with a private per-role range predicate.
- Reuse the predicate from `hasFeatureRoomAccess` while preserving same-role permission and level matching.

## Verification
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --dir apps/gateway exec vitest run --config ./vitest.config.ts src/gateway/utils/room-utils.spec.ts`
- `pnpm --filter @lootlog/gateway build`
- `pnpm exec oxfmt --check apps/gateway/src/gateway/utils/room-utils.ts`
- pre-commit hook: changed-package lint, format check, and full `@lootlog/gateway` tests

## Notes
- Initial dependency install exited on pnpm build-script approval prompts, but after building/reinstalling workspace outputs the targeted checks and pre-commit verification passed.