### PR TITLE
[codex] Remove battle action memo wrappers

### DIFF
--- a/apps/web/src/components/battle/actions/battle-action-item.tsx
+++ b/apps/web/src/components/battle/actions/battle-action-item.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@lootlog/ui/lib/utils";
-import { memo, type FC, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Trans } from "react-i18next";
 import {
   generateDynamicValuesAndComponents,
@@ -22,52 +22,48 @@ export type BattleActionItemProps = {
   dynamicValuesConfig?: DynamicValuesConfig;
 };
 
-export const BattleActionItem: FC<BattleActionItemProps> = memo(
-  ({
-    action,
-    attacker,
-    defender,
-    event,
-    className,
-    customComponents = {},
-    transformValue,
-    dynamicValuesConfig,
-  }) => {
-    const roundedValue = roundValue(action.value);
+export function BattleActionItem({
+  action,
+  attacker,
+  defender,
+  event,
+  className,
+  customComponents = {},
+  transformValue,
+  dynamicValuesConfig,
+}: BattleActionItemProps) {
+  const roundedValue = roundValue(action.value);
 
-    const processedValue = transformValue
-      ? transformValue(roundedValue, action.type)
-      : roundedValue;
+  const processedValue = transformValue
+    ? transformValue(roundedValue, action.type)
+    : roundedValue;
 
-    const dynamicData = generateDynamicValuesAndComponents(
-      action.value,
-      dynamicValuesConfig?.prefix || "v",
-      dynamicValuesConfig?.component || <span className="font-semibold" />,
-    );
+  const dynamicData = generateDynamicValuesAndComponents(
+    action.value,
+    dynamicValuesConfig?.prefix ?? "v",
+    dynamicValuesConfig?.component ?? <span className="font-semibold" />,
+  );
 
-    return (
-      <div className={cn("px-4 py-1 bg-gray-100/10", className)}>
-        <Trans
-          i18nKey={`battle.${action.type}`}
-          values={{
-            name: attacker?.name,
-            defenderName: defender?.name,
-            value: processedValue,
-            hp: roundHpPercentage(event.attackerHpPercentage),
-            defenderHp: roundHpPercentage(event.defenderHpPercentage),
-            v1: 0,
-            ...dynamicData.values,
-          }}
-          components={{
-            value: <span className="font-semibold" />,
-            ...dynamicData.components,
-            ...dynamicValuesConfig?.customComponents,
-            ...customComponents,
-          }}
-        />
-      </div>
-    );
-  },
-);
-
-BattleActionItem.displayName = "BattleActionItem";
+  return (
+    <div className={cn("px-4 py-1 bg-gray-100/10", className)}>
+      <Trans
+        i18nKey={`battle.${action.type}`}
+        values={{
+          name: attacker?.name,
+          defenderName: defender?.name,
+          value: processedValue,
+          hp: roundHpPercentage(event.attackerHpPercentage),
+          defenderHp: roundHpPercentage(event.defenderHpPercentage),
+          v1: 0,
+          ...dynamicData.values,
+        }}
+        components={{
+          value: <span className="font-semibold" />,
+          ...dynamicData.components,
+          ...dynamicValuesConfig?.customComponents,
+          ...customComponents,
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/battle/actions/battle-outcome-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-outcome-actions.tsx
@@ -2,7 +2,6 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
 import { BattleActionItem } from "./battle-action-item";
 
 export type BattleOutcomeActionsProps = {
@@ -12,26 +11,27 @@ export type BattleOutcomeActionsProps = {
   eventIndex: number;
 };
 
-export const BattleOutcomeActions: FC<BattleOutcomeActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex }) => {
-    if (actions.length === 0) return null;
+export function BattleOutcomeActions({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+}: BattleOutcomeActionsProps) {
+  if (actions.length === 0) return null;
 
-    return (
-      <>
-        {actions.map((action, sIndex) => (
-          <BattleActionItem
-            key={`outcomeActions-${eventIndex}-${sIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            customComponents={{
-              value: <span className="font-semibold" />,
-            }}
-          />
-        ))}
-      </>
-    );
-  },
-);
-
-BattleOutcomeActions.displayName = "BattleOutcomeActions";
+  return (
+    <>
+      {actions.map((action, sIndex) => (
+        <BattleActionItem
+          key={`outcomeActions-${eventIndex}-${sIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          customComponents={{
+            value: <span className="font-semibold" />,
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/web/src/components/battle/actions/battle-passive-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-passive-actions.tsx
@@ -2,9 +2,8 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
-import { BattleActionItem } from "./battle-action-item";
 import { cn } from "@lootlog/ui/lib/utils";
+import { BattleActionItem } from "./battle-action-item";
 
 export type BattlePassiveActionsProps = {
   actions: { type: string; value: string }[];
@@ -14,41 +13,43 @@ export type BattlePassiveActionsProps = {
   userTeam?: number;
 };
 
-export const BattlePassiveActions: FC<BattlePassiveActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex, userTeam }) => {
-    if (actions.length === 0) return null;
+export function BattlePassiveActions({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+  userTeam,
+}: BattlePassiveActionsProps) {
+  if (actions.length === 0) return null;
 
-    return (
-      <div
-        className={cn("py-1 bg-gray-100/10", {
-          "bg-red-400/[15%]": attacker?.team !== userTeam,
-          "bg-green-400/[15%]": attacker?.team === userTeam,
-        })}
-      >
-        {actions.map((action, sIndex) => (
-          <BattleActionItem
-            key={`passiveActions-${eventIndex}-${sIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            dynamicValuesConfig={{
-              prefix: "v",
-              component: <span className="font-semibold" />,
-            }}
-            className={cn("p-0 px-4 bg-transparent")}
-            customComponents={{
-              value: <span className="font-semibold" />,
-              heal: <span className="font-semibold text-blue-300" />,
-              poison: <span className="font-semibold text-green-400" />,
-              fire: <span className="font-semibold text-red-400" />,
-              light: <span className="font-semibold text-yellow-400" />,
-              anguish: <span className="font-semibold text-red-600" />,
-            }}
-          />
-        ))}
-      </div>
-    );
-  },
-);
-
-BattlePassiveActions.displayName = "BattlePassiveActions";
+  return (
+    <div
+      className={cn("py-1 bg-gray-100/10", {
+        "bg-red-400/[15%]": attacker?.team !== userTeam,
+        "bg-green-400/[15%]": attacker?.team === userTeam,
+      })}
+    >
+      {actions.map((action, sIndex) => (
+        <BattleActionItem
+          key={`passiveActions-${eventIndex}-${sIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          dynamicValuesConfig={{
+            prefix: "v",
+            component: <span className="font-semibold" />,
+          }}
+          className={cn("p-0 px-4 bg-transparent")}
+          customComponents={{
+            value: <span className="font-semibold" />,
+            heal: <span className="font-semibold text-blue-300" />,
+            poison: <span className="font-semibold text-green-400" />,
+            fire: <span className="font-semibold text-red-400" />,
+            light: <span className="font-semibold text-yellow-400" />,
+            anguish: <span className="font-semibold text-red-600" />,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/battle/actions/battle-spell-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-spell-actions.tsx
@@ -3,7 +3,6 @@ import type {
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
 import { cn } from "@lootlog/ui/lib/utils";
-import { memo, type FC } from "react";
 import { Trans } from "react-i18next";
 import { generateDynamicValuesAndComponents } from "../utils/dynamic-values-helper";
 import {
@@ -20,51 +19,54 @@ export type BattleSpellActionsProps = {
   userTeam?: number;
 };
 
-export const BattleSpellActions: FC<BattleSpellActionsProps> = memo(
-  ({ actions, attacker, defender, event, eventIndex, userTeam }) => {
-    if (actions.length === 0) return null;
+export function BattleSpellActions({
+  actions,
+  attacker,
+  defender,
+  event,
+  eventIndex,
+  userTeam,
+}: BattleSpellActionsProps) {
+  if (actions.length === 0) return null;
 
-    const transformValue = (value: string, type: string): string => {
-      if (type === "energy" || type === "mana") {
-        return transformAndRoundEnergyMana(value);
-      }
-      return value;
-    };
+  const transformValue = (value: string, type: string): string => {
+    if (type === "energy" || type === "mana") {
+      return transformAndRoundEnergyMana(value);
+    }
+    return value;
+  };
 
-    const teamColors = {
-      "bg-red-400/10": attacker?.team !== userTeam,
-      "bg-green-400/10": attacker?.team === userTeam,
-    };
+  const teamColors = {
+    "bg-red-400/10": attacker?.team !== userTeam,
+    "bg-green-400/10": attacker?.team === userTeam,
+  };
 
-    return (
-      <div className={cn("px-4 py-1 bg-gray-100/10", teamColors)}>
-        {actions.map((action, sIndex) => {
-          const processedValue = transformValue(action.value, action.type);
-          const dynamicData = generateDynamicValuesAndComponents(action.value);
+  return (
+    <div className={cn("px-4 py-1 bg-gray-100/10", teamColors)}>
+      {actions.map((action, sIndex) => {
+        const processedValue = transformValue(action.value, action.type);
+        const dynamicData = generateDynamicValuesAndComponents(action.value);
 
-          return (
-            <div key={`spellActions-${eventIndex}-${sIndex}`}>
-              <Trans
-                i18nKey={`battle.${action.type}`}
-                values={{
-                  name: attacker?.name,
-                  defenderName: defender?.name,
-                  value: processedValue,
-                  hp: roundHpPercentage(event.attackerHpPercentage),
-                  defenderHp: roundHpPercentage(event.defenderHpPercentage),
-                  ...dynamicData.values,
-                }}
-                components={{
-                  value: <span className="font-semibold" />,
-                  ...dynamicData.components,
-                }}
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  },
-);
-
-BattleSpellActions.displayName = "BattleSpellActions";
+        return (
+          <div key={`spellActions-${eventIndex}-${sIndex}`}>
+            <Trans
+              i18nKey={`battle.${action.type}`}
+              values={{
+                name: attacker?.name,
+                defenderName: defender?.name,
+                value: processedValue,
+                hp: roundHpPercentage(event.attackerHpPercentage),
+                defenderHp: roundHpPercentage(event.defenderHpPercentage),
+                ...dynamicData.values,
+              }}
+              components={{
+                value: <span className="font-semibold" />,
+                ...dynamicData.components,
+              }}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/battle/actions/battle-system-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-system-actions.tsx
@@ -2,7 +2,6 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
 import { BattleActionItem } from "./battle-action-item";
 
 export type BattleSystemActionsProps = {
@@ -12,26 +11,27 @@ export type BattleSystemActionsProps = {
   eventIndex: number;
 };
 
-export const BattleSystemActions: FC<BattleSystemActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex }) => {
-    if (actions.length === 0) return null;
+export function BattleSystemActions({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+}: BattleSystemActionsProps) {
+  if (actions.length === 0) return null;
 
-    return (
-      <>
-        {actions.map((action, aIndex) => (
-          <BattleActionItem
-            key={`systemActions-${eventIndex}-${aIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            customComponents={{
-              value: <span className="font-semibold" />,
-            }}
-          />
-        ))}
-      </>
-    );
-  },
-);
-
-BattleSystemActions.displayName = "BattleSystemActions";
+  return (
+    <>
+      {actions.map((action, aIndex) => (
+        <BattleActionItem
+          key={`systemActions-${eventIndex}-${aIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          customComponents={{
+            value: <span className="font-semibold" />,
+          }}
+        />
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Remove manual `memo` wrappers from battle action components so React Compiler owns memoization.
- Convert the touched components to plain exported functions and drop `displayName` assignments that only supported `memo`.
- Preserve rendered output while switching local dynamic value defaults from `||` to `??`.

## Verification
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web`
- `pnpm format:check`
- `pnpm turbo run lint '--filter=[HEAD]'`\n- `pnpm turbo run format:check '--filter=[HEAD]'` (no package task configured, no tasks executed)\n- `pnpm turbo run test '--filter=[HEAD]'`\n- Pre-commit hook passed during commit\n\n## Notes\n- Build emits existing dependency warnings from `lottie-web` direct eval and cached `tsdown` module type warnings in workspace dependency builds; no new errors.