### PR TITLE
[codex] derive gateway feature room list

### DIFF
--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -38,20 +38,12 @@ const FEATURE_ROOMS = {
   },
 } as const;
 
-const ALL_FEATURE_ROOMS: Array<{ feature: FeatureName; tier: TierName }> = [
-  { feature: "chat", tier: "base" },
-  { feature: "chat", tier: "titans" },
-  { feature: "chat", tier: "heroes" },
-  { feature: "timers", tier: "base" },
-  { feature: "timers", tier: "titans" },
-  { feature: "timers", tier: "heroes" },
-  { feature: "notifications", tier: "base" },
-  { feature: "notifications", tier: "titans" },
-  { feature: "notifications", tier: "heroes" },
-  { feature: "loots", tier: "base" },
-  { feature: "loots", tier: "titans" },
-  { feature: "loots", tier: "heroes" },
-];
+const FEATURE_NAMES = Object.keys(FEATURE_ROOMS) as FeatureName[];
+const TIER_NAMES = Object.keys(FEATURE_ROOMS.chat) as TierName[];
+
+const ALL_FEATURE_ROOMS = FEATURE_NAMES.flatMap((feature) =>
+  TIER_NAMES.map((tier) => ({ feature, tier })),
+);
 
 export function buildRoomName(
   guildId: string,


### PR DESCRIPTION
## Summary
- derive `ALL_FEATURE_ROOMS` from the `FEATURE_ROOMS` permission map
- remove the duplicated hand-maintained feature/tier matrix while preserving room ordering

## Verification
- `pnpm --filter @lootlog/gateway test -- src/gateway/utils/room-utils.spec.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway build`
- `pnpm exec oxfmt --check apps/gateway/src/gateway/utils/room-utils.ts`
- pre-commit hook: lint and full `@lootlog/gateway` test task

Note: this checkout needed `pnpm install` and `pnpm --filter @lootlog/nest-shared build` first so injected workspace dependencies were available locally.