### PR TITLE
[codex] Derive gateway feature room list

### DIFF
--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -38,20 +38,11 @@ const FEATURE_ROOMS = {
   },
 } as const;
 
-const ALL_FEATURE_ROOMS: Array<{ feature: FeatureName; tier: TierName }> = [
-  { feature: "chat", tier: "base" },
-  { feature: "chat", tier: "titans" },
-  { feature: "chat", tier: "heroes" },
-  { feature: "timers", tier: "base" },
-  { feature: "timers", tier: "titans" },
-  { feature: "timers", tier: "heroes" },
-  { feature: "notifications", tier: "base" },
-  { feature: "notifications", tier: "titans" },
-  { feature: "notifications", tier: "heroes" },
-  { feature: "loots", tier: "base" },
-  { feature: "loots", tier: "titans" },
-  { feature: "loots", tier: "heroes" },
-];
+const FEATURE_NAMES = Object.keys(FEATURE_ROOMS) as FeatureName[];
+const TIER_NAMES = Object.keys(FEATURE_ROOMS.chat) as TierName[];
+const ALL_FEATURE_ROOMS = FEATURE_NAMES.flatMap((feature) =>
+  TIER_NAMES.map((tier) => ({ feature, tier })),
+);
 
 export function buildRoomName(
   guildId: string,


### PR DESCRIPTION
## Summary
- derive gateway feature/tier room combinations from the `FEATURE_ROOMS` permission map
- remove the duplicated manual `ALL_FEATURE_ROOMS` list so new features or tiers only need one source of truth

## Verification
- `pnpm --filter @lootlog/gateway test -- src/gateway/utils/room-utils.spec.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway build`
- `pnpm exec oxfmt --check apps/gateway/src/gateway/utils/room-utils.ts`
- `pnpm turbo run lint build test check-types --filter=@lootlog/gateway`
- pre-commit hooks passed during `git commit`

Note: `pnpm install` populated dependencies but exited nonzero because pnpm requested build-script approval metadata; no workspace approval changes were kept.