### PR TITLE
[codex] Normalize instrumentation service names

### DIFF
--- a/apps/auth/src/instrumentation.ts
+++ b/apps/auth/src/instrumentation.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { initObservability } from "@lootlog/instrumentation";
 
 initObservability({
-  serviceName: process.env.SERVICE_NAME || "auth",
+  serviceName: process.env.SERVICE_NAME ?? "auth",
   otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   serviceEnvironment: process.env.ENV,

--- a/apps/battlelog-service/src/instrumentation.ts
+++ b/apps/battlelog-service/src/instrumentation.ts
@@ -2,7 +2,7 @@ import { initObservability } from "@lootlog/instrumentation";
 import "dotenv/config";
 
 initObservability({
-  serviceName: process.env.SERVICE_NAME || "battlelog-service",
+  serviceName: process.env.SERVICE_NAME ?? "battlelog-service",
   otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   serviceEnvironment: process.env.ENV,

--- a/apps/battlelog-service/vitest.config.ts
+++ b/apps/battlelog-service/vitest.config.ts
@@ -16,6 +16,12 @@ export default defineConfig({
     alias: {
       "@lootlog/battle-processor":
         "../../packages/battle-processor/src/index.ts",
+      "@lootlog/nest-shared/decorators":
+        "../../packages/nest-shared/src/decorators/index.ts",
+      "@lootlog/nest-shared/redis":
+        "../../packages/nest-shared/src/redis/index.ts",
+      "@lootlog/nest-shared/validators":
+        "../../packages/nest-shared/src/validators/index.ts",
     },
     setupFiles: ["./vitest.setup.ts"],
   }),


### PR DESCRIPTION
## Summary
- use nullish fallback for auth and battlelog-service instrumentation service names
- add battlelog-service Vitest aliases for the nest-shared subpaths its specs import

## Validation
- pnpm --filter @lootlog/auth lint
- pnpm --filter @lootlog/auth test
- pnpm --filter @lootlog/battlelog-service lint
- pnpm --filter @lootlog/battlelog-service test
- pnpm turbo run build --filter=@lootlog/auth... --filter=@lootlog/battlelog-service...
- pnpm format:check apps/auth/src/instrumentation.ts apps/battlelog-service/src/instrumentation.ts apps/battlelog-service/vitest.config.ts
- pre-commit hook: lint-staged, changed-package lint, changed-package tests

Note: `pnpm install --frozen-lockfile` populated dependencies but exited nonzero because pnpm blocked unapproved dependency build scripts. Targeted validation passed after building and syncing injected workspace packages.
