### PR TITLE
[codex] simplify npc deduplication

### DIFF
--- a/apps/search/src/npcs/npcs.service.ts
+++ b/apps/search/src/npcs/npcs.service.ts
@@ -52,16 +52,7 @@ export class NpcsService {
         return data.hits;
       }
 
-      const uniqueHits = data.hits.filter((npc, index) => {
-        const npcKey = `${npc.name}_${npc.type}`;
-
-        return (
-          data.hits.findIndex(
-            (candidate) => `${candidate.name}_${candidate.type}` === npcKey,
-          ) === index
-        );
-      });
-      return uniqueHits;
+      return this.getUniqueNpcsByNameAndType(data.hits);
     } catch (error) {
       this.logger.error("NPC search error", { error });
       return [];
@@ -103,5 +94,20 @@ export class NpcsService {
     } catch (error) {
       this.logger.error("Error indexing npcs", { error });
     }
+  }
+
+  private getUniqueNpcsByNameAndType(npcs: NpcHit[]) {
+    const seenNpcKeys = new Set<string>();
+
+    return npcs.filter((npc) => {
+      const npcKey = `${npc.name}_${npc.type}`;
+
+      if (seenNpcKeys.has(npcKey)) {
+        return false;
+      }
+
+      seenNpcKeys.add(npcKey);
+      return true;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Replace the NPC search de-duplication `findIndex` scan with a small Set-backed helper.
- Preserve the existing behavior of keeping the first hit per `name` and `type` pair.

## Verification
- `pnpm turbo run build --filter=@lootlog/search`
- `pnpm turbo run test --filter=@lootlog/search`
- `pnpm exec oxfmt --check apps/search/src/npcs/npcs.service.ts`
- Pre-commit hook: lint-staged `oxlint`/`oxfmt`, changed-package tests

Notes: `pnpm turbo run lint --filter=@lootlog/search` and `pnpm turbo run check-types --filter=@lootlog/search` are no-ops because `@lootlog/search` does not define those package scripts; `nest build` performed the TypeScript check.