### PR TITLE
[codex] support multi-instance gateway sockets

### DIFF
--- a/apps/gateway/src/gateway/gateway.service.spec.ts
+++ b/apps/gateway/src/gateway/gateway.service.spec.ts
@@ -201,6 +201,7 @@ describe("GatewayService", () => {
       await service.handleGuildsTimerUpdate(timerDto);
 
       // Wait for async promise chain to complete
+      await flushPromises();
       // Feature room for titan timers
       expect(mockServer.in).toHaveBeenCalledWith("guild-123:timers:titans");
       expect(mockServer.fetchSockets).toHaveBeenCalled();
@@ -221,6 +222,18 @@ describe("GatewayService", () => {
       expect(mockServer.in).toHaveBeenCalledWith("guild-123:timers:titans");
       expect(mockServer.fetchSockets).toHaveBeenCalled();
       // No sockets to emit to since none are in the room
+    });
+
+    it("should ignore socket fetch failures for filtered timer updates", async () => {
+      mockServer.fetchSockets.mockRejectedValue(
+        new Error("timeout reached while waiting for fetchSockets response"),
+      );
+
+      await service.handleGuildsTimerUpdate(timerDto);
+      await flushPromises();
+
+      expect(mockServer.fetchSockets).toHaveBeenCalled();
+      expect(mockServer.emit).not.toHaveBeenCalled();
     });
 
     it("should emit to administrative users regardless of specific permissions", async () => {
@@ -249,6 +262,7 @@ describe("GatewayService", () => {
       await service.handleGuildsTimerUpdate(timerDto);
 
       // Wait for async promise chain to complete
+      await flushPromises();
       expect(mockAdminSocket.emit).toHaveBeenCalledWith(
         GatewayEvent.TIMERS_CREATE,
         timerDto,
@@ -1507,6 +1521,20 @@ describe("GatewayService", () => {
       await service.rebalanceUserSocketRooms(discordId, userId);
 
       expect(mockGuildsService.getUserGuilds).toHaveBeenCalled();
+    });
+
+    it("should not throw when socket fetch fails", async () => {
+      const discordId = "discord-123";
+      const userId = "user-123";
+
+      mockGuildsService.getUserGuilds.mockResolvedValue([]);
+      mockServer.fetchSockets.mockRejectedValue(
+        new Error("timeout reached while waiting for fetchSockets response"),
+      );
+
+      await expect(
+        service.rebalanceUserSocketRooms(discordId, userId),
+      ).resolves.not.toThrow();
     });
 
     it("should handle errors gracefully", async () => {

--- a/apps/gateway/src/gateway/gateway.service.ts
+++ b/apps/gateway/src/gateway/gateway.service.ts
@@ -39,6 +39,10 @@ import {
   type TierName,
 } from "src/gateway/utils/room-utils";
 
+type FetchedSocket = Awaited<
+  ReturnType<Gateway["server"]["fetchSockets"]>
+>[number];
+
 type FeatureRouting = {
   tier: TierName;
   npcLevel?: number;
@@ -74,10 +78,10 @@ export class GatewayService {
     const room = buildRoomName(guildId, feature, tier);
 
     if (npcLevel !== undefined) {
-      // Level filtering required - fetch sockets and filter
-      this.gateway.server
-        .in(room)
-        .fetchSockets()
+      void this.fetchSocketsSafely(
+        () => this.gateway.server.in(room).fetchSockets(),
+        `feature room ${room}`,
+      )
         .then((sockets) => {
           sockets.forEach((socket) => {
             const guildData = socket.data.guilds?.find(
@@ -98,9 +102,14 @@ export class GatewayService {
               socket.emit(event, data);
             }
           });
+        })
+        .catch((error) => {
+          this.logger.error(
+            `Failed to emit to feature room ${room}: ${error.message}`,
+            error.stack,
+          );
         });
     } else {
-      // No level filtering - direct room broadcast
       this.gateway.server.to(room).emit(event, data);
     }
   }
@@ -172,9 +181,10 @@ export class GatewayService {
     const routing = this.getChatMessageRouting(data);
     const room = buildRoomName(data.guildId, "chat", routing.tier);
 
-    this.gateway.server
-      .in(room)
-      .fetchSockets()
+    void this.fetchSocketsSafely(
+      () => this.gateway.server.in(room).fetchSockets(),
+      `chat room ${room}`,
+    )
       .then((sockets) => {
         sockets.forEach((socket) => {
           const guildData = socket.data.guilds?.find(
@@ -211,6 +221,12 @@ export class GatewayService {
             ),
           );
         });
+      })
+      .catch((error) => {
+        this.logger.error(
+          `Failed to send chat message for guild ${data.guildId}: ${error.message}`,
+          error.stack,
+        );
       });
   }
 
@@ -248,7 +264,10 @@ export class GatewayService {
         discordId,
         userId,
       });
-      const sockets = await this.gateway.server.fetchSockets();
+      const sockets = await this.fetchSocketsSafely(
+        () => this.gateway.server.fetchSockets(),
+        `socket rebalance for user ${discordId}`,
+      );
       const userSockets = sockets.filter(
         (socket) => socket.data.discordId === discordId,
       );
@@ -345,7 +364,10 @@ export class GatewayService {
   }
 
   async handleVolunteerNotification(data: VolunteerNotificationDto) {
-    const sockets = await this.gateway.server.fetchSockets();
+    const sockets = await this.fetchSocketsSafely(
+      () => this.gateway.server.fetchSockets(),
+      `volunteer notification ${data.notificationId}`,
+    );
     const targetSockets = sockets.filter(
       (socket) => socket.data.discordId === data.targetDiscordId,
     );
@@ -458,6 +480,19 @@ export class GatewayService {
     }
 
     return this.getNpcFeatureRouting(data.npc);
+  }
+
+  private async fetchSocketsSafely(
+    fetchSockets: () => Promise<FetchedSocket[]>,
+    context: string,
+  ): Promise<FetchedSocket[]> {
+    try {
+      return await fetchSockets();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to fetch sockets for ${context}: ${message}`);
+      return [];
+    }
   }
 
   private toChatMessageEnvelope(

--- a/apps/gateway/src/gateway/services/presence.service.spec.ts
+++ b/apps/gateway/src/gateway/services/presence.service.spec.ts
@@ -95,6 +95,10 @@ describe("PresenceService", () => {
     } as never);
   });
 
+  async function flushPromises() {
+    return new Promise((resolve) => setImmediate(resolve));
+  }
+
   describe("fetchEventPresence", () => {
     it("returns all guild presence when world is not provided", async () => {
       const guildId = "guild-1";
@@ -168,6 +172,26 @@ describe("PresenceService", () => {
       if (result.status !== "success") return;
 
       expect(result.players["discord-1"][0].lvl).toBe("64");
+    });
+
+    it("returns empty presence when socket fetch fails", async () => {
+      const guildId = "guild-1";
+      const client = createViewerClient(guildId);
+
+      mockFetchSockets.mockRejectedValue(
+        new Error("timeout reached while waiting for fetchSockets response"),
+      );
+
+      const result = await service.fetchEventPresence(
+        mockServer as never,
+        client,
+        guildId,
+      );
+
+      expect(result).toEqual({
+        status: "success",
+        players: {},
+      });
     });
 
     it("returns forbidden when client is not in guild online players room", async () => {
@@ -417,6 +441,26 @@ describe("PresenceService", () => {
       expect(result.players["discord-high"][0].player.lvl).toBe("300");
       expect(result.players["discord-mid"][0].player.lvl).toBe("150");
     });
+
+    it("returns empty online players presence when socket fetch fails", async () => {
+      const guildId = "guild-1";
+
+      mockFetchSockets.mockRejectedValue(
+        new Error("timeout reached while waiting for fetchSockets response"),
+      );
+
+      const result = await service.fetchOnlinePlayersPresence(
+        mockServer as never,
+        createViewerClient(guildId),
+        guildId,
+        "alpha",
+      );
+
+      expect(result).toEqual({
+        status: "success",
+        players: {},
+      });
+    });
   });
 
   describe("live presence events", () => {
@@ -478,7 +522,7 @@ describe("PresenceService", () => {
         mockServer as never,
       );
 
-      await Promise.resolve();
+      await flushPromises();
 
       expect(viewerSocket.emit).toHaveBeenCalledWith(
         GatewayEvent.ONLINE_PLAYERS_PRESENCE_UPDATE,
@@ -542,7 +586,7 @@ describe("PresenceService", () => {
         "guild-1",
       ]);
 
-      await Promise.resolve();
+      await flushPromises();
 
       expect(viewerSocket.emit).toHaveBeenCalledWith(
         GatewayEvent.ONLINE_PLAYERS_PRESENCE_UPDATE,
@@ -603,7 +647,7 @@ describe("PresenceService", () => {
 
       service.emitDisconnectPresence(mockServer as never, client);
 
-      await Promise.resolve();
+      await flushPromises();
 
       expect(viewerSocket.emit).toHaveBeenCalledWith(
         GatewayEvent.ONLINE_PLAYERS_PRESENCE_UPDATE,
@@ -652,7 +696,7 @@ describe("PresenceService", () => {
         mockServer as never,
       );
 
-      await Promise.resolve();
+      await flushPromises();
 
       expect(viewerSocket.emit).not.toHaveBeenCalledWith(
         GatewayEvent.ONLINE_PLAYERS_PRESENCE_UPDATE,

--- a/apps/gateway/src/gateway/services/presence.service.ts
+++ b/apps/gateway/src/gateway/services/presence.service.ts
@@ -36,6 +36,8 @@ export type PresenceFetchResponse<TPlayers> =
       code: typeof ONLINE_PLAYERS_ACCESS_DENIED_CODE;
     };
 
+type FetchedSocket = Awaited<ReturnType<Server["fetchSockets"]>>[number];
+
 @Injectable()
 export class PresenceService {
   private readonly logger = new Logger(PresenceService.name);
@@ -254,7 +256,10 @@ export class PresenceService {
       return this.createOnlinePlayersForbiddenResponse();
     }
 
-    const socketsInRoom = await server.in(presenceRoom).fetchSockets();
+    const socketsInRoom = await this.fetchSocketsSafely(
+      () => server.in(presenceRoom).fetchSockets(),
+      `event presence room ${presenceRoom}`,
+    );
     const result: Record<string, PlayerPresence[]> = {};
 
     for (const socket of socketsInRoom) {
@@ -297,7 +302,10 @@ export class PresenceService {
       return this.createOnlinePlayersForbiddenResponse();
     }
 
-    const socketsInRoom = await server.in(presenceRoom).fetchSockets();
+    const socketsInRoom = await this.fetchSocketsSafely(
+      () => server.in(presenceRoom).fetchSockets(),
+      `online players presence room ${presenceRoom}`,
+    );
 
     let filteredSockets = socketsInRoom.filter(
       (s) => s.data.player?.world === world,
@@ -342,7 +350,10 @@ export class PresenceService {
     mapName: string,
   ): Promise<void> {
     const presenceRoom = buildRoomName(guildId, "presence");
-    const socketsInRoom = await server.in(presenceRoom).fetchSockets();
+    const socketsInRoom = await this.fetchSocketsSafely(
+      () => server.in(presenceRoom).fetchSockets(),
+      `presence check room ${presenceRoom}`,
+    );
 
     for (const socket of socketsInRoom) {
       const playerPresence = socket.data?.playerPresence;
@@ -445,9 +456,10 @@ export class PresenceService {
   }): void {
     const onlinePlayersRoom = buildRoomName(guildId, "online-players");
 
-    server
-      .in(onlinePlayersRoom)
-      .fetchSockets()
+    void this.fetchSocketsSafely(
+      () => server.in(onlinePlayersRoom).fetchSockets(),
+      `online players room ${onlinePlayersRoom}`,
+    )
       .then((sockets) => {
         for (const socket of sockets) {
           if (excludeSourceSocket && socket.id === sourceClient.id) {
@@ -468,6 +480,19 @@ export class PresenceService {
           error.stack,
         );
       });
+  }
+
+  private async fetchSocketsSafely(
+    fetchSockets: () => Promise<FetchedSocket[]>,
+    context: string,
+  ): Promise<FetchedSocket[]> {
+    try {
+      return await fetchSockets();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to fetch sockets for ${context}: ${message}`);
+      return [];
+    }
   }
 
   private buildPlayerPresence(

--- a/apps/gateway/src/lib/redis/redis-io.adapter.ts
+++ b/apps/gateway/src/lib/redis/redis-io.adapter.ts
@@ -6,6 +6,8 @@ import type { ServerOptions } from "socket.io";
 import { msgpackParser } from "@lootlog/socket-parser";
 import { redisConfig } from "src/config/redis.config";
 
+const SOCKET_IO_REDIS_REQUESTS_TIMEOUT = 30000;
+
 export class RedisIoAdapter extends IoAdapter {
   private adapterConstructor: ReturnType<typeof createAdapter>;
 
@@ -23,7 +25,10 @@ export class RedisIoAdapter extends IoAdapter {
 
     const subClient = pubClient.duplicate();
 
-    this.adapterConstructor = createAdapter(pubClient, subClient);
+    this.adapterConstructor = createAdapter(pubClient, subClient, {
+      requestsTimeout: SOCKET_IO_REDIS_REQUESTS_TIMEOUT,
+      publishOnSpecificResponseChannel: true,
+    });
   }
 
   createIOServer(port: number, options?: ServerOptions) {


### PR DESCRIPTION
## Summary
- configure the Socket.IO Redis adapter with a 30s request timeout and node-specific response channel
- make gateway and presence fetchSockets call sites degrade to empty socket lists on Redis adapter timeouts
- add regression tests for rejected fetchSockets paths

## Validation
- pnpm --filter @lootlog/gateway test
- pnpm --filter @lootlog/gateway lint
- pnpm --filter @lootlog/gateway build