### PR TITLE
[codex] update battle panel damage and loading states

### DIFF
--- a/apps/battlelog-service/src/battles/battle-processor.spec.ts
+++ b/apps/battlelog-service/src/battles/battle-processor.spec.ts
@@ -195,6 +195,56 @@ describe("BattleProcessor", () => {
       expect(warrior2?.isDead).toBe(true);
     });
 
+    it("should sum -dmga with post-defense damage taken by the defender", () => {
+      const battleData: CreateBattleDto = {
+        accountId: "test-account",
+        characterId: "1",
+        world: "test-world",
+        events: [
+          {
+            ev: 1000,
+            f: {
+              w: {
+                "1": {
+                  originalId: 101,
+                  name: "Warrior1",
+                  lvl: 50,
+                  prof: "w",
+                  icon: "icon1",
+                  team: 1,
+                },
+                "2": {
+                  originalId: 102,
+                  name: "Warrior2",
+                  lvl: 45,
+                  prof: "p",
+                  icon: "icon2",
+                  team: 2,
+                },
+              },
+              m: ["1=100;2=90;+dmg=20755;-dmg=20754;-dmga=2137"],
+            },
+          },
+        ],
+      };
+
+      const result = processor.processBattle(battleData);
+      const warrior1 = result.warriors.find((w) => w.name === "Warrior1");
+      const warrior2 = result.warriors.find((w) => w.name === "Warrior2");
+      const turn = result.battleTimeline[0];
+
+      expect(warrior1?.damageDealt).toBe(20755);
+      expect(warrior1?.damageDealtAfterDefensive).toBe(22891);
+      expect(warrior2?.damageTaken).toBe(22891);
+      expect(warrior2?.meleeDamageTaken).toBe(20754);
+      expect(warrior2?.auxiliaryDamageTaken).toBe(2137);
+      expect(warrior2?.flatDamageTaken).toBe(22891);
+      expect(warrior2?.maxHp).toBe(228910);
+      expect(turn?.deltas.damage).toBe(22891);
+      expect(turn?.deltas.byWarrior["1"]?.damageDealt).toBe(22891);
+      expect(turn?.deltas.byWarrior["2"]?.damageTaken).toBe(22891);
+    });
+
     it("should track critical hits and armor pierces", () => {
       const battleData: CreateBattleDto = {
         accountId: "test-account",

--- a/apps/web/src/components/battle/actions/battle-log-attack-action.spec.tsx
+++ b/apps/web/src/components/battle/actions/battle-log-attack-action.spec.tsx
@@ -73,12 +73,13 @@ const renderAttackActions = (
 };
 
 describe("BattleLogAttackActions", () => {
-  it("renders crush damage with defender data instead of raw placeholders", () => {
+  it("renders -dmga with defender data instead of raw placeholders", () => {
     const html = renderAttackActions([{ type: "-dmga", value: "982" }]);
 
     expect(html).toContain("Demodras(82.33%)");
     expect(html).toContain("-982");
-    expect(html).toContain("obrażeń od zmiażdżenia");
+    expect(html).toContain("obrażeń");
+    expect(html).not.toContain("obrażeń od zmiażdżenia");
     expect(html).not.toContain("{{defenderName}}");
     expect(html).not.toContain("&lt;dmgo&gt;");
   });
@@ -88,5 +89,19 @@ describe("BattleLogAttackActions", () => {
 
     expect(html).toContain("-Oślepienie w następnej turze");
     expect(html).toContain("text-yellow-400");
+  });
+
+  it("renders -dmga in the defender damage line without crush copy", () => {
+    const html = renderAttackActions([
+      { type: "-dmg", value: "20754" },
+      { type: "-dmga", value: "2137" },
+    ]);
+
+    expect(html).toContain("Demodras(82.33%)");
+    expect(html).toContain("-20754");
+    expect(html).toContain("-2137");
+    expect(html).toContain("obrażeń");
+    expect(html).not.toContain("obrażeń od zmiażdżenia");
+    expect(html).not.toContain("text-rose-300");
   });
 });

--- a/apps/web/src/components/battle/actions/battle-log-attack-action.tsx
+++ b/apps/web/src/components/battle/actions/battle-log-attack-action.tsx
@@ -39,6 +39,7 @@ export const BattleLogAttackActions: FC<BattleLogAttackActionsProps> = ({
             dmgl: "",
             dmg: "",
             dmgo: "",
+            dmga: "",
             dmgc: "",
             thirdatt: "",
           };
@@ -48,6 +49,7 @@ export const BattleLogAttackActions: FC<BattleLogAttackActionsProps> = ({
             dmgl: "",
             dmg: "",
             dmgo: "",
+            dmga: "",
             dmgc: "",
             thirdatt: "",
           };
@@ -72,6 +74,8 @@ export const BattleLogAttackActions: FC<BattleLogAttackActionsProps> = ({
               positiveDamage.dmg = processDamageValue(action.value, "+");
             else if (action.type === "-dmgo")
               negativeDamage.dmgo = processDamageValue(action.value, "-");
+            else if (action.type === "-dmga")
+              negativeDamage.dmga = processDamageValue(action.value, "-");
             else if (action.type === "+dmgo")
               positiveDamage.dmgo = processDamageValue(action.value, "+");
             else if (action.type === "+dmgc")
@@ -100,6 +104,7 @@ export const BattleLogAttackActions: FC<BattleLogAttackActionsProps> = ({
             negativeDamage.dmgl ||
             negativeDamage.dmg ||
             negativeDamage.dmgo ||
+            negativeDamage.dmga ||
             negativeDamage.thirdatt ||
             negativeDamage.dmgc;
 
@@ -219,6 +224,7 @@ export const BattleLogAttackActions: FC<BattleLogAttackActionsProps> = ({
                       dmgl: <span className="font-semibold text-yellow-300" />,
                       dmg: <span className="font-semibold" />,
                       dmgo: <span className="font-semibold text-orange-400" />,
+                      dmga: <span className="font-semibold" />,
                       thirdatt: <span className="font-semibold" />,
                       dmgc: <span className="font-semibold text-blue-400" />,
                     }}

--- a/apps/web/src/components/battle/utils/battle-action-constants.ts
+++ b/apps/web/src/components/battle/utils/battle-action-constants.ts
@@ -39,6 +39,7 @@ export const ATTACK_ACTIONS_SORT_ORDER = [
   "-parry",
   "-pierceb",
   "-arrowblock",
+  "-dmg",
   "-dmga",
   "-contra",
   "-legbon_glare",

--- a/apps/web/src/components/battle/utils/battle-actions-parser.spec.ts
+++ b/apps/web/src/components/battle/utils/battle-actions-parser.spec.ts
@@ -39,4 +39,18 @@ describe("parseActions", () => {
       "combo-max",
     ]);
   });
+
+  it("keeps -dmga with post-defense attack damage actions", () => {
+    const parsedActions = parseActions([
+      { actionType: "+dmg", param: "20755" },
+      { actionType: "-dmg", param: "20754" },
+      { actionType: "-dmga", param: "2137" },
+    ]);
+
+    expect(parsedActions.attackActions.map((action) => action.type)).toEqual([
+      "+dmg",
+      "-dmg",
+      "-dmga",
+    ]);
+  });
 });

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/battle-panel-battles-skeleton.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/battle-panel-battles-skeleton.tsx
@@ -1,5 +1,131 @@
-import { SidebarLayoutSkeleton } from "@/components/skeletons/sidebar-layout-skeleton";
+import { Card } from "@lootlog/ui/components/card";
+import { Skeleton } from "@lootlog/ui/components/skeleton";
+
+const tableRows = Array.from({ length: 10 });
+const filterGroups = Array.from({ length: 6 });
+const teamMembers = Array.from({ length: 2 });
+const tagItems = Array.from({ length: 3 });
+
+const renderTeamSkeleton = () => (
+  <div className="flex min-w-0 max-w-[112px] flex-col gap-1 md:min-w-[200px] md:max-w-[300px]">
+    {teamMembers.map((_, index) => (
+      <div key={index} className="flex min-w-0 items-center gap-1.5">
+        <Skeleton className="size-7 shrink-0 rounded-sm" />
+        <div className="min-w-0 flex-1 space-y-1">
+          <Skeleton className="h-3.5 w-28 max-w-full" />
+          <Skeleton className="h-2.5 w-16" />
+        </div>
+      </div>
+    ))}
+  </div>
+);
 
 export const BattlePanelBattlesSkeleton = () => {
-  return <SidebarLayoutSkeleton />;
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-background/50">
+      <div className="flex flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden p-3">
+          <Card className="flex h-full min-h-0 flex-1 flex-col gap-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm">
+            <div className="grid shrink-0 gap-2 border-b border-border bg-background/80 px-3 py-3 md:min-h-[64px] md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
+              <div className="flex min-w-0 items-center gap-2">
+                <Skeleton className="h-10 min-w-0 flex-1 rounded-md md:max-w-[360px]" />
+              </div>
+              <div className="hidden min-h-8 items-center justify-end gap-2 md:flex">
+                <Skeleton className="h-8 w-24 rounded-md" />
+                <Skeleton className="h-8 w-24 rounded-md" />
+                <Skeleton className="size-9 rounded-md" />
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <div className="min-w-full md:min-w-[840px]">
+                <div className="sticky top-0 z-10 grid h-11 grid-cols-[9%_27%_27%_22%_15%] items-center border-b border-border bg-background px-2 md:grid-cols-[40px_minmax(210px,1fr)_minmax(210px,1fr)_116px_176px_112px_76px_64px] md:px-3">
+                  <Skeleton className="mx-auto size-4 rounded-sm" />
+                  <Skeleton className="h-3.5 w-24" />
+                  <Skeleton className="h-3.5 w-28" />
+                  <Skeleton className="hidden h-3.5 w-16 md:block" />
+                  <Skeleton className="hidden h-3.5 w-20 md:block" />
+                  <Skeleton className="h-3.5 w-14" />
+                  <Skeleton className="hidden h-3.5 w-12 md:block" />
+                  <Skeleton className="h-3.5 w-8 justify-self-end" />
+                </div>
+
+                {tableRows.map((_, rowIndex) => (
+                  <div
+                    key={rowIndex}
+                    className="grid min-h-14 grid-cols-[9%_27%_27%_22%_15%] items-center border-b border-border bg-background/20 px-2 md:grid-cols-[40px_minmax(210px,1fr)_minmax(210px,1fr)_116px_176px_112px_76px_64px] md:px-3"
+                  >
+                    <Skeleton className="mx-auto size-4 rounded-sm" />
+                    {renderTeamSkeleton()}
+                    {renderTeamSkeleton()}
+                    <div className="hidden md:block">
+                      <Skeleton className="h-5 w-20 rounded-md" />
+                    </div>
+                    <div className="hidden max-w-[176px] flex-wrap gap-1 md:flex">
+                      {tagItems.map((_, index) => (
+                        <Skeleton
+                          key={index}
+                          className="h-5 w-12 rounded-full"
+                        />
+                      ))}
+                    </div>
+                    <Skeleton className="h-3.5 w-20" />
+                    <div className="hidden justify-center gap-1 md:flex">
+                      <Skeleton className="size-6 rounded-md" />
+                      {rowIndex % 3 === 0 ? (
+                        <Skeleton className="h-5 w-8 rounded-md" />
+                      ) : null}
+                    </div>
+                    <Skeleton className="size-8 justify-self-end rounded-md" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-t border-border px-4">
+              <Skeleton className="h-4 w-36" />
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-8 w-24 rounded-md" />
+                <Skeleton className="h-8 w-24 rounded-md" />
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <div className="hidden h-full w-[320px] shrink-0 flex-col overflow-hidden bg-background/50 py-3 pr-3 md:flex">
+          <Card className="flex min-h-0 flex-1 flex-col gap-0 border-border bg-filters-sidebar p-0 backdrop-blur-sm">
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <div className="space-y-4 p-4">
+                {filterGroups.map((_, index) => (
+                  <div key={index} className="space-y-2">
+                    <Skeleton className="h-3 w-24" />
+                    {index === 4 ? (
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="size-4 rounded-sm" />
+                        <Skeleton className="size-4 rounded-sm" />
+                        <Skeleton className="h-4 w-32" />
+                      </div>
+                    ) : index === 5 ? (
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-10 flex-1 rounded-md" />
+                        <Skeleton className="size-4 rounded-sm" />
+                        <Skeleton className="h-10 flex-1 rounded-md" />
+                      </div>
+                    ) : (
+                      <Skeleton className="h-10 w-full rounded-md" />
+                    )}
+                    {index < filterGroups.length - 1 ? (
+                      <div className="h-px bg-border" />
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Card>
+        </div>
+      </div>
+
+      <Skeleton className="fixed bottom-4 right-4 z-20 size-14 rounded-full shadow-lg md:hidden" />
+    </div>
+  );
 };

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle-skeleton.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle-skeleton.tsx
@@ -1,38 +1,222 @@
 import { Card } from "@lootlog/ui/components/card";
+import { ScrollArea } from "@lootlog/ui/components/scroll-area";
 import { Skeleton } from "@lootlog/ui/components/skeleton";
+import type { CSSProperties } from "react";
+
+const layoutStyle = {
+  "--battle-side-sticky-top": "368px",
+  "--battle-side-card-height":
+    "max(560px, calc(100dvh - var(--battle-side-sticky-top) - 8px))",
+} as CSSProperties;
+
+const teamRows = Array.from({ length: 3 });
+const chartTicks = Array.from({ length: 7 });
+const chartBarHeights = [
+  "h-12",
+  "h-20",
+  "h-28",
+  "h-16",
+  "h-36",
+  "h-24",
+  "h-32",
+];
+const statsRows = Array.from({ length: 14 });
+const logTurns = Array.from({ length: 9 });
+const recentRows = Array.from({ length: 7 });
 
 export const BattlePanelSingleBattleSkeleton = () => {
   return (
-    <div className="flex flex-col gap-4 px-3 py-3">
-      <Card className="border-border bg-card/40 p-4 backdrop-blur-sm">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1.5">
-            <Skeleton className="h-5 w-40" />
-            <Skeleton className="h-3 w-24" />
-          </div>
-          <Skeleton className="h-8 w-20 rounded-md" />
-        </div>
-      </Card>
+    <ScrollArea className="h-full bg-background/50" aria-hidden="true">
+      <div className="flex flex-col gap-4 px-3 py-3" style={layoutStyle}>
+        <Card className="w-full gap-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm">
+          <div className="relative bg-gradient-to-r from-green-400/10 via-transparent to-red-400/10 text-white">
+            <div className="p-4 pb-6 pt-12">
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-5 w-12 rounded-sm" />
+                  </div>
+                  <div className="space-y-2">
+                    {teamRows.map((_, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-3 rounded-md bg-background/35 p-2"
+                      >
+                        <Skeleton className="size-9 shrink-0 rounded-sm" />
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <Skeleton className="h-4 w-3/4" />
+                          <Skeleton className="h-3 w-1/2" />
+                        </div>
+                        <Skeleton className="h-4 w-10" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
 
-      <Card className="gap-4 border-border bg-card/60 p-4 backdrop-blur-sm">
-        <div className="flex items-center gap-3">
-          <Skeleton className="h-9 w-9 shrink-0 rounded-xl" />
-          <Skeleton className="h-4 w-32" />
-        </div>
-      </Card>
+                <div className="grid min-h-28 grid-cols-3 items-center justify-items-center">
+                  <Skeleton className="size-10 rounded-full opacity-60" />
+                  <div className="space-y-2 text-center">
+                    <Skeleton className="mx-auto h-8 w-12" />
+                    <Skeleton className="mx-auto h-3 w-20" />
+                  </div>
+                  <Skeleton className="size-10 rounded-full opacity-60" />
+                </div>
 
-      <Card className="flex min-h-0 flex-1 flex-col gap-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm">
-        {Array.from({ length: 8 }).map((_, i) => (
-          <div
-            key={i}
-            className="flex h-12 items-center gap-4 border-b border-border px-4"
-          >
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-4 flex-1" />
-            <Skeleton className="h-4 flex-1" />
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-5 w-12 rounded-sm" />
+                  </div>
+                  <div className="space-y-2">
+                    {teamRows.map((_, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center gap-3 rounded-md bg-background/35 p-2"
+                      >
+                        <Skeleton className="size-9 shrink-0 rounded-sm" />
+                        <div className="min-w-0 flex-1 space-y-1.5">
+                          <Skeleton className="h-4 w-3/4" />
+                          <Skeleton className="h-3 w-1/2" />
+                        </div>
+                        <Skeleton className="h-4 w-10" />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid gap-2 border-t border-border/70 bg-background/70 p-3 sm:grid-cols-2 lg:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="space-y-1">
+                  <Skeleton className="h-3 w-20" />
+                  <Skeleton className="h-4 w-28" />
+                </div>
+              ))}
+            </div>
           </div>
-        ))}
-      </Card>
-    </div>
+        </Card>
+
+        <div className="sticky top-3 z-30 bg-background">
+          <Card className="gap-3 border-border bg-card p-3">
+            <div className="flex flex-wrap items-start justify-between gap-3 px-1">
+              <div className="flex items-center gap-2">
+                <Skeleton className="size-4 rounded-sm" />
+                <div className="space-y-1.5">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-64 max-w-[60vw]" />
+                </div>
+              </div>
+              <Skeleton className="h-8 w-28 rounded-sm" />
+            </div>
+
+            <div className="relative h-64 w-full overflow-hidden rounded-md border border-border/60 bg-background/45 px-4 py-5">
+              <div className="absolute inset-x-4 top-1/2 h-px bg-border/70" />
+              <div className="absolute inset-x-4 top-1/4 h-px bg-border/40" />
+              <div className="absolute inset-x-4 top-3/4 h-px bg-border/40" />
+              <div className="flex h-full items-end justify-between gap-2">
+                {chartTicks.map((_, index) => (
+                  <div
+                    key={index}
+                    className="flex h-full flex-1 flex-col justify-end gap-2"
+                  >
+                    <Skeleton
+                      className={`w-full rounded-sm ${chartBarHeights[index] ?? "h-16"}`}
+                    />
+                    <Skeleton className="mx-auto h-2 w-8" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.3fr)] xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)_minmax(300px,0.9fr)]">
+          <div className="min-w-0 lg:sticky lg:[top:var(--battle-side-sticky-top)] lg:self-start">
+            <Card className="flex w-full flex-col gap-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm lg:h-[var(--battle-side-card-height)] lg:min-h-0">
+              <div className="flex min-h-[57px] items-center justify-between gap-3 border-b bg-background px-3 py-3">
+                <div className="flex min-w-0 flex-1 items-center gap-2">
+                  <Skeleton className="size-4 rounded-sm" />
+                  <Skeleton className="h-4 w-32" />
+                </div>
+                <div className="flex shrink-0 gap-1.5">
+                  <Skeleton className="size-9 rounded-sm" />
+                  <Skeleton className="size-9 rounded-sm" />
+                </div>
+              </div>
+              <div className="min-h-0 flex-1 space-y-0 overflow-hidden">
+                {statsRows.map((_, index) => (
+                  <div
+                    key={index}
+                    className="grid grid-cols-[minmax(0,1fr)_72px] items-center gap-3 border-b border-border/70 px-3 py-2.5"
+                  >
+                    <Skeleton className="h-3.5 w-full" />
+                    <Skeleton className="h-3.5 w-full" />
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-3 lg:sticky lg:[top:var(--battle-side-sticky-top)] lg:self-start">
+            <Card className="overflow-hidden border-border bg-card p-0 lg:flex lg:h-[var(--battle-side-card-height)] lg:min-h-0 lg:w-full lg:flex-col">
+              <div className="flex min-h-[52px] items-center gap-2 border-b bg-background px-3 py-2.5">
+                <Skeleton className="h-9 flex-1 rounded-sm" />
+                <Skeleton className="size-9 rounded-sm" />
+                <Skeleton className="size-9 rounded-sm" />
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                {logTurns.map((_, index) => (
+                  <div
+                    key={index}
+                    className="space-y-2 border-b border-border/70 px-4 py-3"
+                  >
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-3.5 w-28" />
+                      <Skeleton className="h-3.5 w-16" />
+                    </div>
+                    <Skeleton className="h-3.5 w-11/12" />
+                    <Skeleton className="h-3.5 w-7/12" />
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </div>
+
+          <div className="hidden min-w-0 xl:block xl:self-start">
+            <div className="sticky lg:[top:var(--battle-side-sticky-top)]">
+              <Card className="flex max-h-[420px] min-h-0 w-full flex-col gap-0 overflow-hidden border-border bg-card p-0 xl:h-[var(--battle-side-card-height)] xl:max-h-none">
+                <div className="flex min-h-[61px] shrink-0 items-center justify-between gap-3 border-b bg-background px-3 py-3">
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <Skeleton className="size-4 rounded-sm" />
+                    <div className="min-w-0 flex-1 space-y-1.5">
+                      <Skeleton className="h-4 w-36" />
+                      <Skeleton className="h-3 w-44" />
+                    </div>
+                  </div>
+                  <Skeleton className="h-8 w-20 rounded-sm" />
+                </div>
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  {recentRows.map((_, index) => (
+                    <div
+                      key={index}
+                      className="grid grid-cols-[40px_minmax(0,1fr)_56px] items-center gap-3 border-b border-border/70 px-3 py-3"
+                    >
+                      <Skeleton className="size-8 rounded-sm" />
+                      <div className="min-w-0 space-y-1.5">
+                        <Skeleton className="h-3.5 w-full" />
+                        <Skeleton className="h-3 w-2/3" />
+                      </div>
+                      <Skeleton className="h-4 w-full" />
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ScrollArea>
   );
 };

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-table.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-table.tsx
@@ -37,14 +37,16 @@ const getRecentBattleRowClassName = (battle: PlayerVsPlayerBattle) => {
 };
 
 const renderWarrior = (warrior: RecentOpponentWarrior) => (
-  <div className="flex min-w-0 items-center gap-1">
+  <div className="flex min-w-0 items-center gap-1.5">
     <PlayerTile
       player={warrior}
-      className="h-9 w-6 origin-top-left scale-[0.72]"
+      className="h-10 w-7 origin-top-left scale-[0.78]"
     />
     <div className="min-w-0">
-      <div className="truncate text-xs font-medium">{warrior.name}</div>
-      <div className="text-[10px] text-muted-foreground">
+      <div className="truncate text-sm font-medium leading-tight">
+        {warrior.name}
+      </div>
+      <div className="text-xs leading-tight text-muted-foreground">
         {warrior.lvl}
         {warrior.prof}
       </div>
@@ -126,9 +128,9 @@ export function RecentOpponentBattlesTable({
         <Table className="table-fixed border-b">
           <colgroup>
             <col className="w-[34%]" />
-            <col className="w-5" />
+            <col className="w-6" />
             <col className="w-[34%]" />
-            <col className="w-[76px]" />
+            <col className="w-[88px]" />
           </colgroup>
           <TableBody>
             {battles.map((recentBattle) => {
@@ -144,7 +146,7 @@ export function RecentOpponentBattlesTable({
                   tabIndex={0}
                   aria-label={t("battlePanel.list.openBattle")}
                   className={cn(
-                    "h-12 cursor-pointer border-b border-border transition-colors [&_td:first-child]:!pl-2 [&_td:last-child]:!pr-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+                    "h-14 cursor-pointer border-b border-border transition-colors [&_td:first-child]:!pl-2 [&_td:last-child]:!pr-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
                     getRecentBattleRowClassName(recentBattle),
                   )}
                   onClick={() => handleOpenBattle(recentBattle.battleId)}
@@ -155,7 +157,7 @@ export function RecentOpponentBattlesTable({
                   <TableCell className="min-w-0 py-1 pl-2 pr-1">
                     {renderWarrior(recentBattle.userWarrior)}
                   </TableCell>
-                  <TableCell className="px-0 py-1 text-center text-[9px] font-medium uppercase text-muted-foreground/80">
+                  <TableCell className="px-0 py-1 text-center text-[10px] font-medium uppercase text-muted-foreground/80">
                     {t("battlePanel.single.recentOpponent.versus")}
                   </TableCell>
                   <TableCell className="min-w-0 px-1 py-1">
@@ -164,7 +166,7 @@ export function RecentOpponentBattlesTable({
                   <TableCell className="py-1 pl-1 pr-2 text-right">
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="inline-block max-w-full truncate text-xs font-medium text-muted-foreground">
+                        <span className="inline-block max-w-full truncate text-sm font-medium text-muted-foreground">
                           {getRelativeTime(recentBattle.createdAt)}
                         </span>
                       </TooltipTrigger>

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/combat-profile-overview.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/combat-profile-overview.tsx
@@ -1,15 +1,6 @@
 import type { CombatProfileResponseDtoOutput } from "@/lib/api/generated/battlelog/model";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-  type ChartConfig,
-} from "@lootlog/ui/components/chart";
-import { Badge } from "@lootlog/ui/components/badge";
 import { Card } from "@lootlog/ui/components/card";
 import {
-  Activity,
-  BarChart3,
   Clock,
   Crosshair,
   Shield,
@@ -18,15 +9,6 @@ import {
   Trophy,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Line,
-  LineChart,
-  XAxis,
-  YAxis,
-} from "recharts";
 
 type CombatProfileOverviewProps = {
   data: CombatProfileResponseDtoOutput | undefined;
@@ -49,28 +31,6 @@ export function CombatProfileOverview({
   isLoading,
 }: CombatProfileOverviewProps) {
   const { t } = useTranslation();
-  const chartConfig = {
-    value: {
-      label: t("battlePanel.statistics.combatProfile.value"),
-      color: "var(--chart-1)",
-    },
-    wins: {
-      label: t("battlePanel.statistics.combatProfile.wins"),
-      color: "var(--chart-2)",
-    },
-    losses: {
-      label: t("battlePanel.statistics.combatProfile.losses"),
-      color: "var(--chart-3)",
-    },
-    ph: {
-      label: t("battlePanel.statistics.combatProfile.ph"),
-      color: "var(--chart-4)",
-    },
-    rating: {
-      label: t("battlePanel.statistics.combatProfile.rating"),
-      color: "var(--chart-5)",
-    },
-  } satisfies ChartConfig;
 
   if (isLoading || !data) {
     return (
@@ -81,46 +41,6 @@ export function CombatProfileOverview({
       </Card>
     );
   }
-
-  const damageMix = data.damageMix.slice(0, 8).map((item) => ({
-    label: t(`battlePanel.statistics.combatProfile.damageTypes.${item.key}`, {
-      defaultValue: item.label,
-    }),
-    value: item.value,
-    share: item.share,
-  }));
-  const mitigationMix = data.mitigationMix.slice(0, 8).map((item) => ({
-    label: t(
-      `battlePanel.statistics.combatProfile.mitigationTypes.${item.key}`,
-      {
-        defaultValue: item.label,
-      },
-    ),
-    value: item.value,
-    share: item.share,
-  }));
-  const spellUsage = data.spellUsage.slice(0, 8).map((spell) => ({
-    label: spell.spell,
-    value: spell.casts,
-    share: spell.share,
-  }));
-  const matchupByProfession = data.matchupByProfession.map((matchup) => ({
-    label: t(`professions.${matchup.prof}`, { defaultValue: matchup.prof }),
-    wins: matchup.wins,
-    losses: matchup.losses,
-    totalBattles: matchup.totalBattles,
-  }));
-  const trendData = data.phTrend.map((point, index) => {
-    const ratingPoint = data.ratingTrend[index];
-    return {
-      label: new Date(point.date).toLocaleDateString("pl-PL", {
-        day: "2-digit",
-        month: "2-digit",
-      }),
-      ph: point.cumulativeValue,
-      rating: ratingPoint?.cumulativeValue ?? 0,
-    };
-  });
 
   const kpis = [
     {
@@ -185,153 +105,6 @@ export function CombatProfileOverview({
             <div className="text-xs text-muted-foreground">{kpi.subvalue}</div>
           </Card>
         ))}
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 2xl:grid-cols-2">
-        <Card className="gap-3 border-border bg-card/40 p-4 backdrop-blur-sm">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <BarChart3 className="size-4 text-primary" />
-            {t("battlePanel.statistics.combatProfile.damageMix")}
-          </div>
-          <ChartContainer config={chartConfig} className="h-64 w-full">
-            <BarChart data={damageMix} margin={{ left: -20, right: 8 }}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={compactFormatter.format}
-              />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar dataKey="value" fill="var(--color-value)" radius={4} />
-            </BarChart>
-          </ChartContainer>
-        </Card>
-
-        <Card className="gap-3 border-border bg-card/40 p-4 backdrop-blur-sm">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Shield className="size-4 text-primary" />
-            {t("battlePanel.statistics.combatProfile.mitigationMix")}
-          </div>
-          <ChartContainer config={chartConfig} className="h-64 w-full">
-            <BarChart data={mitigationMix} margin={{ left: -20, right: 8 }}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={compactFormatter.format}
-              />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar dataKey="value" fill="var(--color-value)" radius={4} />
-            </BarChart>
-          </ChartContainer>
-        </Card>
-
-        <Card className="gap-3 border-border bg-card/40 p-4 backdrop-blur-sm">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Activity className="size-4 text-primary" />
-            {t("battlePanel.statistics.combatProfile.spellUsage")}
-          </div>
-          <ChartContainer config={chartConfig} className="h-64 w-full">
-            <BarChart data={spellUsage} margin={{ left: -20, right: 8 }}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar dataKey="value" fill="var(--color-value)" radius={4} />
-            </BarChart>
-          </ChartContainer>
-        </Card>
-
-        <Card className="gap-3 border-border bg-card/40 p-4 backdrop-blur-sm">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Trophy className="size-4 text-primary" />
-            {t("battlePanel.statistics.combatProfile.matchups")}
-          </div>
-          <ChartContainer config={chartConfig} className="h-64 w-full">
-            <BarChart
-              data={matchupByProfession}
-              margin={{ left: -20, right: 8 }}
-            >
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar
-                dataKey="wins"
-                stackId="record"
-                fill="var(--color-wins)"
-                radius={4}
-              />
-              <Bar
-                dataKey="losses"
-                stackId="record"
-                fill="var(--color-losses)"
-                radius={4}
-              />
-            </BarChart>
-          </ChartContainer>
-        </Card>
-      </div>
-
-      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
-        <Card className="gap-3 border-border bg-card/40 p-4 backdrop-blur-sm">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Activity className="size-4 text-primary" />
-            {t("battlePanel.statistics.combatProfile.trends")}
-          </div>
-          <ChartContainer config={chartConfig} className="h-64 w-full">
-            <LineChart data={trendData} margin={{ left: -20, right: 8 }}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="label" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Line
-                dataKey="ph"
-                stroke="var(--color-ph)"
-                strokeWidth={2}
-                dot={false}
-              />
-              <Line
-                dataKey="rating"
-                stroke="var(--color-rating)"
-                strokeWidth={2}
-                dot={false}
-              />
-            </LineChart>
-          </ChartContainer>
-        </Card>
-
-        <Card className="gap-3 border-border bg-card/40 p-4 backdrop-blur-sm">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Sparkles className="size-4 text-primary" />
-            {t("battlePanel.statistics.combatProfile.highlights")}
-          </div>
-          <div className="space-y-2">
-            {data.highlights.map((highlight) => (
-              <div
-                key={highlight.type}
-                className="flex items-center justify-between gap-3 rounded-md border border-border/70 bg-background/50 p-2"
-              >
-                <div className="min-w-0">
-                  <div className="truncate text-sm font-medium">
-                    {t(
-                      `battlePanel.statistics.combatProfile.highlightTypes.${highlight.type}`,
-                      { defaultValue: highlight.label },
-                    )}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {new Date(highlight.createdAt).toLocaleDateString("pl-PL")}
-                  </div>
-                </div>
-                <Badge variant="secondary" className="shrink-0">
-                  {compactFormatter.format(highlight.value)}
-                </Badge>
-              </div>
-            ))}
-          </div>
-        </Card>
       </div>
     </div>
   );

--- a/apps/web/src/i18n/translations/battle.json
+++ b/apps/web/src/i18n/translations/battle.json
@@ -28,7 +28,7 @@
   "-absorbm": "-Absorpcja <value>{{value}}</value> obrażeń magicznych",
   "-arrowblock": "-Strzała zneutralizowana",
   "-blok": "-Zablokowanie <value>{{value}}</value> obrażeń",
-  "-combined_dmg": "<value>{{name}}({{hp}}%)</value> otrzymał <dmg>{{dmg}}</dmg><dmgo>{{dmgo}}</dmgo><dmgd>{{dmgd}}</dmgd><dmgf>{{dmgf}}</dmgf><dmgl>{{dmgl}}</dmgl><thirdatt>{{thirdatt}}</thirdatt><dmgc>{{dmgc}}</dmgc> obrażeń",
+  "-combined_dmg": "<value>{{name}}({{hp}}%)</value> otrzymał <dmg>{{dmg}}</dmg><dmga>{{dmga}}</dmga><dmgo>{{dmgo}}</dmgo><dmgd>{{dmgd}}</dmgd><dmgf>{{dmgf}}</dmgf><dmgl>{{dmgl}}</dmgl><thirdatt>{{thirdatt}}</thirdatt><dmgc>{{dmgc}}</dmgc> obrażeń",
   "-contra": "-Kontratak",
   "-endest": "<resourceDestroy>-Zniszczono <value>{{value}}</value> energii</resourceDestroy>",
   "-endest_reduced": "<resourceDestroy>-Zniszczono <value>{{value}}</value> (osłabione o <value>{{reducedValue}}</value> punktów) energii</resourceDestroy>",

--- a/packages/battle-processor/src/index.ts
+++ b/packages/battle-processor/src/index.ts
@@ -1214,6 +1214,7 @@ export class BattleProcessor {
     const defender = move.defenderId
       ? (this.warriors.get(move.defenderId) ?? null)
       : null;
+    let defenderTakenDamage = 0;
 
     for (const { actionType, param } of move.actions) {
       if (actionType === "winner") {
@@ -1263,11 +1264,7 @@ export class BattleProcessor {
           defender.damageTaken += value;
           (defender[DAMAGE_TAKEN_ACTIONS[actionType]] as number) += value;
           defender.flatDamageTaken += value;
-          this.tryCalculateMaxHp(
-            move.defenderId,
-            value,
-            move.defenderHpPercentage,
-          );
+          defenderTakenDamage += value;
         }
         continue;
       }
@@ -1485,6 +1482,14 @@ export class BattleProcessor {
           attacker.reducedPoisonResistance += value;
           break;
       }
+    }
+
+    if (defender && move.defenderId && defenderTakenDamage > 0) {
+      this.tryCalculateMaxHp(
+        move.defenderId,
+        defenderTakenDamage,
+        move.defenderHpPercentage,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- handle `-dmga` as defender-side post-defense damage in battle processor totals and frontend battle log rendering
- hide unfinished battle statistics cards and refresh loading skeletons for battle list/detail layouts
- increase recent opponent battle table readability

## Why
The battle engine now emits `-dmga` damage in the defender damage line, and the panel loading states needed to match the refreshed battle panel layouts more closely.

## Validation
- `pnpm --filter @lootlog/battlelog-service test -- battle-processor.spec.ts`
- `pnpm --filter @lootlog/web exec vitest run src/components/battle/utils/battle-actions-parser.spec.ts src/components/battle/actions/battle-log-attack-action.spec.tsx`
- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web build`
- pre-commit changed-package lint/test checks