### PR TITLE
[codex] simplify router search parsing

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,14 @@ export interface RouterContext {
   session?: SessionData | null;
 }
 
+const parseSearchValue = (values: string[]) => {
+  if (values.length > 1) {
+    return values;
+  }
+
+  return values[0] ?? "";
+};
+
 const parseSearch = (searchString: string) => {
   const normalizedSearch = searchString.startsWith("?")
     ? searchString.slice(1)
@@ -32,7 +40,7 @@ const parseSearch = (searchString: string) => {
     seenKeys.add(key);
 
     const values = searchParams.getAll(key);
-    parsedSearch[key] = values.length > 1 ? values : (values[0] ?? "");
+    parsedSearch[key] = parseSearchValue(values);
   }
 
   return parsedSearch;


### PR DESCRIPTION
## Summary
- Extracted router search value normalization in `apps/web/src/App.tsx` into a named helper.
- Kept the existing behavior for repeated query keys, single query values, and empty missing values.

## Verification
- `pnpm --filter @lootlog/web lint`
- `pnpm exec oxfmt --check apps/web/src/App.tsx`
- `pnpm turbo run build --filter=@lootlog/web...`
- Pre-commit hook: lint-staged, changed-package lint, format check, changed-package test flow

## Notes
- A direct `pnpm --filter @lootlog/web build` initially failed because workspace dependency artifacts were missing in a fresh checkout; the dependency-aware Turbo build passed.
- `pnpm install` emitted pnpm ignored-builds warnings for native dependencies, but the web lint/build path completed successfully after dependencies were available.