### PR TITLE
[codex] Simplify loot stats filter parameters

### DIFF
--- a/apps/api/src/loots/services/loot-stats.service.ts
+++ b/apps/api/src/loots/services/loot-stats.service.ts
@@ -130,10 +130,14 @@ export class LootStatsService {
     npcTypes?: NpcType[],
     excludeColossus?: boolean,
   ) {
-    const dateCondition = dateFrom ? `AND l."createdAt" >= $2` : "";
-    const worldCondition = world ? `AND l.world = $${dateFrom ? 3 : 2}` : "";
+    let nextParamIndex = 2;
+
+    const dateCondition = dateFrom
+      ? `AND l."createdAt" >= $${nextParamIndex++}`
+      : "";
+    const worldCondition = world ? `AND l.world = $${nextParamIndex++}` : "";
     const npcTypeCondition = npcTypes?.length
-      ? `AND ns.type = ANY($${(dateFrom ? 3 : 2) + (world ? 1 : 0)}::text[])`
+      ? `AND ns.type = ANY($${nextParamIndex}::text[])`
       : "";
     const excludeColossusCondition = excludeColossus
       ? `AND ns.type != 'COLOSSUS'`


### PR DESCRIPTION
## Summary
- Replace inline SQL placeholder arithmetic in `LootStatsService.buildFilterConditions` with an explicit `nextParamIndex` sequence.
- Keep parameter ordering aligned with `buildFilterParams` while making the optional date/world/npc-type filters easier to read.

## Validation
- `pnpm --filter @lootlog/api format`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm --filter @lootlog/api test`
- `pnpm --filter @lootlog/api build`
- Commit pre-checks passed: lint-staged, changed-package lint, changed-package build/test via Turbo.

Note: fresh checkout required building injected workspace dependencies before API tests/build could resolve internal package outputs.