### PR TITLE
[codex] simplify socket parser validation

### DIFF
--- a/packages/socket-parser/src/index.ts
+++ b/packages/socket-parser/src/index.ts
@@ -8,7 +8,19 @@ const PacketType = {
   CONNECT_ERROR: 4,
   BINARY_EVENT: 5,
   BINARY_ACK: 6,
-};
+} as const;
+
+function isValidPacketType(type: unknown): type is number {
+  return (
+    typeof type === "number" &&
+    type >= PacketType.CONNECT &&
+    type <= PacketType.BINARY_ACK
+  );
+}
+
+function isValidPacketId(id: unknown): id is number | undefined {
+  return id === undefined || typeof id === "number";
+}
 
 // Custom extension codec to handle undefined properly
 const extensionCodec = new ExtensionCodec();
@@ -33,7 +45,7 @@ interface Packet {
 }
 
 class MsgpackEncoder {
-  encode(packet: unknown) {
+  encode(packet: unknown): Uint8Array[] {
     return [encode(packet, { extensionCodec })];
   }
 }
@@ -43,13 +55,13 @@ type EventCallback = (...args: unknown[]) => void;
 class MsgpackDecoder {
   private listeners: Map<string, EventCallback[]> = new Map();
 
-  on(event: string, callback: EventCallback) {
+  on(event: string, callback: EventCallback): void {
     const callbacks = this.listeners.get(event) ?? [];
     callbacks.push(callback);
     this.listeners.set(event, callbacks);
   }
 
-  off(event: string, callback: EventCallback) {
+  off(event: string, callback: EventCallback): void {
     const callbacks = this.listeners.get(event);
     if (callbacks) {
       const index = callbacks.indexOf(callback);
@@ -60,16 +72,16 @@ class MsgpackDecoder {
   }
 
   // Alias for off() - required by Socket.IO
-  removeListener(event: string, callback: EventCallback) {
+  removeListener(event: string, callback: EventCallback): void {
     this.off(event, callback);
   }
 
   // Alias for on() - for compatibility
-  addListener(event: string, callback: EventCallback) {
+  addListener(event: string, callback: EventCallback): void {
     this.on(event, callback);
   }
 
-  private emit(event: string, ...args: unknown[]) {
+  private emit(event: string, ...args: unknown[]): void {
     const callbacks = this.listeners.get(event);
     if (callbacks) {
       for (const callback of callbacks) {
@@ -78,7 +90,7 @@ class MsgpackDecoder {
     }
   }
 
-  add(obj: Uint8Array | ArrayLike<number>) {
+  add(obj: Uint8Array | ArrayLike<number>): void {
     const input = obj instanceof Uint8Array ? obj : new Uint8Array(obj);
     const decoded = decode(input, { extensionCodec }) as Packet;
 
@@ -91,13 +103,8 @@ class MsgpackDecoder {
     this.emit("decoded", decoded);
   }
 
-  private checkPacket(decoded: Packet) {
-    const isTypeValid =
-      typeof decoded.type === "number" &&
-      decoded.type >= PacketType.CONNECT &&
-      decoded.type <= PacketType.BINARY_ACK;
-
-    if (!isTypeValid) {
+  private checkPacket(decoded: Packet): void {
+    if (!isValidPacketType(decoded.type)) {
       throw new Error("invalid packet type");
     }
 
@@ -105,14 +112,12 @@ class MsgpackDecoder {
       throw new Error("invalid namespace");
     }
 
-    const isAckValid =
-      decoded.id === undefined || typeof decoded.id === "number";
-    if (!isAckValid) {
+    if (!isValidPacketId(decoded.id)) {
       throw new Error("invalid packet id");
     }
   }
 
-  destroy() {
+  destroy(): void {
     this.listeners.clear();
   }
 }


### PR DESCRIPTION
## Summary

- Extract packet type and packet id validation helpers in `@lootlog/socket-parser`
- Mark packet type constants as immutable with `as const`
- Add explicit return types to parser encoder/decoder methods

## Verification

- `pnpm exec tsc -p packages/socket-parser/tsconfig.json --noEmit`
- `pnpm exec oxfmt --check packages/socket-parser/src/index.ts`
- `pnpm exec oxlint packages/socket-parser/src/index.ts`
- `pnpm --filter @lootlog/socket-parser build`
- `git diff --check`
- pre-commit hook: lint-staged formatting/linting passed; changed-package Turbo lint/format/test reported no package scripts to run for `@lootlog/socket-parser`

## Notes

`pnpm install` was needed because `node_modules` was absent. It completed dependency linking but reported the workspace's build-script approval gate for native packages; the focused parser checks above passed after dependencies were available.
