### PR TITLE
[codex] clean up timer settings sync

### DIFF
--- a/apps/game-client/src/store/timer-settings-sync.ts
+++ b/apps/game-client/src/store/timer-settings-sync.ts
@@ -13,24 +13,11 @@ const pendingGuildPayloads: Map<string, UpdateGuildTimerSettingsPayload> =
 const SYNC_DEBOUNCE_MS = 500;
 
 type MutateGlobalFn = (payload: UpdateTimerSettingsPayload) => void;
-type MutateGuildFn = (payload: UpdateGuildTimerSettingsPayload) => void;
 
 let globalMutateFn: MutateGlobalFn | null = null;
-const guildMutateFns: Map<string, MutateGuildFn> = new Map();
 
 export const registerGlobalSettingsMutation = (mutateFn: MutateGlobalFn) => {
   globalMutateFn = mutateFn;
-};
-
-const registerGuildSettingsMutation = (
-  guildId: string,
-  mutateFn: MutateGuildFn,
-) => {
-  guildMutateFns.set(guildId, mutateFn);
-};
-
-const unregisterGuildSettingsMutation = (guildId: string) => {
-  guildMutateFns.delete(guildId);
 };
 
 export const debouncedSyncGlobalSettings = (
@@ -69,7 +56,7 @@ export const debouncedSyncGuildSettings = (
   guildId: string,
   payload: UpdateGuildTimerSettingsPayload,
 ) => {
-  const existingPayload = pendingGuildPayloads.get(guildId) || {};
+  const existingPayload = pendingGuildPayloads.get(guildId) ?? {};
   pendingGuildPayloads.set(guildId, { ...existingPayload, ...payload });
 
   const existingTimeout = guildSyncTimeouts.get(guildId);
@@ -78,7 +65,6 @@ export const debouncedSyncGuildSettings = (
   }
 
   const timeoutId = setTimeout(() => {
-    const payloadToSend = { ...pendingGuildPayloads.get(guildId) };
     pendingGuildPayloads.delete(guildId);
 
     const { syncEnabled } = useTimersStore.getState();
@@ -88,32 +74,11 @@ export const debouncedSyncGuildSettings = (
       return;
     }
 
-    const mutateFn = guildMutateFns.get(guildId);
-    if (!mutateFn) {
-      console.warn(
-        `[TimerSync] Guild mutation not registered for ${guildId}, skipping sync`,
-      );
-      guildSyncTimeouts.delete(guildId);
-      return;
-    }
-
-    mutateFn(payloadToSend);
+    console.warn(
+      `[TimerSync] Guild mutation not registered for ${guildId}, skipping sync`,
+    );
     guildSyncTimeouts.delete(guildId);
   }, SYNC_DEBOUNCE_MS);
 
   guildSyncTimeouts.set(guildId, timeoutId);
-};
-
-const clearAllSyncTimeouts = () => {
-  if (syncTimeoutId) {
-    clearTimeout(syncTimeoutId);
-    syncTimeoutId = null;
-  }
-  pendingGlobalPayload = {};
-
-  for (const timeoutId of guildSyncTimeouts.values()) {
-    clearTimeout(timeoutId);
-  }
-  guildSyncTimeouts.clear();
-  pendingGuildPayloads.clear();
 };


### PR DESCRIPTION
## Summary
- removed unreachable guild mutation registration helpers and timeout cleanup from timer settings sync
- simplified the guild pending payload fallback to use nullish coalescing
- kept the existing unregistered guild sync warning path explicit

## Verification
- pnpm --filter @lootlog/types --filter @lootlog/margonem --filter @lootlog/socket-parser build
- pnpm --filter @lootlog/game-client test
- pnpm --filter @lootlog/game-client build
- pnpm exec oxfmt --check apps/game-client/src/store/timer-settings-sync.ts
- pnpm exec oxlint apps/game-client/src/store/timer-settings-sync.ts (passes with pre-existing console warnings)
- pnpm lint
- pnpm format:check
- pre-commit hook during git commit
