### PR TITLE
[codex] remove manual memoization from rating delta card

### DIFF
--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/rating-delta-by-opponent-card.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/rating-delta-by-opponent-card.tsx
@@ -1,4 +1,3 @@
-import { useMemo, useCallback } from "react";
 import {
   useReactTable,
   getCoreRowModel,
@@ -38,146 +37,140 @@ export function RatingDeltaByOpponentCard({
 }: RatingDeltaByOpponentCardProps) {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const topData = useMemo(() => data.slice(0, 5), [data]);
+  const topData = data.slice(0, 5);
 
-  const handleRowClick = useCallback(
-    (opponentId: string) => {
-      if (!search.characterId) return;
+  const handleRowClick = (opponentId: string) => {
+    if (!search.characterId) return;
 
-      void navigate({
-        to: "/@me/battle-panel/statistics/player-vs-player/$myId/$opponentId",
-        params: {
-          myId: search.characterId,
-          opponentId,
-        },
-        search,
-      });
+    void navigate({
+      to: "/@me/battle-panel/statistics/player-vs-player/$myId/$opponentId",
+      params: {
+        myId: search.characterId,
+        opponentId,
+      },
+      search,
+    });
+  };
+
+  const columns: ColumnDef<RatingDeltaByOpponentRecord>[] = [
+    {
+      id: "avatar",
+      header: "",
+      cell: ({ row }) => (
+        <PlayerTile
+          player={{
+            name: row.original.opponentName,
+            lvl: row.original.opponentLvl,
+            prof: row.original.opponentProf,
+            icon: row.original.opponentIcon,
+          }}
+          className="scale-75"
+        />
+      ),
     },
-    [navigate, search],
-  );
-
-  const columns: ColumnDef<RatingDeltaByOpponentRecord>[] = useMemo(
-    () => [
-      {
-        id: "avatar",
-        header: "",
-        cell: ({ row }) => (
-          <PlayerTile
-            player={{
-              name: row.original.opponentName,
-              lvl: row.original.opponentLvl,
-              prof: row.original.opponentProf,
-              icon: row.original.opponentIcon,
-            }}
-            className="scale-75"
-          />
-        ),
-      },
-      {
-        accessorKey: "opponentName",
-        header: t("battlePanel.statistics.columns.name"),
-        cell: ({ row }) => (
-          <span className="font-medium">{row.original.opponentName}</span>
-        ),
-      },
-      {
-        accessorKey: "opponentLvl",
-        header: () => (
+    {
+      accessorKey: "opponentName",
+      header: t("battlePanel.statistics.columns.name"),
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.opponentName}</span>
+      ),
+    },
+    {
+      accessorKey: "opponentLvl",
+      header: () => (
+        <div className="text-center">
+          {t("battlePanel.statistics.columns.level")}
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-center">{row.original.opponentLvl}</div>
+      ),
+    },
+    {
+      accessorKey: "opponentProf",
+      header: () => (
+        <div className="text-center">
+          {t("battlePanel.statistics.columns.profession")}
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-center">
+          {getProfessionName(row.original.opponentProf)}
+        </div>
+      ),
+    },
+    {
+      id: "record",
+      header: () => (
+        <div className="text-center">
+          {t("battlePanel.statistics.columns.winLoss")}
+        </div>
+      ),
+      cell: ({ row }) => (
+        <div className="text-center">
+          <span className="text-green-600 font-medium">
+            {row.original.wins}
+          </span>
+          &nbsp;-&nbsp;
+          <span className="text-red-600 font-medium">
+            {row.original.losses}
+          </span>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "totalRatingDelta",
+      header: () => (
+        <div className="text-center">
+          {t("battlePanel.statistics.columns.totalRatingDelta")}
+        </div>
+      ),
+      cell: ({ row }) => {
+        const delta = row.original.totalRatingDelta;
+        const sign = delta >= 0 ? "+" : "";
+        return (
           <div className="text-center">
-            {t("battlePanel.statistics.columns.level")}
-          </div>
-        ),
-        cell: ({ row }) => (
-          <div className="text-center">{row.original.opponentLvl}</div>
-        ),
-      },
-      {
-        accessorKey: "opponentProf",
-        header: () => (
-          <div className="text-center">
-            {t("battlePanel.statistics.columns.profession")}
-          </div>
-        ),
-        cell: ({ row }) => (
-          <div className="text-center">
-            {getProfessionName(row.original.opponentProf)}
-          </div>
-        ),
-      },
-      {
-        id: "record",
-        header: () => (
-          <div className="text-center">
-            {t("battlePanel.statistics.columns.winLoss")}
-          </div>
-        ),
-        cell: ({ row }) => (
-          <div className="text-center">
-            <span className="text-green-600 font-medium">
-              {row.original.wins}
+            <span
+              className={
+                delta >= 0
+                  ? "text-green-600 font-medium"
+                  : "text-red-600 font-medium"
+              }
+            >
+              {sign}
+              {delta}
             </span>
-            &nbsp;-&nbsp;
-            <span className="text-red-600 font-medium">
-              {row.original.losses}
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "avgRatingDelta",
+      header: () => (
+        <div className="text-center">
+          {t("battlePanel.statistics.columns.avgRating")}
+        </div>
+      ),
+      cell: ({ row }) => {
+        const delta = row.original.avgRatingDelta;
+        const sign = delta >= 0 ? "+" : "";
+        return (
+          <div className="text-center">
+            <span
+              className={
+                delta >= 0
+                  ? "text-green-600 font-medium"
+                  : "text-red-600 font-medium"
+              }
+            >
+              {sign}
+              {delta.toFixed(2)}
             </span>
           </div>
-        ),
+        );
       },
-      {
-        accessorKey: "totalRatingDelta",
-        header: () => (
-          <div className="text-center">
-            {t("battlePanel.statistics.columns.totalRatingDelta")}
-          </div>
-        ),
-        cell: ({ row }) => {
-          const delta = row.original.totalRatingDelta;
-          const sign = delta >= 0 ? "+" : "";
-          return (
-            <div className="text-center">
-              <span
-                className={
-                  delta >= 0
-                    ? "text-green-600 font-medium"
-                    : "text-red-600 font-medium"
-                }
-              >
-                {sign}
-                {delta}
-              </span>
-            </div>
-          );
-        },
-      },
-      {
-        accessorKey: "avgRatingDelta",
-        header: () => (
-          <div className="text-center">
-            {t("battlePanel.statistics.columns.avgRating")}
-          </div>
-        ),
-        cell: ({ row }) => {
-          const delta = row.original.avgRatingDelta;
-          const sign = delta >= 0 ? "+" : "";
-          return (
-            <div className="text-center">
-              <span
-                className={
-                  delta >= 0
-                    ? "text-green-600 font-medium"
-                    : "text-red-600 font-medium"
-                }
-              >
-                {sign}
-                {delta.toFixed(2)}
-              </span>
-            </div>
-          );
-        },
-      },
-    ],
-    [t],
-  );
+    },
+  ];
 
   const table = useReactTable({
     data: topData,


### PR DESCRIPTION
## Summary
- Remove manual `useMemo` and `useCallback` from the rating delta opponent card.
- Keep table data, navigation, and translated column labels behavior unchanged while relying on React Compiler memoization.

## Verification
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web...`
- `pnpm exec oxfmt --check apps/web/src/features/user/battle-panel/battle-panel-statistics/components/rating-delta-by-opponent-card.tsx pnpm-workspace.yaml`
- `git diff --check`
- Commit hook ran lint-staged, changed-package lint, format check, and changed-package tests/build dependencies successfully.

Note: initial direct `pnpm --filter @lootlog/web build` failed before dependency packages were built in this fresh worktree; the scoped Turborepo build including dependencies passed.