### PR TITLE
[codex] refactor game account id lookup

### DIFF
--- a/apps/game-client/src/hooks/use-current-game-account-preferences.test.tsx
+++ b/apps/game-client/src/hooks/use-current-game-account-preferences.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/lib/game", () => ({
     hero: {
       account: 202,
     },
+    getAccountId: () => "202",
   },
 }));
 

--- a/apps/game-client/src/hooks/use-current-game-account-preferences.tsx
+++ b/apps/game-client/src/hooks/use-current-game-account-preferences.tsx
@@ -6,7 +6,7 @@ export const useCurrentGameAccountPreferences = () => {
   const gameInitialized = useGlobalStore(
     (state) => state.gameState.gameInitialized,
   );
-  const accountId = Game.hero?.account ? String(Game.hero.account) : null;
+  const accountId = Game.getAccountId();
   const query = useUserGameAccountPreferences(accountId, gameInitialized);
 
   return {

--- a/apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx
+++ b/apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/game-account-preferences";
 import { useGameAccountPreferencesSync } from "@/hooks/use-game-account-preferences-sync";
 import { getUsersControllerGetUserGameAccountPreferencesQueryKey } from "@/lib/api/generated/main/users/users";
+import type * as UsersApi from "@/lib/api/generated/main/users/users";
 
 const mockUseAccessibleGuilds = vi.fn();
 const mockUseUserGameAccountPreferences = vi.fn();
@@ -16,9 +17,9 @@ const mockFlushPending = vi.fn();
 const mockMutate = vi.fn();
 
 vi.mock("@/lib/api/generated/main/users/users", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/api/generated/main/users/users")
-  >("@/lib/api/generated/main/users/users");
+  const actual = await vi.importActual<typeof UsersApi>(
+    "@/lib/api/generated/main/users/users",
+  );
 
   return {
     ...actual,
@@ -39,6 +40,7 @@ vi.mock("@/lib/game", () => ({
     hero: {
       account: 202,
     },
+    getAccountId: () => "202",
   },
 }));
 

--- a/apps/game-client/src/hooks/use-game-account-preferences-sync.tsx
+++ b/apps/game-client/src/hooks/use-game-account-preferences-sync.tsx
@@ -28,8 +28,7 @@ export const useGameAccountPreferencesSync = () => {
     isLoading: areGuildsLoading,
   } = useUsersControllerGetCurrentUserAccessibleGuilds();
   const queryClient = useQueryClient();
-  const accountId = Game.hero?.account ? String(Game.hero.account) : null;
-  const guildIds = guilds?.map((guild) => guild.id) ?? [];
+  const accountId = Game.getAccountId();
   const seededAccountsRef = useRef<Set<string>>(new Set());
 
   const { data, isLoading, isFetching, isFetched } =
@@ -59,6 +58,7 @@ export const useGameAccountPreferencesSync = () => {
       const queryKey = getUsersControllerGetUserGameAccountPreferencesQueryKey({
         accountId,
       });
+      const guildIds = guilds?.map((guild) => guild.id) ?? [];
       const seededNotifications = data.hasStoredNotifications
         ? data.notifications
         : createNotificationsSettings(guildIds);
@@ -98,7 +98,7 @@ export const useGameAccountPreferencesSync = () => {
     accountId,
     data,
     gameInitialized,
-    guildIds,
+    guilds,
     areGuildsFetched,
     areGuildsFetching,
     areGuildsLoading,

--- a/apps/game-client/src/lib/game.ts
+++ b/apps/game-client/src/lib/game.ts
@@ -21,6 +21,10 @@ export class Game {
     return this.interface === "ni" ? window.Engine.hero.d : window.hero;
   }
 
+  static getAccountId(): string | null {
+    return this.hero?.account ? String(this.hero.account) : null;
+  }
+
   static get map(): GameMap {
     return this.interface === "ni" ? window.Engine.map.d : window.map;
   }

--- a/apps/game-client/src/processors/npcs-detection-processor.test.ts
+++ b/apps/game-client/src/processors/npcs-detection-processor.test.ts
@@ -10,6 +10,8 @@ import { NpcsDetectionProcessor } from "./npcs-detection-processor";
 import type { NpcTpl } from "@lootlog/margonem/npc-tpl-manager";
 import type { GameNpc } from "@lootlog/margonem/npcs";
 import type { GameEvent } from "@lootlog/margonem/game-events";
+import type * as Api from "@/api";
+import type * as LootlogTypes from "@lootlog/types";
 
 const {
   mockCreateNotification,
@@ -35,6 +37,7 @@ const {
       name: "Ithan",
     },
     npcs: [] as GameNpc[],
+    getAccountId: vi.fn(() => "202"),
     getNpcTpl: vi.fn(),
     getNpcIcon: vi.fn(),
     getWorldName: vi.fn(() => "pandora"),
@@ -42,7 +45,7 @@ const {
 }));
 
 vi.mock("@/api", async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import("@/api")>();
+  const originalModule = await importOriginal<typeof Api>();
 
   return {
     ...originalModule,
@@ -60,8 +63,7 @@ vi.mock("@/lib/sound-playback", () => ({
 }));
 
 vi.mock("@lootlog/types", async (importOriginal) => {
-  const originalModule =
-    await importOriginal<typeof import("@lootlog/types")>();
+  const originalModule = await importOriginal<typeof LootlogTypes>();
   return {
     ...originalModule,
     getNpcTypeByWt: (...args: unknown[]) => mockGetNpcTypeByWt(...args),

--- a/apps/game-client/src/processors/npcs-detection-processor.ts
+++ b/apps/game-client/src/processors/npcs-detection-processor.ts
@@ -329,7 +329,7 @@ export class NpcsDetectionProcessor {
   }
 
   private getCurrentAccountId() {
-    return Game.hero?.account ? String(Game.hero.account) : null;
+    return Game.getAccountId();
   }
 
   private isDetectorReady(accountId: string) {


### PR DESCRIPTION
## Summary
- Added `Game.getAccountId()` to centralize current game account ID lookup.
- Updated game account preference hooks and NPC detection processor to use the shared helper.
- Adjusted focused tests and cleaned touched-file lint warnings.

## Verification
- `pnpm exec oxfmt --check apps/game-client/src/lib/game.ts apps/game-client/src/hooks/use-current-game-account-preferences.tsx apps/game-client/src/hooks/use-game-account-preferences-sync.tsx apps/game-client/src/processors/npcs-detection-processor.ts apps/game-client/src/hooks/use-current-game-account-preferences.test.tsx apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx apps/game-client/src/processors/npcs-detection-processor.test.ts`
- `pnpm exec oxlint apps/game-client/src/lib/game.ts apps/game-client/src/hooks/use-current-game-account-preferences.tsx apps/game-client/src/hooks/use-game-account-preferences-sync.tsx apps/game-client/src/processors/npcs-detection-processor.ts apps/game-client/src/hooks/use-current-game-account-preferences.test.tsx apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx apps/game-client/src/processors/npcs-detection-processor.test.ts`
- `pnpm --dir apps/game-client exec vitest run src/hooks/use-current-game-account-preferences.test.tsx src/hooks/use-game-account-preferences-sync.test.tsx src/processors/npcs-detection-processor.test.ts`
- `pnpm turbo run build --filter=@lootlog/game-client...`
- pre-commit hook: lint-staged, changed-package checks, and full `@lootlog/game-client` test suite (`119` files, `576` tests)

Note: initial `pnpm install` populated missing dependencies in the fresh worktree but exited on pnpm build-script approval prompts; no dependency metadata changes are included.