### PR TITLE
[codex] Use nullish env fallbacks

### DIFF
--- a/apps/auth/src/instrumentation.ts
+++ b/apps/auth/src/instrumentation.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { initObservability } from "@lootlog/instrumentation";
 
 initObservability({
-  serviceName: process.env.SERVICE_NAME || "auth",
+  serviceName: process.env.SERVICE_NAME ?? "auth",
   otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   serviceEnvironment: process.env.ENV,

--- a/apps/battlelog-service/src/instrumentation.ts
+++ b/apps/battlelog-service/src/instrumentation.ts
@@ -2,7 +2,7 @@ import { initObservability } from "@lootlog/instrumentation";
 import "dotenv/config";
 
 initObservability({
-  serviceName: process.env.SERVICE_NAME || "battlelog-service",
+  serviceName: process.env.SERVICE_NAME ?? "battlelog-service",
   otlpEndpoint: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
   otlpHeaders: process.env.OTEL_EXPORTER_OTLP_HEADERS,
   serviceEnvironment: process.env.ENV,

--- a/apps/game-client/vite.config.ts
+++ b/apps/game-client/vite.config.ts
@@ -10,9 +10,9 @@ import { visualizer } from "rollup-plugin-visualizer";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, "");
   const commitSha =
-    env.VITE_COMMIT_SHA ||
-    env.WORKERS_CI_COMMIT_SHA ||
-    process.env.WORKERS_CI_COMMIT_SHA ||
+    env.VITE_COMMIT_SHA ??
+    env.WORKERS_CI_COMMIT_SHA ??
+    process.env.WORKERS_CI_COMMIT_SHA ??
     "";
 
   return {

--- a/apps/landing/src/config/addon.ts
+++ b/apps/landing/src/config/addon.ts
@@ -1,3 +1,3 @@
 export const ADDON_URL =
-  process.env.NEXT_PUBLIC_ADDON_URL ||
+  process.env.NEXT_PUBLIC_ADDON_URL ??
   "https://github.com/lootlog/monorepo/releases/latest";

--- a/apps/landing/src/config/auth.ts
+++ b/apps/landing/src/config/auth.ts
@@ -1,2 +1,2 @@
 export const AUTH_SERVICE_URL =
-  process.env.NEXT_PUBLIC_AUTH_SERVICE_URL || "http://localhost:4000";
+  process.env.NEXT_PUBLIC_AUTH_SERVICE_URL ?? "http://localhost:4000";

--- a/packages/cli/src/commands/seed/seed.ts
+++ b/packages/cli/src/commands/seed/seed.ts
@@ -20,7 +20,7 @@ const prisma = new PrismaClient();
 
 // Use separate connection string for battlelog if provided
 const battlelogConnectionUri =
-  process.env.BATTLELOG_DATABASE_URL || process.env.POSTGRESQL_CONNECTION_URI;
+  process.env.BATTLELOG_DATABASE_URL ?? process.env.POSTGRESQL_CONNECTION_URI;
 
 const battlelogPrisma = new BattlelogPrismaClient({
   datasources: {


### PR DESCRIPTION
## Summary
- Replace truthy environment fallbacks with nullish coalescing in service instrumentation, landing config, game-client commit SHA config, and CLI seed database config.
- Preserve explicitly configured empty-string values instead of treating them as missing.

## Verification
- pnpm exec oxlint apps/landing/src/config/addon.ts apps/landing/src/config/auth.ts apps/auth/src/instrumentation.ts apps/battlelog-service/src/instrumentation.ts apps/game-client/vite.config.ts packages/cli/src/commands/seed/seed.ts
- pnpm --filter @lootlog/landing typecheck
- pnpm --filter @lootlog/auth lint
- pnpm --filter @lootlog/battlelog-service lint
- pnpm --filter @lootlog/game-client... build
- pnpm --filter @lootlog/cli test
- pnpm format:check
- pnpm lint --filter=@lootlog/landing --filter=@lootlog/auth --filter=@lootlog/battlelog-service
- pnpm --filter @lootlog/auth test
- pnpm --filter @lootlog/battlelog-service... build
- pnpm --filter @lootlog/battlelog-service test
- pnpm --filter @lootlog/landing build
- pre-commit hook: lint-staged, changed-package lint, changed-package format check, changed-package tests

## Notes
- Initial `pnpm install` populated missing dependencies but exited after pnpm requested build-script approval; subsequent checks passed after dependency builds ran through package scripts.