### PR TITLE
[codex] remove web guild hook memoization

### DIFF
--- a/apps/web/src/features/guild/events/hooks/utils/use-local-coverage-timer.ts
+++ b/apps/web/src/features/guild/events/hooks/utils/use-local-coverage-timer.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { formatDurationPadded } from "../../utils/format-duration";
 
 export type CoverageGapType = "UNASSIGNED" | "UNCOVERED";
@@ -27,7 +27,7 @@ export const useLocalCoverageTimer = (
   const initializedRef = useRef(false);
   const usedBackendValueRef = useRef(false);
 
-  const gapType = useMemo(() => getGapTypeFromStatus(status), [status]);
+  const gapType = getGapTypeFromStatus(status);
 
   useEffect(() => {
     const prevGapType = prevGapTypeRef.current;

--- a/apps/web/src/features/guild/reservations/schedule/use-schedule-navigation.ts
+++ b/apps/web/src/features/guild/reservations/schedule/use-schedule-navigation.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState } from "react";
 import {
   getISOWeek,
   getISOWeekYear,
@@ -15,7 +15,7 @@ export function useScheduleNavigation() {
   const [currentYear, setCurrentYear] = useState(initialYear);
   const [currentWeek, setCurrentWeek] = useState(initialWeek);
 
-  const handlePrevWeek = useCallback(() => {
+  const handlePrevWeek = () => {
     if (currentWeek > 1) {
       setCurrentWeek(currentWeek - 1);
     } else {
@@ -23,9 +23,9 @@ export function useScheduleNavigation() {
       setCurrentYear(prevYear);
       setCurrentWeek(getLastISOWeek(prevYear));
     }
-  }, [currentWeek, currentYear]);
+  };
 
-  const handleNextWeek = useCallback(() => {
+  const handleNextWeek = () => {
     const lastWeek = getLastISOWeek(currentYear);
     if (currentWeek < lastWeek) {
       setCurrentWeek(currentWeek + 1);
@@ -33,12 +33,9 @@ export function useScheduleNavigation() {
       setCurrentYear(currentYear + 1);
       setCurrentWeek(1);
     }
-  }, [currentWeek, currentYear]);
+  };
 
-  const weekStart = useMemo(
-    () => getDateOfISOWeek(currentWeek, currentYear),
-    [currentWeek, currentYear],
-  );
+  const weekStart = getDateOfISOWeek(currentWeek, currentYear);
 
   const monthName = MONTH_NAMES[weekStart.getMonth()] ?? "";
 


### PR DESCRIPTION
## Summary
- removed unnecessary React memoization from two small web guild hooks
- kept the coverage timer status mapping and schedule navigation behavior unchanged
- aligned the touched hooks with the repo React Compiler guidance

## Verification
- pnpm exec oxfmt --check apps/web/src/features/guild/events/hooks/utils/use-local-coverage-timer.ts apps/web/src/features/guild/reservations/schedule/use-schedule-navigation.ts
- pnpm --filter @lootlog/web lint
- pnpm build --filter=@lootlog/web
- git commit pre-commit hook passed (lint-staged, changed-package lint, changed-package test pipeline)