### PR TITLE
[codex] remove unused guild refresh helper

### DIFF
--- a/apps/gateway/src/guilds/guilds.service.ts
+++ b/apps/gateway/src/guilds/guilds.service.ts
@@ -127,14 +127,6 @@ export class GuildsService {
     }
   }
 
-  private async refreshInBackground(
-    options: GetUserGuildsOptions,
-    cacheKey: string,
-  ): Promise<void> {
-    const guilds = await this.fetchFromHttpWithRetry(options);
-    await this.cacheGuilds(cacheKey, guilds);
-  }
-
   private async getCachedGuilds(
     cacheKey: string,
   ): Promise<CachedGuildData | null> {


### PR DESCRIPTION
## Summary

- Removed the unused private `refreshInBackground` helper from `GuildsService`.
- Kept the existing fetch, retry, cache, and stale-cache fallback paths unchanged.

## Verification

- `pnpm --filter @lootlog/gateway format`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway test -- guilds.service.spec.ts`
- `pnpm turbo run build --filter=@lootlog/gateway...`
- Pre-commit hook: lint and full gateway test task passed

## Notes

`pnpm install --frozen-lockfile` linked dependencies in this fresh worktree but exited nonzero because pnpm requires approval for third-party build scripts. The gateway checks and filtered build passed after workspace dependency outputs were built through Turborepo.