### PR TITLE
[codex] Type game-client HMR teardown hook

### DIFF
--- a/apps/game-client/src/App.tsx
+++ b/apps/game-client/src/App.tsx
@@ -32,12 +32,15 @@ import { BackendPreferencesWarning } from "@/features/backend-preferences-warnin
 
 const THEME_STORAGE_KEY = storageKey("lootlog-theme");
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- HMR teardown guard
-const win = window as any;
-if (win.__lootlogApiTeardown) {
-  win.__lootlogApiTeardown();
+type LootlogApiWindow = Window & {
+  __lootlogApiTeardown?: () => void;
+};
+
+const lootlogApiWindow = window as LootlogApiWindow;
+if (lootlogApiWindow.__lootlogApiTeardown) {
+  lootlogApiWindow.__lootlogApiTeardown();
 }
-win.__lootlogApiTeardown = bootstrapPublicApi(queryClient);
+lootlogApiWindow.__lootlogApiTeardown = bootstrapPublicApi(queryClient);
 
 function AppContent() {
   useGameEventHandlers();


### PR DESCRIPTION
## Summary

- Replace the loose `window as any` cast used for the game-client public API HMR teardown hook with a local `LootlogApiWindow` type.
- Keep the existing teardown/rebootstrap behavior unchanged while removing the explicit-any lint suppression.

## Verification

- `pnpm exec oxfmt --check apps/game-client/src/App.tsx`
- `pnpm exec oxlint apps/game-client/src/App.tsx` (exit 0; reports existing `console.error` warning in the file)
- `pnpm turbo run build --filter=@lootlog/game-client`
- `pnpm turbo run test --filter=@lootlog/game-client`
- `sh .husky/pre-commit`

## Notes

- Direct `pnpm --filter @lootlog/game-client test/build` initially failed because workspace dependency packages had not been built in this fresh worktree. Rerunning through Turbo built the dependency graph first and passed.