### PR TITLE
[codex] Remove landing component barrel

### DIFF
--- a/apps/landing/src/app/page.tsx
+++ b/apps/landing/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import type { JSX } from "react";
-import { HomeContent } from "@/src/components/landing";
+import { HomeContent } from "@/src/components/landing/home-content";
 
 export const metadata: Metadata = {
   title: "Lootlog.pl - Dodatek do Margonem | Timery, Łupy, Analiza Walk",

--- a/apps/landing/src/components/landing/home-content.tsx
+++ b/apps/landing/src/components/landing/home-content.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { useTranslation } from "react-i18next";
-import {
-  LandingHeader,
-  LandingFooter,
-  HeroSection,
-  FaqPanel,
-  Testimonials,
-} from "@/src/components/landing";
+import { FaqPanel } from "@/src/components/landing/faq-panel";
+import { LandingFooter } from "@/src/components/landing/footer";
+import { LandingHeader } from "@/src/components/landing/header";
+import { HeroSection } from "@/src/components/landing/hero-section";
+import { Testimonials } from "@/src/components/landing/testimonials";
 
 export function HomeContent() {
   const { t } = useTranslation();

--- a/apps/landing/src/components/landing/index.ts
+++ b/apps/landing/src/components/landing/index.ts
@@ -1,6 +1,0 @@
-export { LandingHeader } from "./header";
-export { LandingFooter } from "./footer";
-export { HeroSection } from "./hero-section";
-export { FaqPanel } from "./faq-panel";
-export { Testimonials } from "./testimonials";
-export { HomeContent } from "./home-content";

--- a/apps/landing/src/components/policy-layout.tsx
+++ b/apps/landing/src/components/policy-layout.tsx
@@ -4,7 +4,8 @@ import type { ReactNode } from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { LandingHeader, LandingFooter } from "@/src/components/landing";
+import { LandingFooter } from "@/src/components/landing/footer";
+import { LandingHeader } from "@/src/components/landing/header";
 
 interface PolicyLayoutProps {
   children: ReactNode;


### PR DESCRIPTION
## Summary
- Replaced landing component barrel imports with direct component module imports.
- Deleted the re-export-only `apps/landing/src/components/landing/index.ts` wrapper.

## Verification
- `pnpm --filter @lootlog/landing lint`
- `pnpm --filter @lootlog/landing typecheck`
- `pnpm exec oxfmt --check apps/landing/src/components/landing/home-content.tsx apps/landing/src/components/policy-layout.tsx apps/landing/src/app/page.tsx`
- `pnpm --filter @lootlog/landing build`
- `pnpm format:check`
- `pnpm lint`
- pre-commit hook: lint-staged, changed-package lint, changed-package format/test checks

Note: `pnpm install --frozen-lockfile` linked dependencies but returned pnpm's ignored-builds policy warning; no installer artifact was committed.