### PR TITLE
[codex] remove events interface barrel

### DIFF
--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -22,12 +22,11 @@ import type { UpdateLocationDto } from "./dto/update-location.dto";
 import type {
   CheckEventHeroKillParams,
   EventHeroKillJobData,
-  KillTimerData,
-} from "./interfaces";
+} from "./interfaces/check-event-hero-kill-params.interface";
+import type { KillTimerData } from "./interfaces/kill-timer-data.interface";
 import type {
   CloseRespawnWindowOptions,
   OpenRespawnWindowOptions,
-  MapStatus,
 } from "./interfaces/respawn-window.interface";
 import {
   EVENT_HERO_KILL_JOB_NAME,

--- a/apps/api/src/events/interfaces/index.ts
+++ b/apps/api/src/events/interfaces/index.ts
@@ -1,4 +1,0 @@
-export * from "./kill-timer-data.interface";
-export * from "./check-event-hero-kill-params.interface";
-export * from "./presence-log.interface";
-export * from "./respawn-window.interface";

--- a/apps/api/src/events/interfaces/presence-log.interface.ts
+++ b/apps/api/src/events/interfaces/presence-log.interface.ts
@@ -1,5 +1,0 @@
-import type { EventPresenceLog, Member } from "src/generated/prisma/client";
-
-interface PresenceLogWithMember extends EventPresenceLog {
-  member: Pick<Member, "id" | "name" | "avatar" | "userId">;
-}

--- a/apps/api/src/events/services/event-timer-hooks.service.ts
+++ b/apps/api/src/events/services/event-timer-hooks.service.ts
@@ -3,8 +3,8 @@ import { Injectable } from "@nestjs/common";
 import type { Queue } from "bullmq";
 import type { Event, EventHeroNpc } from "src/generated/prisma/client";
 import { PrismaService } from "src/db/prisma.service";
-import type { CheckEventHeroKillParams } from "../interfaces";
 import { EVENT_HERO_KILL_QUEUE } from "../constants/event-hero-kill-queue.constant";
+import type { CheckEventHeroKillParams } from "../interfaces/check-event-hero-kill-params.interface";
 import {
   EVENT_HERO_KILL_JOB_NAME,
   buildEventHeroKillJobId,


### PR DESCRIPTION
## Summary

- Remove the re-export-only `events/interfaces` barrel.
- Import event timer/job types from their defining modules directly.
- Delete an unused, unexported presence log interface and drop an unused `MapStatus` import.

## Validation

- `pnpm --filter @lootlog/api format`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm --filter @lootlog/api build`
- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/events/events.service.spec.ts src/events/event-hero-kill.processor.spec.ts`
- `pnpm turbo run test '--filter=[HEAD]'`
- `pnpm format:check`
- Commit pre-commit hook passed (`lint-staged`, Turbo lint, format check, tests).