### PR TITLE
[codex] remove events interface barrel

### DIFF
--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -22,12 +22,11 @@ import type { UpdateLocationDto } from "./dto/update-location.dto";
 import type {
   CheckEventHeroKillParams,
   EventHeroKillJobData,
-  KillTimerData,
-} from "./interfaces";
+} from "./interfaces/check-event-hero-kill-params.interface";
+import type { KillTimerData } from "./interfaces/kill-timer-data.interface";
 import type {
   CloseRespawnWindowOptions,
   OpenRespawnWindowOptions,
-  MapStatus,
 } from "./interfaces/respawn-window.interface";
 import {
   EVENT_HERO_KILL_JOB_NAME,

--- a/apps/api/src/events/interfaces/index.ts
+++ b/apps/api/src/events/interfaces/index.ts
@@ -1,4 +1,0 @@
-export * from "./kill-timer-data.interface";
-export * from "./check-event-hero-kill-params.interface";
-export * from "./presence-log.interface";
-export * from "./respawn-window.interface";

--- a/apps/api/src/events/interfaces/presence-log.interface.ts
+++ b/apps/api/src/events/interfaces/presence-log.interface.ts
@@ -1,5 +1,0 @@
-import type { EventPresenceLog, Member } from "src/generated/prisma/client";
-
-interface PresenceLogWithMember extends EventPresenceLog {
-  member: Pick<Member, "id" | "name" | "avatar" | "userId">;
-}

--- a/apps/api/src/events/services/event-timer-hooks.service.ts
+++ b/apps/api/src/events/services/event-timer-hooks.service.ts
@@ -3,8 +3,8 @@ import { Injectable } from "@nestjs/common";
 import type { Queue } from "bullmq";
 import type { Event, EventHeroNpc } from "src/generated/prisma/client";
 import { PrismaService } from "src/db/prisma.service";
-import type { CheckEventHeroKillParams } from "../interfaces";
 import { EVENT_HERO_KILL_QUEUE } from "../constants/event-hero-kill-queue.constant";
+import type { CheckEventHeroKillParams } from "../interfaces/check-event-hero-kill-params.interface";
 import {
   EVENT_HERO_KILL_JOB_NAME,
   buildEventHeroKillJobId,


### PR DESCRIPTION
## Summary

- Replace the internal events interface barrel imports with direct type imports.
- Delete the re-export-only `apps/api/src/events/interfaces/index.ts` wrapper.
- Delete unused `presence-log.interface.ts`, which declared a non-exported type and was only referenced by the barrel.

## Validation

- `corepack pnpm --dir apps/api exec oxlint src/events/events.service.ts src/events/services/event-timer-hooks.service.ts`
- `corepack pnpm exec oxfmt --check apps/api/src/events/events.service.ts apps/api/src/events/services/event-timer-hooks.service.ts`
- `corepack pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/events/events.service.spec.ts src/events/services/event-timer-hooks.service.spec.ts src/events/event-hero-kill.processor.spec.ts src/events/utils/event-hero-kill-job.spec.ts`
- `corepack pnpm turbo run build --filter=@lootlog/api...`
- Commit hook ran lint-staged, `turbo run lint --filter=@lootlog/api`, and `turbo run test --filter=@lootlog/api` successfully.