### PR TITLE
[codex] use nullish guild timer payload fallback

### DIFF
--- a/apps/game-client/src/store/timer-settings-sync.ts
+++ b/apps/game-client/src/store/timer-settings-sync.ts
@@ -69,7 +69,7 @@ export const debouncedSyncGuildSettings = (
   guildId: string,
   payload: UpdateGuildTimerSettingsPayload,
 ) => {
-  const existingPayload = pendingGuildPayloads.get(guildId) || {};
+  const existingPayload = pendingGuildPayloads.get(guildId) ?? {};
   pendingGuildPayloads.set(guildId, { ...existingPayload, ...payload });
 
   const existingTimeout = guildSyncTimeouts.get(guildId);


### PR DESCRIPTION
## Summary

- use a nullish fallback when merging pending guild timer sync payloads
- keeps the debounce merge behavior explicit for absent map entries

## Verification

- pnpm --filter @lootlog/types build
- pnpm --filter @lootlog/margonem build
- pnpm --filter @lootlog/socket-parser build
- pnpm --filter @lootlog/game-client test
- pnpm --filter @lootlog/game-client build
- pnpm exec oxlint apps/game-client/src/store/timer-settings-sync.ts
- pnpm exec oxfmt --check apps/game-client/src/store/timer-settings-sync.ts
- pre-commit hook passed on commit
