### PR TITLE
[codex] refactor activity suggestion limits

### DIFF
--- a/apps/activity/src/activities/services/activities-query.service.spec.ts
+++ b/apps/activity/src/activities/services/activities-query.service.spec.ts
@@ -1,0 +1,96 @@
+import { ActivitiesQueryService } from "./activities-query.service";
+import type { PrismaService } from "src/shared/db/prisma.service";
+
+describe("ActivitiesQueryService", () => {
+  const activityFindManyMock = vi.fn();
+  const activityActorSnapshotFindManyMock = vi.fn();
+  const prismaServiceMock = {
+    activity: {
+      findMany: activityFindManyMock,
+    },
+    activityActorSnapshot: {
+      findMany: activityActorSnapshotFindManyMock,
+    },
+  } as unknown as PrismaService;
+
+  let service: ActivitiesQueryService;
+
+  beforeEach(() => {
+    service = new ActivitiesQueryService(prismaServiceMock);
+    vi.clearAllMocks();
+  });
+
+  it("deduplicates suggested actor names and clamps the lower limit", async () => {
+    activityActorSnapshotFindManyMock.mockResolvedValue([
+      { name: " Player " },
+      { name: "player" },
+    ]);
+
+    const names = await service.suggestActorNames("guild-1", "  pla ", 0);
+
+    expect(names).toEqual(["Player"]);
+    expect(activityActorSnapshotFindManyMock).toHaveBeenCalledWith({
+      where: {
+        activities: {
+          some: { guildId: "guild-1" },
+        },
+        name: {
+          contains: "pla",
+          mode: "insensitive",
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 2,
+      select: { name: true },
+    });
+  });
+
+  it("clamps suggested clan names to the maximum limit", async () => {
+    activityActorSnapshotFindManyMock.mockResolvedValue(
+      Array.from({ length: 60 }, (_, index) => ({
+        clanName: `Clan ${index + 1}`,
+      })),
+    );
+
+    const names = await service.suggestClanNames("guild-1", undefined, 80);
+
+    expect(names).toHaveLength(50);
+    expect(activityActorSnapshotFindManyMock).toHaveBeenCalledWith({
+      where: {
+        activities: {
+          some: { guildId: "guild-1" },
+        },
+        clanName: {
+          not: null,
+          notIn: [""],
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      take: 100,
+      select: { clanName: true },
+    });
+  });
+
+  it("clamps suggested worlds to the lower limit and trims results", async () => {
+    activityFindManyMock.mockResolvedValue([{ world: "  Aether  " }]);
+
+    const worlds = await service.suggestWorlds("guild-1", "  ae ", -5);
+
+    expect(worlds).toEqual(["Aether"]);
+    expect(activityFindManyMock).toHaveBeenCalledWith({
+      where: {
+        guildId: "guild-1",
+        world: {
+          not: null,
+          notIn: [""],
+          contains: "ae",
+          mode: "insensitive",
+        },
+      },
+      distinct: ["world"],
+      select: { world: true },
+      orderBy: { world: "asc" },
+      take: 1,
+    });
+  });
+});

--- a/apps/activity/src/activities/services/activities-query.service.ts
+++ b/apps/activity/src/activities/services/activities-query.service.ts
@@ -4,6 +4,10 @@ import { PrismaService } from "src/shared/db/prisma.service";
 import type { QueryActivitiesDto } from "../dto/query-activities.dto";
 import { mapActivityDetails } from "../utils/map-activity-details";
 
+const DEFAULT_SUGGESTION_LIMIT = 10;
+const MIN_SUGGESTION_LIMIT = 1;
+const MAX_SUGGESTION_LIMIT = 50;
+
 @Injectable()
 export class ActivitiesQueryService {
   constructor(private readonly prisma: PrismaService) {}
@@ -94,9 +98,9 @@ export class ActivitiesQueryService {
   async suggestActorNames(
     guildId: string,
     search?: string,
-    limit = 10,
+    limit = DEFAULT_SUGGESTION_LIMIT,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.normalizeSuggestionLimit(limit);
     const trimmedSearch = search?.trim();
 
     const where: Prisma.ActivityActorSnapshotWhereInput = {
@@ -130,7 +134,7 @@ export class ActivitiesQueryService {
     search?: string,
     limit = 20,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.normalizeSuggestionLimit(limit);
     const trimmedSearch = search?.trim();
 
     const worldFilter = this.buildNonEmptyNullableFilter(trimmedSearch);
@@ -156,9 +160,9 @@ export class ActivitiesQueryService {
   async suggestClanNames(
     guildId: string,
     search?: string,
-    limit = 10,
+    limit = DEFAULT_SUGGESTION_LIMIT,
   ): Promise<string[]> {
-    const limitValue = Math.min(Math.max(limit, 1), 50);
+    const limitValue = this.normalizeSuggestionLimit(limit);
     const trimmedSearch = search?.trim();
 
     const clanNameFilter = this.buildNonEmptyNullableFilter(trimmedSearch);
@@ -216,6 +220,13 @@ export class ActivitiesQueryService {
     }
 
     return filter;
+  }
+
+  private normalizeSuggestionLimit(limit: number): number {
+    return Math.min(
+      Math.max(limit, MIN_SUGGESTION_LIMIT),
+      MAX_SUGGESTION_LIMIT,
+    );
   }
 
   private deduplicateNames(


### PR DESCRIPTION
## What changed

- Extracted activity suggestion limit clamping into a named helper with shared bounds.
- Replaced repeated inline clamp expressions in actor, clan, and world suggestion paths.
- Added focused `ActivitiesQueryService` specs for limit bounds, search trimming, result trimming, and case-insensitive name deduplication.

## Why

The suggestion methods were repeating the same min/max normalization logic. A single helper makes the bounds explicit and easier to keep consistent without changing behavior.

## Verification

- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/activity test -- src/activities/services/activities-query.service.spec.ts`
- `pnpm --filter @lootlog/activity lint`
- `pnpm --filter @lootlog/activity build`
- `pnpm exec oxfmt --check apps/activity/src/activities/services/activities-query.service.ts apps/activity/src/activities/services/activities-query.service.spec.ts`
- Commit pre-hook: lint-staged formatting/lint, changed-package lint, changed-package test

Note: the initial `pnpm install` populated dependencies but exited with pnpm's ignored-builds policy prompt; required workspace packages were then built directly before verification.