### PR TITLE
[codex] refactor retry service defaults

### DIFF
--- a/apps/api/src/rabbitmq/retry.service.spec.ts
+++ b/apps/api/src/rabbitmq/retry.service.spec.ts
@@ -1,0 +1,85 @@
+import type { Mock } from "vitest";
+import { mockFn } from "src/test/mock-fn";
+import type { AmqpConnection } from "@golevelup/nestjs-rabbitmq";
+import type { Logger } from "winston";
+import { RETRY_EXCHANGE_NAME } from "src/config/rabbitmq.config";
+import { RetryService } from "./retry.service";
+
+describe("RetryService", () => {
+  let service: RetryService;
+  let amqp: {
+    publish: Mock;
+  };
+  let logger: {
+    log: Mock;
+  };
+
+  beforeEach(() => {
+    amqp = {
+      publish: mockFn(),
+    };
+    logger = {
+      log: mockFn(),
+    };
+    service = new RetryService(
+      logger as unknown as Logger,
+      amqp as unknown as AmqpConnection,
+    );
+  });
+
+  describe("getRetryCount", () => {
+    it("should preserve an explicit zero retry header", () => {
+      expect(service.getRetryCount({ "x-retry-count": 0 })).toBe(0);
+    });
+
+    it("should read retry count from x-death when retry header is missing", () => {
+      expect(service.getRetryCount({ "x-death": [{ count: 2 }] })).toBe(2);
+    });
+  });
+
+  describe("getRetryQueueOptions", () => {
+    it("should preserve an explicit zero retry delay", () => {
+      expect(service.getRetryQueueOptions("guild.create", 0)).toEqual({
+        durable: true,
+        messageTtl: 0,
+        deadLetterExchange: "default",
+        deadLetterRoutingKey: "guild.create",
+      });
+    });
+  });
+
+  describe("getMainQueueOptions", () => {
+    it("should fall back to the default retry exchange when config is omitted", () => {
+      expect(service.getMainQueueOptions("guild.create.retry")).toEqual({
+        durable: true,
+        deadLetterExchange: RETRY_EXCHANGE_NAME,
+        deadLetterRoutingKey: "guild.create.retry",
+      });
+    });
+  });
+
+  describe("handleRetryLogic", () => {
+    it("should send directly to DLQ when max retries is explicitly zero", async () => {
+      const shouldContinue = await service.handleRetryLogic(
+        { id: "message-1" },
+        {},
+        "guild.create.dlq",
+        "guild create",
+        { maxRetries: 0 },
+      );
+
+      expect(shouldContinue).toBe(false);
+      expect(amqp.publish).toHaveBeenCalledWith(
+        "dlx",
+        "guild.create.dlq",
+        { id: "message-1" },
+        {
+          headers: expect.objectContaining({
+            "x-final-attempt": true,
+            "x-sent-to-dlq-at": expect.any(String),
+          }),
+        },
+      );
+    });
+  });
+});

--- a/apps/api/src/rabbitmq/retry.service.ts
+++ b/apps/api/src/rabbitmq/retry.service.ts
@@ -21,6 +21,9 @@ interface RetryConfig {
   dlqExchange?: string;
 }
 
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 30000;
+
 @Injectable()
 export class RetryService {
   constructor(
@@ -30,18 +33,16 @@ export class RetryService {
 
   shouldRetry(
     headers: Record<string, unknown>,
-    maxRetries: number = 3,
+    maxRetries: number = DEFAULT_MAX_RETRIES,
   ): boolean {
     const retryCount = this.getRetryCount(headers);
     return retryCount < maxRetries;
   }
 
   getRetryCount(headers: Record<string, unknown>): number {
-    if (
-      headers["x-retry-count"] &&
-      typeof headers["x-retry-count"] === "number"
-    ) {
-      return headers["x-retry-count"];
+    const retryCount = headers["x-retry-count"];
+    if (typeof retryCount === "number") {
+      return retryCount;
     }
 
     const xDeath = headers["x-death"];
@@ -59,7 +60,7 @@ export class RetryService {
     headers: Record<string, unknown> = {},
     config: RetryConfig = {},
   ): Promise<void> {
-    const dlqExchange = config.dlqExchange || DEAD_LETTER_EXCHANGE_NAME;
+    const dlqExchange = config.dlqExchange ?? DEAD_LETTER_EXCHANGE_NAME;
 
     this.logger.log({
       level: "warn",
@@ -75,7 +76,10 @@ export class RetryService {
     });
   }
 
-  getRetryQueueOptions(mainRoutingKey: string, retryDelayMs: number = 30000) {
+  getRetryQueueOptions(
+    mainRoutingKey: string,
+    retryDelayMs: number = DEFAULT_RETRY_DELAY_MS,
+  ) {
     const mainExchange = DEFAULT_EXCHANGE_NAME;
 
     return {
@@ -89,7 +93,7 @@ export class RetryService {
   getMainQueueOptions(retryRoutingKey: string, config: RetryConfig = {}) {
     return {
       durable: true,
-      deadLetterExchange: config.retryExchange || RETRY_EXCHANGE_NAME,
+      deadLetterExchange: config.retryExchange ?? RETRY_EXCHANGE_NAME,
       deadLetterRoutingKey: retryRoutingKey,
     };
   }
@@ -102,7 +106,7 @@ export class RetryService {
     config: RetryConfig = {},
   ): Promise<boolean> {
     const retryCount = this.getRetryCount(headers);
-    const maxRetries = config.maxRetries || 3;
+    const maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
 
     if (!this.shouldRetry(headers, maxRetries)) {
       this.logger.log({
@@ -126,9 +130,9 @@ export class RetryService {
     identifier: string,
     config: RetryConfig = {},
   ): void {
-    const headers = amqpMsg.properties.headers || {};
+    const headers = amqpMsg.properties.headers ?? {};
     const currentRetryCount = this.getRetryCount(headers);
-    const retryDelayMs = config.retryDelayMs || 30000;
+    const retryDelayMs = config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
 
     this.logger.log({
       level: "info",


### PR DESCRIPTION
## Summary
- Extracted retry defaults into named constants.
- Replaced truthy fallback checks in `RetryService` with nullish/type checks so explicit zero-valued retry settings are preserved.
- Added focused unit coverage for retry count parsing, retry queue options, main queue defaults, and zero-max-retry DLQ handling.

## Verification
- `pnpm --dir apps/api exec oxfmt --check src/rabbitmq/retry.service.ts src/rabbitmq/retry.service.spec.ts`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings outside the touched files)
- `pnpm turbo run check-types --filter=@lootlog/api` (no package task configured)
- `pnpm --filter @lootlog/api build`
- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/rabbitmq/retry.service.spec.ts`
- pre-commit hook: changed-package lint/build/test pipeline, including full `@lootlog/api` test suite (`78` files, `845` tests)

Note: this worktree needed `pnpm install`; pnpm reported ignored dependency build scripts requiring approval, but the relevant API checks ran after direct workspace dependency builds synced injected package outputs.