### PR TITLE
[codex] clarify query helper preprocessors

### DIFF
--- a/packages/nest-shared/src/validators/query-helpers.ts
+++ b/packages/nest-shared/src/validators/query-helpers.ts
@@ -1,35 +1,53 @@
 import { z } from "zod";
 
+type IntFromStringOptions = {
+  min?: number;
+  max?: number;
+};
+
 export const nonEmptyString = z.string().trim().min(1);
 
-const emptyStringToUndefined = (value: unknown) => {
+const emptyStringToUndefined = (value: unknown): unknown => {
   if (value === "") return undefined;
   return value;
 };
 
-export const booleanFromString = z.preprocess((val) => {
-  if (val === "true" || val === true) return true;
-  if (val === "false" || val === false) return false;
-  return val;
-}, z.boolean());
+const parseBooleanFromString = (value: unknown): unknown => {
+  if (value === "true" || value === true) return true;
+  if (value === "false" || value === false) return false;
+  return value;
+};
+
+const parseCommaSeparatedArray = (value: unknown): unknown[] => {
+  if (Array.isArray(value)) return value;
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((arrayValue) => arrayValue.trim())
+      .filter((arrayValue) => arrayValue.length > 0);
+  }
+
+  return [value];
+};
+
+export const booleanFromString = z.preprocess(
+  parseBooleanFromString,
+  z.boolean(),
+);
 
 export const optionalFromQuery = <T extends z.ZodTypeAny>(schema: T) =>
   z.preprocess(emptyStringToUndefined, schema.optional());
 
-export const intFromString = (opts?: { min?: number; max?: number }) => {
+export const intFromString = (opts?: IntFromStringOptions) => {
   let schema = z.coerce.number().int();
-  if (opts?.min !== undefined) schema = schema.min(opts.min);
-  if (opts?.max !== undefined) schema = schema.max(opts.max);
+  if (opts?.min !== undefined) {
+    schema = schema.min(opts.min);
+  }
+  if (opts?.max !== undefined) {
+    schema = schema.max(opts.max);
+  }
   return z.preprocess(emptyStringToUndefined, schema);
 };
 
 export const commaSeparatedArray = <T extends z.ZodTypeAny>(itemSchema: T) =>
-  z.preprocess((val) => {
-    if (Array.isArray(val)) return val;
-    if (typeof val === "string")
-      return val
-        .split(",")
-        .map((v) => v.trim())
-        .filter((v) => v.length > 0);
-    return [val];
-  }, z.array(itemSchema));
+  z.preprocess(parseCommaSeparatedArray, z.array(itemSchema));


### PR DESCRIPTION
## Summary

- Extract named preprocessors for boolean and comma-separated query values in `@lootlog/nest-shared`
- Add a small `IntFromStringOptions` type for integer coercion bounds
- Expand terse conditional assignments in `intFromString` for clearer control flow

## Verification

- `pnpm exec oxfmt --check packages/nest-shared/src/validators/query-helpers.ts`
- `pnpm exec oxlint packages/nest-shared/src/validators/query-helpers.ts`
- `pnpm turbo run build --filter=@lootlog/nest-shared...`
- `pnpm turbo run lint --filter=@lootlog/nest-shared` (no package-local lint task configured)
- `pnpm turbo run test --filter=@lootlog/nest-shared` (no package-local test task configured; dependency build replayed from cache)
- `git diff --check`
- pre-commit hook passed lint-staged formatting/linting and changed-package checks

## Notes

A direct `pnpm --filter @lootlog/nest-shared build` initially failed because `@lootlog/types` had not been built in this worktree. The Turbo build with dependency inclusion handled the workspace build order and passed.
