### PR TITLE
[codex] Remove battle component memo wrappers

### DIFF
--- a/apps/web/src/components/battle/actions/battle-action-item.tsx
+++ b/apps/web/src/components/battle/actions/battle-action-item.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@lootlog/ui/lib/utils";
-import { memo, type FC, type ReactNode } from "react";
+import type { FC, ReactNode } from "react";
 import { Trans } from "react-i18next";
 import {
   generateDynamicValuesAndComponents,
@@ -23,54 +23,50 @@ export type BattleActionItemProps = {
   dynamicValuesConfig?: DynamicValuesConfig;
 };
 
-export const BattleActionItem: FC<BattleActionItemProps> = memo(
-  ({
-    action,
-    attacker,
-    defender,
-    event,
-    className,
-    customComponents = {},
-    transformValue,
-    dynamicValuesConfig,
-  }) => {
-    const roundedValue = roundValue(action.value);
+export const BattleActionItem: FC<BattleActionItemProps> = ({
+  action,
+  attacker,
+  defender,
+  event,
+  className,
+  customComponents = {},
+  transformValue,
+  dynamicValuesConfig,
+}) => {
+  const roundedValue = roundValue(action.value);
 
-    const processedValue = transformValue
-      ? transformValue(roundedValue, action.type)
-      : roundedValue;
-    const actionPresentation = getBattleActionPresentation(action);
+  const processedValue = transformValue
+    ? transformValue(roundedValue, action.type)
+    : roundedValue;
+  const actionPresentation = getBattleActionPresentation(action);
 
-    const dynamicData = generateDynamicValuesAndComponents(
-      action.value,
-      dynamicValuesConfig?.prefix || "v",
-      dynamicValuesConfig?.component || <span className="font-semibold" />,
-    );
+  const dynamicData = generateDynamicValuesAndComponents(
+    action.value,
+    dynamicValuesConfig?.prefix ?? "v",
+    dynamicValuesConfig?.component ?? <span className="font-semibold" />,
+  );
 
-    return (
-      <div className={cn("px-4 py-1 bg-gray-100/10", className)}>
-        <Trans
-          i18nKey={actionPresentation.i18nKey}
-          values={{
-            name: attacker?.name,
-            defenderName: defender?.name,
-            value: processedValue,
-            hp: roundHpPercentage(event.attackerHpPercentage),
-            defenderHp: roundHpPercentage(event.defenderHpPercentage),
-            v1: 0,
-            ...actionPresentation.values,
-            ...dynamicData.values,
-          }}
-          components={{
-            value: <span className="font-semibold" />,
-            ...dynamicData.components,
-            ...dynamicValuesConfig?.customComponents,
-            ...customComponents,
-          }}
-        />
-      </div>
-    );
-  },
-);
-
-BattleActionItem.displayName = "BattleActionItem";
+  return (
+    <div className={cn("px-4 py-1 bg-gray-100/10", className)}>
+      <Trans
+        i18nKey={actionPresentation.i18nKey}
+        values={{
+          name: attacker?.name,
+          defenderName: defender?.name,
+          value: processedValue,
+          hp: roundHpPercentage(event.attackerHpPercentage),
+          defenderHp: roundHpPercentage(event.defenderHpPercentage),
+          v1: 0,
+          ...actionPresentation.values,
+          ...dynamicData.values,
+        }}
+        components={{
+          value: <span className="font-semibold" />,
+          ...dynamicData.components,
+          ...dynamicValuesConfig?.customComponents,
+          ...customComponents,
+        }}
+      />
+    </div>
+  );
+};

--- a/apps/web/src/components/battle/actions/battle-buff-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-buff-actions.tsx
@@ -2,7 +2,7 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
+import type { FC } from "react";
 import { BattleActionItem } from "./battle-action-item";
 
 export type BattleBuffActionsProps = {
@@ -12,26 +12,27 @@ export type BattleBuffActionsProps = {
   eventIndex: number;
 };
 
-export const BattleBuffActions: FC<BattleBuffActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex }) => {
-    if (actions.length === 0) return null;
+export const BattleBuffActions: FC<BattleBuffActionsProps> = ({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+}) => {
+  if (actions.length === 0) return null;
 
-    return (
-      <>
-        {actions.map((action, aIndex) => (
-          <BattleActionItem
-            key={`buffActions-${eventIndex}-${aIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            customComponents={{
-              value: <span className="font-bold text-orange-500" />,
-            }}
-          />
-        ))}
-      </>
-    );
-  },
-);
-
-BattleBuffActions.displayName = "BattleBuffActions";
+  return (
+    <>
+      {actions.map((action, aIndex) => (
+        <BattleActionItem
+          key={`buffActions-${eventIndex}-${aIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          customComponents={{
+            value: <span className="font-bold text-orange-500" />,
+          }}
+        />
+      ))}
+    </>
+  );
+};

--- a/apps/web/src/components/battle/actions/battle-outcome-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-outcome-actions.tsx
@@ -2,7 +2,7 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
+import type { FC } from "react";
 import { BattleActionItem } from "./battle-action-item";
 
 export type BattleOutcomeActionsProps = {
@@ -12,26 +12,27 @@ export type BattleOutcomeActionsProps = {
   eventIndex: number;
 };
 
-export const BattleOutcomeActions: FC<BattleOutcomeActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex }) => {
-    if (actions.length === 0) return null;
+export const BattleOutcomeActions: FC<BattleOutcomeActionsProps> = ({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+}) => {
+  if (actions.length === 0) return null;
 
-    return (
-      <>
-        {actions.map((action, sIndex) => (
-          <BattleActionItem
-            key={`outcomeActions-${eventIndex}-${sIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            customComponents={{
-              value: <span className="font-semibold" />,
-            }}
-          />
-        ))}
-      </>
-    );
-  },
-);
-
-BattleOutcomeActions.displayName = "BattleOutcomeActions";
+  return (
+    <>
+      {actions.map((action, sIndex) => (
+        <BattleActionItem
+          key={`outcomeActions-${eventIndex}-${sIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          customComponents={{
+            value: <span className="font-semibold" />,
+          }}
+        />
+      ))}
+    </>
+  );
+};

--- a/apps/web/src/components/battle/actions/battle-passive-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-passive-actions.tsx
@@ -2,7 +2,7 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
+import type { FC } from "react";
 import { BattleActionItem } from "./battle-action-item";
 import { cn } from "@lootlog/ui/lib/utils";
 
@@ -14,41 +14,43 @@ export type BattlePassiveActionsProps = {
   userTeam?: number;
 };
 
-export const BattlePassiveActions: FC<BattlePassiveActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex, userTeam }) => {
-    if (actions.length === 0) return null;
+export const BattlePassiveActions: FC<BattlePassiveActionsProps> = ({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+  userTeam,
+}) => {
+  if (actions.length === 0) return null;
 
-    return (
-      <div
-        className={cn("py-1 bg-gray-100/10", {
-          "bg-red-400/[15%]": attacker?.team !== userTeam,
-          "bg-green-400/[15%]": attacker?.team === userTeam,
-        })}
-      >
-        {actions.map((action, sIndex) => (
-          <BattleActionItem
-            key={`passiveActions-${eventIndex}-${sIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            dynamicValuesConfig={{
-              prefix: "v",
-              component: <span className="font-semibold" />,
-            }}
-            className={cn("p-0 px-4 bg-transparent")}
-            customComponents={{
-              value: <span className="font-semibold" />,
-              heal: <span className="font-semibold text-blue-300" />,
-              poison: <span className="font-semibold text-green-400" />,
-              fire: <span className="font-semibold text-red-400" />,
-              light: <span className="font-semibold text-yellow-400" />,
-              anguish: <span className="font-semibold text-red-600" />,
-            }}
-          />
-        ))}
-      </div>
-    );
-  },
-);
-
-BattlePassiveActions.displayName = "BattlePassiveActions";
+  return (
+    <div
+      className={cn("py-1 bg-gray-100/10", {
+        "bg-red-400/[15%]": attacker?.team !== userTeam,
+        "bg-green-400/[15%]": attacker?.team === userTeam,
+      })}
+    >
+      {actions.map((action, sIndex) => (
+        <BattleActionItem
+          key={`passiveActions-${eventIndex}-${sIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          dynamicValuesConfig={{
+            prefix: "v",
+            component: <span className="font-semibold" />,
+          }}
+          className={cn("p-0 px-4 bg-transparent")}
+          customComponents={{
+            value: <span className="font-semibold" />,
+            heal: <span className="font-semibold text-blue-300" />,
+            poison: <span className="font-semibold text-green-400" />,
+            fire: <span className="font-semibold text-red-400" />,
+            light: <span className="font-semibold text-yellow-400" />,
+            anguish: <span className="font-semibold text-red-600" />,
+          }}
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/components/battle/actions/battle-spell-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-spell-actions.tsx
@@ -3,7 +3,7 @@ import type {
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
 import { cn } from "@lootlog/ui/lib/utils";
-import { memo, type FC } from "react";
+import type { FC } from "react";
 import { Trans } from "react-i18next";
 import { generateDynamicValuesAndComponents } from "../utils/dynamic-values-helper";
 import {
@@ -20,51 +20,54 @@ export type BattleSpellActionsProps = {
   userTeam?: number;
 };
 
-export const BattleSpellActions: FC<BattleSpellActionsProps> = memo(
-  ({ actions, attacker, defender, event, eventIndex, userTeam }) => {
-    if (actions.length === 0) return null;
+export const BattleSpellActions: FC<BattleSpellActionsProps> = ({
+  actions,
+  attacker,
+  defender,
+  event,
+  eventIndex,
+  userTeam,
+}) => {
+  if (actions.length === 0) return null;
 
-    const transformValue = (value: string, type: string): string => {
-      if (type === "energy" || type === "mana") {
-        return transformAndRoundEnergyMana(value);
-      }
-      return value;
-    };
+  const transformValue = (value: string, type: string): string => {
+    if (type === "energy" || type === "mana") {
+      return transformAndRoundEnergyMana(value);
+    }
+    return value;
+  };
 
-    const teamColors = {
-      "bg-red-400/10": attacker?.team !== userTeam,
-      "bg-green-400/10": attacker?.team === userTeam,
-    };
+  const teamColors = {
+    "bg-red-400/10": attacker?.team !== userTeam,
+    "bg-green-400/10": attacker?.team === userTeam,
+  };
 
-    return (
-      <div className={cn("px-4 py-1 bg-gray-100/10", teamColors)}>
-        {actions.map((action, sIndex) => {
-          const processedValue = transformValue(action.value, action.type);
-          const dynamicData = generateDynamicValuesAndComponents(action.value);
+  return (
+    <div className={cn("px-4 py-1 bg-gray-100/10", teamColors)}>
+      {actions.map((action, sIndex) => {
+        const processedValue = transformValue(action.value, action.type);
+        const dynamicData = generateDynamicValuesAndComponents(action.value);
 
-          return (
-            <div key={`spellActions-${eventIndex}-${sIndex}`}>
-              <Trans
-                i18nKey={`battle.${action.type}`}
-                values={{
-                  name: attacker?.name,
-                  defenderName: defender?.name,
-                  value: processedValue,
-                  hp: roundHpPercentage(event.attackerHpPercentage),
-                  defenderHp: roundHpPercentage(event.defenderHpPercentage),
-                  ...dynamicData.values,
-                }}
-                components={{
-                  value: <span className="font-semibold" />,
-                  ...dynamicData.components,
-                }}
-              />
-            </div>
-          );
-        })}
-      </div>
-    );
-  },
-);
-
-BattleSpellActions.displayName = "BattleSpellActions";
+        return (
+          <div key={`spellActions-${eventIndex}-${sIndex}`}>
+            <Trans
+              i18nKey={`battle.${action.type}`}
+              values={{
+                name: attacker?.name,
+                defenderName: defender?.name,
+                value: processedValue,
+                hp: roundHpPercentage(event.attackerHpPercentage),
+                defenderHp: roundHpPercentage(event.defenderHpPercentage),
+                ...dynamicData.values,
+              }}
+              components={{
+                value: <span className="font-semibold" />,
+                ...dynamicData.components,
+              }}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/web/src/components/battle/actions/battle-system-actions.tsx
+++ b/apps/web/src/components/battle/actions/battle-system-actions.tsx
@@ -2,7 +2,7 @@ import type {
   BattleWarrior as Warrior,
   RawBattleParsedEvent,
 } from "@/lib/api/battlelog-types";
-import { memo, type FC } from "react";
+import type { FC } from "react";
 import { BattleActionItem } from "./battle-action-item";
 
 export type BattleSystemActionsProps = {
@@ -12,26 +12,27 @@ export type BattleSystemActionsProps = {
   eventIndex: number;
 };
 
-export const BattleSystemActions: FC<BattleSystemActionsProps> = memo(
-  ({ actions, attacker, event, eventIndex }) => {
-    if (actions.length === 0) return null;
+export const BattleSystemActions: FC<BattleSystemActionsProps> = ({
+  actions,
+  attacker,
+  event,
+  eventIndex,
+}) => {
+  if (actions.length === 0) return null;
 
-    return (
-      <>
-        {actions.map((action, aIndex) => (
-          <BattleActionItem
-            key={`systemActions-${eventIndex}-${aIndex}`}
-            action={action}
-            attacker={attacker}
-            event={event}
-            customComponents={{
-              value: <span className="font-semibold" />,
-            }}
-          />
-        ))}
-      </>
-    );
-  },
-);
-
-BattleSystemActions.displayName = "BattleSystemActions";
+  return (
+    <>
+      {actions.map((action, aIndex) => (
+        <BattleActionItem
+          key={`systemActions-${eventIndex}-${aIndex}`}
+          action={action}
+          attacker={attacker}
+          event={event}
+          customComponents={{
+            value: <span className="font-semibold" />,
+          }}
+        />
+      ))}
+    </>
+  );
+};

--- a/apps/web/src/components/battle/battle-header.tsx
+++ b/apps/web/src/components/battle/battle-header.tsx
@@ -1,52 +1,51 @@
 import type { BattleWarrior as Warrior } from "@/lib/api/battlelog-types";
 import { cn } from "@lootlog/ui/lib/utils";
-import { memo, type FC } from "react";
+import type { FC } from "react";
 
 export type BattleHeaderProps = {
   warriors: Warrior[];
   characterId?: string;
 };
 
-export const BattleHeader: FC<BattleHeaderProps> = memo(
-  ({ warriors, characterId }) => {
-    const attackingTeam = warriors.filter((w) => w.team === 1);
-    const defendingTeam = warriors.filter((w) => w.team === 2);
+export const BattleHeader: FC<BattleHeaderProps> = ({
+  warriors,
+  characterId,
+}) => {
+  const attackingTeam = warriors.filter((w) => w.team === 1);
+  const defendingTeam = warriors.filter((w) => w.team === 2);
 
-    return (
-      <>
-        <li className="bg-gray-500/10 px-4 py-1 border-b-2 border-background border-solid">
-          Rozpoczęła się walka pomiędzy{" "}
-          {attackingTeam.map((w) => {
-            const isLast = w === attackingTeam[attackingTeam.length - 1];
+  return (
+    <>
+      <li className="bg-gray-500/10 px-4 py-1 border-b-2 border-background border-solid">
+        Rozpoczęła się walka pomiędzy{" "}
+        {attackingTeam.map((w) => {
+          const isLast = w === attackingTeam[attackingTeam.length - 1];
 
-            return (
-              <span
-                key={w.originalId}
-                className={cn({ "font-bold": w.originalId === characterId })}
-              >
-                {w.name} ({w.lvl}
-                {w.prof}){!isLast && ", "}
-              </span>
-            );
-          })}{" "}
-          a{" "}
-          {defendingTeam.map((w) => {
-            const isLast = w === defendingTeam[defendingTeam.length - 1];
+          return (
+            <span
+              key={w.originalId}
+              className={cn({ "font-bold": w.originalId === characterId })}
+            >
+              {w.name} ({w.lvl}
+              {w.prof}){!isLast && ", "}
+            </span>
+          );
+        })}{" "}
+        a{" "}
+        {defendingTeam.map((w) => {
+          const isLast = w === defendingTeam[defendingTeam.length - 1];
 
-            return (
-              <span
-                key={w.originalId}
-                className={cn({ "font-bold": w.originalId === characterId })}
-              >
-                {w.name} ({w.lvl}
-                {w.prof}){!isLast && ", "}
-              </span>
-            );
-          })}
-        </li>
-      </>
-    );
-  },
-);
-
-BattleHeader.displayName = "BattleHeader";
+          return (
+            <span
+              key={w.originalId}
+              className={cn({ "font-bold": w.originalId === characterId })}
+            >
+              {w.name} ({w.lvl}
+              {w.prof}){!isLast && ", "}
+            </span>
+          );
+        })}
+      </li>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary
- Removes manual React.memo wrappers from battle action display components and the battle header.
- Drops now-unneeded displayName assignments and memo imports.
- Uses nullish coalescing for dynamic value defaults while touching the shared action item.

## Verification
- pnpm exec oxfmt apps/web/src/components/battle/actions/battle-action-item.tsx apps/web/src/components/battle/actions/battle-buff-actions.tsx apps/web/src/components/battle/actions/battle-outcome-actions.tsx apps/web/src/components/battle/actions/battle-passive-actions.tsx apps/web/src/components/battle/actions/battle-spell-actions.tsx apps/web/src/components/battle/actions/battle-system-actions.tsx apps/web/src/components/battle/battle-header.tsx
- pnpm --filter @lootlog/web lint
- pnpm --filter @lootlog/types build
- pnpm --filter @lootlog/socket-parser build
- pnpm --filter @lootlog/web build
- pnpm turbo run lint --filter=[HEAD]
- pnpm turbo run format:check --filter=[HEAD] (no package format task for @lootlog/web)
- pnpm turbo run test --filter=[HEAD] (no @lootlog/web test script; dependency builds resolved from cache)
- pre-commit hook passed during commit

Note: initial pnpm install exited nonzero because pnpm reported ignored dependency build scripts requiring approve-builds; existing toolchain checks still ran successfully after dependency install.