### PR TITLE
[codex] Refactor CLI external env key lookup

### DIFF
--- a/packages/cli/src/utils/env-generator.ts
+++ b/packages/cli/src/utils/env-generator.ts
@@ -105,8 +105,10 @@ const EXTERNAL_VALUE_KEYS = [
   "SEEDING_USER_ID",
 ] as const;
 
+const EXTERNAL_VALUE_KEY_SET = new Set<string>(EXTERNAL_VALUE_KEYS);
+
 const shouldGenerateValue = (key: string): boolean => {
-  return !EXTERNAL_VALUE_KEYS.some((externalKey) => key === externalKey);
+  return !EXTERNAL_VALUE_KEY_SET.has(key);
 };
 
 const generateSmartDefault = (


### PR DESCRIPTION
## Summary

- Replace the CLI env generator's repeated external-key array scan with a `Set` lookup.
- Keep behavior unchanged while matching the existing shared-key lookup pattern in the same module.

## Verification

- `pnpm --filter @lootlog/cli test`
- `pnpm exec oxlint packages/cli/src/utils/env-generator.ts`
- `pnpm exec oxfmt --check packages/cli/src/utils/env-generator.ts`
- `pnpm turbo run build --filter=@lootlog/cli`
- `.husky/pre-commit` (also ran during `git commit`)

Note: `@lootlog/cli` does not define `lint`, `format:check`, or `build` package scripts, so filtered Turbo lint/format build work was limited to available dependency tasks and the CLI test.