### PR TITLE
[codex] refactor battle outcome team fallback

### DIFF
--- a/packages/battle-processor/src/index.ts
+++ b/packages/battle-processor/src/index.ts
@@ -873,29 +873,31 @@ export class BattleProcessor {
       const dealt2 = teams.dmgDealt[t2] ?? 0;
       const taken1 = teams.dmgTaken[t1] ?? 0;
       const taken2 = teams.dmgTaken[t2] ?? 0;
+      const getDefaultOpposingTeam = (team: number): number =>
+        team === t1 ? t2 : t1;
 
       if (winningTeam === null && losingTeam === null) {
         if (alive1 !== alive2) {
           winningTeam = alive1 > alive2 ? t1 : t2;
-          losingTeam = winningTeam === t1 ? t2 : t1;
+          losingTeam = getDefaultOpposingTeam(winningTeam);
         } else if (hp1 !== hp2) {
           winningTeam = hp1 > hp2 ? t1 : t2;
-          losingTeam = winningTeam === t1 ? t2 : t1;
+          losingTeam = getDefaultOpposingTeam(winningTeam);
         } else if (dealt1 !== dealt2) {
           winningTeam = dealt1 > dealt2 ? t1 : t2;
-          losingTeam = winningTeam === t1 ? t2 : t1;
+          losingTeam = getDefaultOpposingTeam(winningTeam);
         } else if (taken1 !== taken2) {
           winningTeam = taken1 < taken2 ? t1 : t2;
-          losingTeam = winningTeam === t1 ? t2 : t1;
+          losingTeam = getDefaultOpposingTeam(winningTeam);
         } else {
           // Deterministic default
           winningTeam = t1;
           losingTeam = t2;
         }
       } else if (winningTeam === null) {
-        winningTeam = losingTeam === t1 ? t2 : t1;
+        winningTeam = getDefaultOpposingTeam(losingTeam);
       } else if (losingTeam === null) {
-        losingTeam = winningTeam === t1 ? t2 : t1;
+        losingTeam = getDefaultOpposingTeam(winningTeam);
       }
     }
 


### PR DESCRIPTION
## Summary

- Introduce a named fallback helper for deriving the opposing team while inferring battle outcomes.
- Replace repeated `team === t1 ? t2 : t1` expressions in the battle processor with the shared helper.

## Impact

This keeps the existing two-team inference behavior intact while making the fallback logic easier to scan and adjust.

## Verification

- `pnpm --filter @lootlog/battle-processor build`
- `pnpm format:check`
- `pnpm lint` (passes; existing warnings remain in unrelated packages)
- `pnpm turbo run test --filter=@lootlog/battle-processor` (no test task exists for this package)
- pre-commit hook passed for the staged source file