### PR TITLE
[codex] Increase gateway RabbitMQ connection timeout

### DIFF
--- a/apps/gateway/src/config/rabbitmq.config.ts
+++ b/apps/gateway/src/config/rabbitmq.config.ts
@@ -8,6 +8,7 @@ export const DEAD_LETTER_EXCHANGE_NAME = "dlx";
 export const RETRY_EXCHANGE_NAME = "retry";
 
 const DEFAULT_TTL = 30000; // 30 seconds
+const RABBITMQ_CONNECTION_INIT_TIMEOUT = 30000;
 
 export const rabbitmqConfig: RabbitMQConfig = {
   uri: env.RABBITMQ_URI,
@@ -176,5 +177,8 @@ export const rabbitmqConfig: RabbitMQConfig = {
       prefetchCount: 1,
       default: true,
     },
+  },
+  connectionInitOptions: {
+    timeout: RABBITMQ_CONNECTION_INIT_TIMEOUT,
   },
 };


### PR DESCRIPTION
## Summary

- Increase the gateway RabbitMQ connection initialization timeout from the library default of 5s to 30s.
- Keep `wait`/`reject` behavior unchanged so the app still fails when RabbitMQ is genuinely unavailable, just with a less aggressive startup window.

## Why

During the production incident, gateway pods were exiting during startup with `Failed to connect to a RabbitMQ broker within a timeout of 5000ms`. The short default timeout made transient RabbitMQ lag restart the only gateway instance, which disrupted websocket traffic.

## Validation

- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway build`
- pre-commit hook: changed-package lint and `@lootlog/gateway` tests, 150 passing