### PR TITLE
[codex] refactor timer fallbacks

### DIFF
--- a/apps/game-client/src/features/timers/components/timer-color-picker.tsx
+++ b/apps/game-client/src/features/timers/components/timer-color-picker.tsx
@@ -68,7 +68,7 @@ export const TimerColorPicker: FC<TimerColorPickerProps> = ({
                 />
               </TooltipTrigger>
               <TooltipContent side="top" className="ll:text-xs">
-                {defaultColorNames[id] || getDefaultColorName(id)}
+                {defaultColorNames[id] ?? getDefaultColorName(id)}
               </TooltipContent>
             </Tooltip>
           );

--- a/apps/game-client/src/features/timers/components/timers-color-statistics.tsx
+++ b/apps/game-client/src/features/timers/components/timers-color-statistics.tsx
@@ -48,7 +48,8 @@ export const TimersColorStatistics: FC<TimersColorStatisticsProps> = ({
             colorStatistics.map((stat) => {
               const defaultColor =
                 TIMERS_COLORS[stat.color as keyof typeof TIMERS_COLORS];
-              const hasCustomColors = stat.bgColor || stat.borderColor;
+              const hasCustomColors =
+                stat.bgColor !== undefined || stat.borderColor !== undefined;
 
               return (
                 <div

--- a/apps/game-client/src/features/timers/components/timers-filters.tsx
+++ b/apps/game-client/src/features/timers/components/timers-filters.tsx
@@ -44,7 +44,7 @@ export const TimersFilters: FC<TimersFiltersProps> = ({ filtersKey }) => {
     colorFiltersEnabled,
   } = useTimersStore();
 
-  const filters = timersFilters[filtersKey] || DEFAULT_TIMERS_FILTERS;
+  const filters = timersFilters[filtersKey] ?? DEFAULT_TIMERS_FILTERS;
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTimerFiltersSearchText(e.target.value);
@@ -182,7 +182,7 @@ export const TimersFilters: FC<TimersFiltersProps> = ({ filtersKey }) => {
                     />
                   </TooltipTrigger>
                   <TooltipContent side="top" className="ll:text-xs">
-                    {defaultColorNames[colorId] || getDefaultColorName(colorId)}
+                    {defaultColorNames[colorId] ?? getDefaultColorName(colorId)}
                   </TooltipContent>
                 </Tooltip>
               );

--- a/apps/game-client/src/features/timers/timers.tsx
+++ b/apps/game-client/src/features/timers/timers.tsx
@@ -67,7 +67,9 @@ export const Timers = () => {
   const [showHiddenTimers, setShowHiddenTimers] = useState(false);
 
   const settingsKey = generalConfig.timersGrouping ? "global" : guildId;
-  const filters = timersFilters[settingsKey] || DEFAULT_TIMERS_FILTERS;
+  const filters = timersFilters[settingsKey] ?? DEFAULT_TIMERS_FILTERS;
+  const hiddenTimersForSettings = hiddenTimers[settingsKey] ?? [];
+  const pinnedTimersForSettings = pinnedTimers[settingsKey] ?? [];
 
   const rawTimers = timers ? timers : EMPTY_TIMERS;
 
@@ -119,7 +121,7 @@ export const Timers = () => {
     calculatedTimers,
     isGrouping: generalConfig.timersGrouping,
     guildId: guildId ?? "",
-    hiddenTimers: hiddenTimers[settingsKey] || [],
+    hiddenTimers: hiddenTimersForSettings,
     showHiddenTimers,
     searchText: timerFiltersSearchText ?? "",
     selectedNpcTypes: filters.selectedNpcTypes,
@@ -128,7 +130,7 @@ export const Timers = () => {
     selectedColors: filters.selectedColors,
     colorFiltersEnabled: colorFiltersEnabled ?? false,
     timersColors: timersColors as Record<string, string>,
-    pinnedTimers: pinnedTimers[settingsKey] || [],
+    pinnedTimers: pinnedTimersForSettings,
     sortOrder: timersSortOrder ?? "asc",
     expiredTimersAtBottom: true,
     removeTimerAfterMs: generalConfig.removeTimerAfterMs,
@@ -167,7 +169,7 @@ export const Timers = () => {
         <TimersContent
           sortedTimers={sortedTimers}
           settingsKey={settingsKey}
-          hiddenTimers={hiddenTimers[settingsKey] || []}
+          hiddenTimers={hiddenTimersForSettings}
           areFiltersActive={areFiltersActive}
           colorStatistics={colorStatistics}
           guildId={guildId}
@@ -212,7 +214,7 @@ export const Timers = () => {
           <TimersContent
             sortedTimers={sortedTimers}
             settingsKey={settingsKey}
-            hiddenTimers={hiddenTimers[settingsKey] || []}
+            hiddenTimers={hiddenTimersForSettings}
             areFiltersActive={areFiltersActive}
             colorStatistics={colorStatistics}
             guildId={guildId}


### PR DESCRIPTION
## Summary
- Replaced truthy timer fallback checks with nullish checks for filter state, hidden/pinned timer arrays, and default color labels.
- Reused derived timer arrays in the main timers component to avoid repeated indexed lookups.
- Made custom color detection explicit in timer color statistics.

## Verification
- pnpm exec oxfmt --check apps/game-client/src/features/timers/components/timer-color-picker.tsx apps/game-client/src/features/timers/components/timers-filters.tsx apps/game-client/src/features/timers/components/timers-color-statistics.tsx apps/game-client/src/features/timers/timers.tsx
- pnpm exec oxlint apps/game-client/src/features/timers/components/timer-color-picker.tsx apps/game-client/src/features/timers/components/timers-filters.tsx apps/game-client/src/features/timers/components/timers-color-statistics.tsx apps/game-client/src/features/timers/timers.tsx
- pnpm --filter @lootlog/types build
- pnpm --filter @lootlog/margonem build
- pnpm --filter @lootlog/socket-parser build
- pnpm --filter @lootlog/game-client build
- pnpm --dir apps/game-client exec vitest run src/features/timers/timers.test.tsx src/features/timers/utils/timers-utils.test.ts src/features/timers/components/timers-controls.test.tsx
- pre-commit hook: lint-staged, changed-package checks, and @lootlog/game-client test suite (119 files, 576 tests)

## Notes
- A first full game-client test attempt failed before internal workspace packages were built and included unrelated worker/timeouts from an overbroad manual invocation; after building workspace dependencies and using the hook flow, the changed-package suite passed.