### PR TITLE
[codex] clarify loot stats filter params

### DIFF
--- a/apps/api/src/loots/services/loot-stats.service.ts
+++ b/apps/api/src/loots/services/loot-stats.service.ts
@@ -130,10 +130,18 @@ export class LootStatsService {
     npcTypes?: NpcType[],
     excludeColossus?: boolean,
   ) {
-    const dateCondition = dateFrom ? `AND l."createdAt" >= $2` : "";
-    const worldCondition = world ? `AND l.world = $${dateFrom ? 3 : 2}` : "";
+    const dateParamIndex = this.getDateFilterParamIndex();
+    const worldParamIndex = this.getWorldFilterParamIndex(dateFrom);
+    const npcTypesParamIndex = this.getNpcTypesFilterParamIndex(
+      dateFrom,
+      world,
+    );
+    const dateCondition = dateFrom
+      ? `AND l."createdAt" >= $${dateParamIndex}`
+      : "";
+    const worldCondition = world ? `AND l.world = $${worldParamIndex}` : "";
     const npcTypeCondition = npcTypes?.length
-      ? `AND ns.type = ANY($${(dateFrom ? 3 : 2) + (world ? 1 : 0)}::text[])`
+      ? `AND ns.type = ANY($${npcTypesParamIndex}::text[])`
       : "";
     const excludeColossusCondition = excludeColossus
       ? `AND ns.type != 'COLOSSUS'`
@@ -147,6 +155,32 @@ export class LootStatsService {
       excludeColossusCondition,
       needsNpcFilter,
     };
+  }
+
+  private getDateFilterParamIndex() {
+    return 2;
+  }
+
+  private getWorldFilterParamIndex(dateFrom: Date | null) {
+    if (dateFrom) {
+      return 3;
+    }
+
+    return 2;
+  }
+
+  private getNpcTypesFilterParamIndex(dateFrom: Date | null, world?: string) {
+    let paramIndex = 2;
+
+    if (dateFrom) {
+      paramIndex += 1;
+    }
+
+    if (world) {
+      paramIndex += 1;
+    }
+
+    return paramIndex;
   }
 
   private buildFilterParams(


### PR DESCRIPTION
## Summary

- Extracted loot stats SQL filter placeholder calculations into named helper methods.
- Removed inline ternary arithmetic from NPC type filter construction while preserving the existing parameter order.

## Verification

- `pnpm --filter @lootlog/api lint`
- `pnpm turbo run build --filter=@lootlog/api`
- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/loots/loots.controller.spec.ts`
- `pnpm --filter @lootlog/api test`
- Pre-commit hook: formatting, changed-package lint/build/test

Note: local verification required syncing injected workspace packages by building `@lootlog/nest-shared`, `@lootlog/api-helpers`, and `@lootlog/types` after dependency install.