### PR TITLE
[codex] remove nest shared middleware wrapper

### DIFF
--- a/apps/activity/src/app.module.ts
+++ b/apps/activity/src/app.module.ts
@@ -4,7 +4,7 @@ import { ZodSerializerInterceptor, ZodValidationPipe } from "nestjs-zod";
 import { WinstonModule } from "nest-winston";
 import { HealthzModule } from "src/healthz/healthz.module";
 import { ActivitiesModule } from "./activities/activities.module";
-import { LoggerMiddleware } from "@lootlog/nest-shared/middleware";
+import { LoggerMiddleware } from "@lootlog/nest-shared";
 import { winstonConfig } from "src/config/winston.config";
 
 @Module({

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,7 +3,7 @@ import { APP_INTERCEPTOR, APP_PIPE } from "@nestjs/core";
 import { ZodSerializerInterceptor, ZodValidationPipe } from "nestjs-zod";
 import { WinstonModule } from "nest-winston";
 import { BullModule } from "@nestjs/bullmq";
-import { LoggerMiddleware } from "@lootlog/nest-shared/middleware";
+import { LoggerMiddleware } from "@lootlog/nest-shared";
 import { env } from "src/config/env";
 import { winstonConfig } from "src/config/winston.config";
 import { UsersModule } from "./users/users.module";

--- a/apps/auth/src/app.module.ts
+++ b/apps/auth/src/app.module.ts
@@ -1,5 +1,5 @@
 import { Module, type MiddlewareConsumer } from "@nestjs/common";
-import { LoggerMiddleware } from "@lootlog/nest-shared/middleware";
+import { LoggerMiddleware } from "@lootlog/nest-shared";
 import { WinstonModule } from "nest-winston";
 import { winstonConfig } from "src/config/winston.config";
 import { AuthModule } from "src/auth/auth.module";

--- a/apps/battlelog-service/src/app.module.ts
+++ b/apps/battlelog-service/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module, type MiddlewareConsumer } from "@nestjs/common";
 import { APP_PIPE } from "@nestjs/core";
-import { LoggerMiddleware } from "@lootlog/nest-shared/middleware";
+import { LoggerMiddleware } from "@lootlog/nest-shared";
 import { ZodValidationPipe } from "nestjs-zod";
 import { WinstonModule } from "nest-winston";
 import { BullModule } from "@nestjs/bullmq";

--- a/apps/gateway/src/app.module.ts
+++ b/apps/gateway/src/app.module.ts
@@ -3,7 +3,7 @@ import { APP_PIPE } from "@nestjs/core";
 import { ZodValidationPipe } from "nestjs-zod";
 import { HealthzModule } from "./healthz/healthz.module";
 import { WinstonModule } from "nest-winston";
-import { LoggerMiddleware } from "@lootlog/nest-shared/middleware";
+import { LoggerMiddleware } from "@lootlog/nest-shared";
 import { GatewayModule } from "./gateway/gateway.module";
 import { winstonConfig } from "src/config/winston.config";
 

--- a/apps/search/src/app.module.ts
+++ b/apps/search/src/app.module.ts
@@ -2,7 +2,7 @@ import { Module, type MiddlewareConsumer } from "@nestjs/common";
 import { APP_INTERCEPTOR, APP_PIPE } from "@nestjs/core";
 import { WinstonModule } from "nest-winston";
 import { ZodSerializerInterceptor, ZodValidationPipe } from "nestjs-zod";
-import { LoggerMiddleware } from "@lootlog/nest-shared/middleware";
+import { LoggerMiddleware } from "@lootlog/nest-shared";
 import { winstonConfig } from "src/config/winston.config";
 import { HealthzModule } from "src/healthz/healthz.module";
 import { MeilisearchModule } from "src/meilisearch/meilisearch.module";

--- a/packages/nest-shared/package.json
+++ b/packages/nest-shared/package.json
@@ -19,10 +19,6 @@
       "types": "./dist/decorators/index.d.ts",
       "default": "./dist/decorators/index.js"
     },
-    "./middleware": {
-      "types": "./dist/middleware/index.d.ts",
-      "default": "./dist/middleware/index.js"
-    },
     "./openapi": {
       "types": "./dist/openapi/index.d.ts",
       "default": "./dist/openapi/index.js"

--- a/packages/nest-shared/src/middleware/index.ts
+++ b/packages/nest-shared/src/middleware/index.ts
@@ -1,1 +1,0 @@
-export { LoggerMiddleware } from "./logger.middleware";


### PR DESCRIPTION
## Summary
- replace internal imports of `@lootlog/nest-shared/middleware` with the existing root `@lootlog/nest-shared` export
- remove the `./middleware` package export and delete the re-export-only wrapper file

## Verification
- `pnpm exec oxfmt --check packages/nest-shared/package.json apps/gateway/src/app.module.ts apps/auth/src/app.module.ts apps/activity/src/app.module.ts apps/battlelog-service/src/app.module.ts apps/search/src/app.module.ts apps/api/src/app.module.ts`
- `pnpm exec oxlint apps/gateway/src/app.module.ts apps/auth/src/app.module.ts apps/activity/src/app.module.ts apps/battlelog-service/src/app.module.ts apps/search/src/app.module.ts apps/api/src/app.module.ts`
- `pnpm turbo run build --filter=@lootlog/nest-shared...`
- `pnpm turbo run build --filter=@lootlog/api --filter=@lootlog/auth --filter=@lootlog/activity --filter=@lootlog/battlelog-service --filter=@lootlog/gateway --filter=@lootlog/search`
- `pnpm turbo run lint --filter=@lootlog/api --filter=@lootlog/auth --filter=@lootlog/activity --filter=@lootlog/battlelog-service --filter=@lootlog/gateway --filter=@lootlog/search` (passes with existing `@lootlog/api` warnings)
- `pnpm turbo run test --filter=@lootlog/api --filter=@lootlog/auth --filter=@lootlog/activity --filter=@lootlog/battlelog-service --filter=@lootlog/gateway --filter=@lootlog/search`
- `pnpm format:check`
- `git diff --check`
- pre-commit hook passed changed-package checks during commit

Note: local `pnpm install` still exits with `ERR_PNPM_IGNORED_BUILDS` unless dependency build scripts are approved, but install populated dependencies and verification passed after the injected workspace package copy refreshed.