### PR TITLE
[codex] simplify item image badge fallback

### DIFF
--- a/packages/ui/src/components/item-image.tsx
+++ b/packages/ui/src/components/item-image.tsx
@@ -48,11 +48,11 @@ export const ItemImage: FC<ItemImageProps> = ({
           backgroundImage: `url(${MARGONEM_CDN_ITEMS_URL}/${icon})`,
         }}
       />
-      {(shareIndex || shareIndex === 0) && (
+      {shareIndex !== undefined && (
         <div
           className="absolute -right-1 top-7 flex size-4 items-center justify-center rounded-sm text-xs font-medium shadow-sm"
           style={{
-            backgroundColor: color ? `${color}` : "var(--background)",
+            backgroundColor: color ?? "var(--background)",
           }}
         >
           {shareIndex + 1}


### PR DESCRIPTION
## Summary

- Simplifies the `ItemImage` share badge render guard to check `shareIndex` explicitly against `undefined`.
- Replaces a redundant color string interpolation with a nullish fallback.

## Verification

- `pnpm --filter @lootlog/ui lint` (passes; existing `no-img-element` warning in `packages/ui/src/components/npc-tile.tsx`)
- `pnpm exec oxfmt --check packages/ui/src/components/item-image.tsx`
- `pnpm exec turbo run check-types --filter=@lootlog/ui` (no tasks configured for package)
- `pnpm exec turbo run build --filter=@lootlog/ui` (no tasks configured for package)
- `pnpm exec turbo run test --filter=@lootlog/ui` (no tasks configured for package)
- `pnpm exec tsc -p packages/ui/tsconfig.json --noEmit` (fails on existing unrelated `ogl` export errors in `aurora.tsx` and missing `NodeJS` namespace in `bento.tsx`)
- pre-commit hook passed for the staged change
