### PR TITLE
[codex] Type battle event payload mapper

### DIFF
--- a/apps/game-client/src/api/battle.api.ts
+++ b/apps/game-client/src/api/battle.api.ts
@@ -1,6 +1,11 @@
 import { getApiClient } from "@/lib/api-client";
 import { runSingleLoggedAction } from "@/lib/logs/log-actions";
-import type { F, GameEvent, MatchSummary } from "@lootlog/margonem/game-events";
+import type {
+  F,
+  GameEvent,
+  MatchSummary,
+  W,
+} from "@lootlog/margonem/game-events";
 
 type KillNpcData = {
   id: number;
@@ -40,9 +45,18 @@ export async function createKill(
   return response.data;
 }
 
+export type BattleEventWarriorPayload = Pick<
+  W[string],
+  "originalId" | "name" | "lvl" | "prof" | "icon" | "team"
+>;
+
+type BattleEventFightPayload = Pick<F, "m" | "endBattle" | "init" | "auto"> & {
+  w?: Record<string, BattleEventWarriorPayload>;
+};
+
 export type BattleEventPayload = {
-  f?: Pick<F, "m" | "endBattle" | "init" | "auto" | "w">;
-  ev: number;
+  f?: BattleEventFightPayload;
+  ev?: number;
   party?: GameEvent["party"];
   match_summary?: Partial<MatchSummary>;
   matchmaking_state?: number;

--- a/apps/game-client/src/helpers/mappers/battlelog.mappers.ts
+++ b/apps/game-client/src/helpers/mappers/battlelog.mappers.ts
@@ -1,6 +1,22 @@
-import type { BattleEventPayload } from "@/api";
+import type { BattleEventPayload, BattleEventWarriorPayload } from "@/api";
 import type { GameEvent, W } from "@lootlog/margonem/game-events";
-import { isEmpty, pick } from "@/utils/object-utils";
+import { isEmpty } from "@/utils/object-utils";
+
+const mapBattleWarriorToPayload = ({
+  icon,
+  lvl,
+  name,
+  originalId,
+  prof,
+  team,
+}: W[string]): BattleEventWarriorPayload => ({
+  icon,
+  lvl,
+  name,
+  originalId,
+  prof,
+  team,
+});
 
 export const mapBattleEventsToPayload = (
   events: GameEvent[],
@@ -8,20 +24,13 @@ export const mapBattleEventsToPayload = (
   if (!events || events.length === 0) return null;
 
   const result = events.map((event) => {
-    const fightWarriors: W = {} as W;
-    Object.entries(event.f?.w || {}).forEach(([key, warrior]) => {
-      const entry = pick(warrior, [
-        "originalId",
-        "name",
-        "lvl",
-        "prof",
-        "icon",
-        "team",
-      ]);
+    const fightWarriors: Record<string, BattleEventWarriorPayload> = {};
+    Object.entries(event.f?.w ?? {}).forEach(([key, warrior]) => {
+      const entry = mapBattleWarriorToPayload(warrior);
 
       if (isEmpty(entry)) return;
 
-      fightWarriors[key] = entry as W[string];
+      fightWarriors[key] = entry;
     });
 
     const f = event.f
@@ -55,6 +64,5 @@ export const mapBattleEventsToPayload = (
     };
   });
 
-  // @ts-expect-error - Type mismatch expected
   return result;
 };


### PR DESCRIPTION
## Summary
- Typed the game-client battle event warrior payload as the reduced shape sent over the API.
- Replaced the mapper cast and `@ts-expect-error` with an explicit `mapBattleWarriorToPayload` helper.
- Marked `ev` optional to match the source `GameEvent` type and the existing mapper behavior.

## Verification
- `pnpm exec oxfmt --check apps/game-client/src/api/battle.api.ts apps/game-client/src/helpers/mappers/battlelog.mappers.ts`
- `pnpm exec oxlint apps/game-client/src/api/battle.api.ts apps/game-client/src/helpers/mappers/battlelog.mappers.ts`
- `pnpm turbo run build --filter=@lootlog/game-client...`
- `pnpm --filter @lootlog/game-client test`
- pre-commit hook: lint-staged, changed-package tests

Note: `pnpm install` returned pnpm's ignored-builds warning after installing dependencies; no repository config changes from that run are included.