### PR TITLE
[codex] Add page titles and stabilize loot cache

### DIFF
--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -85,6 +85,8 @@ describe("LootsService", () => {
     get: Mock;
     del: Mock;
     set: Mock;
+    deleteByPattern: Mock;
+    getOrSetJsonBestEffort: Mock;
   };
   let amqpConnection: {
     publish: Mock;
@@ -1312,6 +1314,39 @@ describe("LootsService", () => {
         uniqueId: "unique1",
         submissions: mockSubmissions,
       });
+    });
+
+    it("should revive cached loot dates before returning first page results", async () => {
+      const cachedLoot = {
+        id: 1,
+        uniqueId: "unique1",
+        world: "testworld",
+        source: LootSource.FIGHT,
+        location: "Test Location",
+        lootShare: {},
+        createdAt: "2026-01-01T10:00:00.000Z",
+        updatedAt: "2026-01-01T10:05:00.000Z",
+        items: [],
+        players: [],
+        npcs: [],
+        submissions: [],
+        commentsCount: 0,
+      };
+
+      _redisService.getOrSetJsonBestEffort.mockResolvedValue([cachedLoot]);
+
+      const result = await service.fetchLootsByGuildId(
+        mockGuild,
+        [],
+        [],
+        params,
+      );
+
+      expect(result[0]?.createdAt).toBeInstanceOf(Date);
+      expect(result[0]?.createdAt.toISOString()).toBe(cachedLoot.createdAt);
+      expect(result[0]?.updatedAt).toBeInstanceOf(Date);
+      expect(result[0]?.updatedAt.toISOString()).toBe(cachedLoot.updatedAt);
+      expect(prismaService.loot.findMany).not.toHaveBeenCalled();
     });
 
     it("should return empty array when no loots found", async () => {

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -42,6 +42,7 @@ import type {
   CreateLootResponse,
   CreateLootSubmittedGuild,
 } from "src/loots/dto/loot-response.dto";
+import type { LootQueryResult } from "src/loots/dto/loot-query-result.dto";
 
 type LootSubmissionData = {
   guildId: string;
@@ -69,6 +70,14 @@ type CreateLootOutcome = {
   submissionData: LootSubmissionData[];
   submittedGuilds: CreateLootSubmittedGuild[];
   rejectedGuilds: CreateLootRejectedGuild[];
+};
+
+type CachedLootQueryResult = Omit<
+  LootQueryResult,
+  "createdAt" | "updatedAt"
+> & {
+  createdAt: Date | string;
+  updatedAt: Date | string;
 };
 
 const LOOTS_LIST_CACHE_TTL_SECONDS = 10;
@@ -281,6 +290,24 @@ export class LootsService implements OnModuleInit {
     }
 
     return JSON.stringify(value);
+  }
+
+  private normalizeCachedLootDate(value: Date | string): Date {
+    if (value instanceof Date) {
+      return value;
+    }
+
+    return new Date(value);
+  }
+
+  private normalizeCachedLoots(
+    loots: CachedLootQueryResult[],
+  ): LootQueryResult[] {
+    return loots.map((loot) => ({
+      ...loot,
+      createdAt: this.normalizeCachedLootDate(loot.createdAt),
+      updatedAt: this.normalizeCachedLootDate(loot.updatedAt),
+    }));
   }
 
   private getSocketNpcPayloadFromLootNpcs(
@@ -765,14 +792,16 @@ export class LootsService implements OnModuleInit {
     return mappedLootShare;
   }
 
-  fetchLootsByGuildId(
+  async fetchLootsByGuildId(
     guild: Guild,
     permissions: Permission[],
     roles: Role[],
     params: FetchLootsParamsDto,
   ) {
     if (this.isFirstLootsPage(params)) {
-      return this.redisService.getOrSetJsonBestEffort({
+      const loots = await this.redisService.getOrSetJsonBestEffort<
+        CachedLootQueryResult[]
+      >({
         key: this.getLootsListCacheKey(guild, permissions, roles, params),
         ttlSeconds: LOOTS_LIST_CACHE_TTL_SECONDS,
         onError: (error) =>
@@ -785,6 +814,8 @@ export class LootsService implements OnModuleInit {
             params,
           ),
       });
+
+      return this.normalizeCachedLoots(loots);
     }
 
     return this.lootQueryService.fetchLootsByGuildId(

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,7 +7,6 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>Lootlog.pl</title>
     <script type="module" src="/src/themes/bootstrap.ts"></script>
   </head>
   <body class="overflow-hidden">

--- a/apps/web/src/components/layout/get-navigation-info.ts
+++ b/apps/web/src/components/layout/get-navigation-info.ts
@@ -38,7 +38,8 @@ type GetNavigationInfoArgs = {
 };
 
 export function getNavigationInfo(args: GetNavigationInfoArgs): NavigationInfo {
-  const { path, params, guildName, t } = args;
+  const { params, guildName, t } = args;
+  const path = normalizePath(args.path);
   const { guildId } = params;
 
   if (!guildId) {
@@ -71,6 +72,8 @@ function buildRoutes(guildId: string) {
     timers: ROUTES.guild.timers(guildId),
     reservations: ROUTES.guild.reservations.base(guildId),
     stats: ROUTES.guild.stats(guildId),
+    statsKills: ROUTES.guild.statsKills(guildId),
+    statsLoots: ROUTES.guild.statsLoots(guildId),
     statsRanking: `${ROUTES.guild.stats(guildId)}/ranking`,
     statsNpcs: `${ROUTES.guild.stats(guildId)}/npcs`,
     notifications: ROUTES.guild.notifications.base(guildId),
@@ -86,6 +89,14 @@ function buildRoutes(guildId: string) {
 }
 
 type Routes = ReturnType<typeof buildRoutes>;
+
+function normalizePath(path: string) {
+  if (path.length <= 1) {
+    return path;
+  }
+
+  return path.replace(/\/$/, "");
+}
 
 function resolveSimpleRoute(
   path: string,
@@ -125,6 +136,16 @@ function resolveSimpleRoute(
       path: routes.stats,
       label: t("common.breadcrumbs.stats"),
       backPath: routes.base,
+    },
+    {
+      path: routes.statsKills,
+      label: t("common.stats.kills"),
+      backPath: routes.stats,
+    },
+    {
+      path: routes.statsLoots,
+      label: t("common.stats.loots"),
+      backPath: routes.stats,
     },
     {
       path: routes.events,
@@ -428,10 +449,13 @@ function resolveSettingsRoutes(
       path: null,
     });
   } else if (path === routes.settingsNpcs) {
-    breadcrumbs.push({ label: t("common.breadcrumbs.npcs"), path: null });
+    breadcrumbs.push({
+      label: t("common.breadcrumbs.settingsNpcs"),
+      path: null,
+    });
   } else if (path.startsWith(`${routes.settingsNpcs}/`)) {
     breadcrumbs.push({
-      label: t("common.breadcrumbs.npcs"),
+      label: t("common.breadcrumbs.settingsNpcs"),
       path: routes.settingsNpcs,
     });
     breadcrumbs.push({

--- a/apps/web/src/components/layout/get-user-navigation-info.ts
+++ b/apps/web/src/components/layout/get-user-navigation-info.ts
@@ -1,0 +1,199 @@
+import { ROUTES } from "@/config/routes";
+import type { NavigationInfo } from "./get-navigation-info";
+
+type GetUserNavigationInfoArgs = {
+  path: string;
+  t: (key: string, options?: Record<string, unknown>) => string;
+};
+
+function normalizePath(path: string) {
+  if (path.length <= 1) {
+    return path;
+  }
+
+  return path.replace(/\/$/, "");
+}
+
+export function getUserNavigationInfo({
+  path,
+  t,
+}: GetUserNavigationInfoArgs): NavigationInfo {
+  const normalizedPath = normalizePath(path);
+
+  if (normalizedPath === ROUTES.user.dashboard) {
+    return {
+      breadcrumbs: [{ label: t("layout.navigation.dashboard"), path: null }],
+      showBack: false,
+    };
+  }
+
+  if (normalizedPath === ROUTES.user.battlePanel.base) {
+    return {
+      breadcrumbs: [{ label: t("layout.navigation.battlePanel"), path: null }],
+      showBack: false,
+    };
+  }
+
+  if (normalizedPath === ROUTES.user.battlePanel.statistics) {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.battlePanel"),
+          path: ROUTES.user.battlePanel.base,
+        },
+        { label: t("layout.breadcrumbs.statistics"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.battlePanel.base,
+    };
+  }
+
+  if (normalizedPath === ROUTES.user.battlePanel.h2h) {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.battlePanel"),
+          path: ROUTES.user.battlePanel.base,
+        },
+        {
+          label: t("layout.breadcrumbs.statistics"),
+          path: ROUTES.user.battlePanel.statistics,
+        },
+        { label: t("layout.breadcrumbs.headToHead"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.battlePanel.statistics,
+    };
+  }
+
+  if (normalizedPath === ROUTES.user.battlePanel.matchmakingH2h) {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.battlePanel"),
+          path: ROUTES.user.battlePanel.base,
+        },
+        {
+          label: t("layout.breadcrumbs.statistics"),
+          path: ROUTES.user.battlePanel.statistics,
+        },
+        { label: t("layout.breadcrumbs.matchmakingHeadToHead"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.battlePanel.statistics,
+    };
+  }
+
+  if (
+    normalizedPath.startsWith(
+      `${ROUTES.user.battlePanel.statistics}/player-vs-player/`,
+    )
+  ) {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.battlePanel"),
+          path: ROUTES.user.battlePanel.base,
+        },
+        {
+          label: t("layout.breadcrumbs.statistics"),
+          path: ROUTES.user.battlePanel.statistics,
+        },
+        { label: t("layout.breadcrumbs.playerVsPlayer"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.battlePanel.statistics,
+    };
+  }
+
+  const battlesDetailsPath = `${ROUTES.user.battlePanel.base}/battles`;
+
+  if (normalizedPath.startsWith(`${battlesDetailsPath}/`)) {
+    const battleId = normalizedPath.split("/").pop();
+    if (battleId) {
+      return {
+        breadcrumbs: [
+          {
+            label: t("layout.navigation.battlePanel"),
+            path: ROUTES.user.battlePanel.base,
+          },
+          {
+            label: t("layout.breadcrumbs.battles"),
+            path: ROUTES.user.battlePanel.base,
+          },
+          {
+            label: t("battlePanel.navigation.battleFallback", {
+              id: battleId,
+            }),
+            path: null,
+          },
+        ],
+        showBack: true,
+        backPath: ROUTES.user.battlePanel.base,
+      };
+    }
+  }
+
+  if (normalizedPath === ROUTES.user.settings.account) {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.settings"),
+          path: ROUTES.user.settings.base,
+        },
+        { label: t("settings.account.title"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.settings.base,
+    };
+  }
+
+  if (normalizedPath === ROUTES.user.settings.appearance) {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.settings"),
+          path: ROUTES.user.settings.base,
+        },
+        { label: t("settings.appearance.title"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.settings.base,
+    };
+  }
+
+  if (normalizedPath.startsWith(ROUTES.user.settings.base)) {
+    return {
+      breadcrumbs: [{ label: t("layout.navigation.settings"), path: null }],
+      showBack: false,
+    };
+  }
+
+  if (normalizedPath.startsWith(ROUTES.user.notifications.base)) {
+    return {
+      breadcrumbs: [
+        { label: t("layout.navigation.notifications"), path: null },
+      ],
+      showBack: false,
+    };
+  }
+
+  if (normalizedPath === "/@me/kills") {
+    return {
+      breadcrumbs: [
+        {
+          label: t("layout.navigation.dashboard"),
+          path: ROUTES.user.dashboard,
+        },
+        { label: t("layout.breadcrumbs.npcRanking"), path: null },
+      ],
+      showBack: true,
+      backPath: ROUTES.user.dashboard,
+    };
+  }
+
+  return {
+    breadcrumbs: [{ label: t("layout.navigation.dashboard"), path: null }],
+    showBack: false,
+  };
+}

--- a/apps/web/src/components/layout/user-shell.tsx
+++ b/apps/web/src/components/layout/user-shell.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft } from "lucide-react";
 import { useState, type FC, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { ThemeInteractiveFrame } from "@/themes";
+import { getUserNavigationInfo } from "./get-user-navigation-info";
 
 type UserShellProps = {
   children: ReactNode;
@@ -22,161 +23,10 @@ export const UserShell: FC<UserShellProps> = ({ children }) => {
   const [headerActionsElement, setHeaderActionsElement] =
     useState<HTMLElement | null>(null);
 
-  const getNavigationInfo = () => {
-    const path = location.pathname;
-
-    if (path === ROUTES.user.dashboard) {
-      return {
-        breadcrumbs: [{ label: t("layout.navigation.dashboard"), path: null }],
-        showBack: false,
-      };
-    }
-
-    if (path === ROUTES.user.battlePanel.base) {
-      return {
-        breadcrumbs: [
-          { label: t("layout.navigation.battlePanel"), path: null },
-        ],
-        showBack: false,
-      };
-    }
-
-    if (path === ROUTES.user.battlePanel.statistics) {
-      return {
-        breadcrumbs: [
-          {
-            label: t("layout.navigation.battlePanel"),
-            path: ROUTES.user.battlePanel.base,
-          },
-          { label: t("layout.breadcrumbs.statistics"), path: null },
-        ],
-        showBack: true,
-        backPath: ROUTES.user.battlePanel.base,
-      };
-    }
-
-    if (path === ROUTES.user.battlePanel.h2h) {
-      return {
-        breadcrumbs: [
-          {
-            label: t("layout.navigation.battlePanel"),
-            path: ROUTES.user.battlePanel.base,
-          },
-          {
-            label: t("layout.breadcrumbs.statistics"),
-            path: ROUTES.user.battlePanel.statistics,
-          },
-          { label: t("layout.breadcrumbs.headToHead"), path: null },
-        ],
-        showBack: true,
-        backPath: ROUTES.user.battlePanel.statistics,
-      };
-    }
-
-    if (path === ROUTES.user.battlePanel.matchmakingH2h) {
-      return {
-        breadcrumbs: [
-          {
-            label: t("layout.navigation.battlePanel"),
-            path: ROUTES.user.battlePanel.base,
-          },
-          {
-            label: t("layout.breadcrumbs.statistics"),
-            path: ROUTES.user.battlePanel.statistics,
-          },
-          { label: t("layout.breadcrumbs.matchmakingHeadToHead"), path: null },
-        ],
-        showBack: true,
-        backPath: ROUTES.user.battlePanel.statistics,
-      };
-    }
-
-    if (
-      path.startsWith(`${ROUTES.user.battlePanel.statistics}/player-vs-player/`)
-    ) {
-      return {
-        breadcrumbs: [
-          {
-            label: t("layout.navigation.battlePanel"),
-            path: ROUTES.user.battlePanel.base,
-          },
-          {
-            label: t("layout.breadcrumbs.statistics"),
-            path: ROUTES.user.battlePanel.statistics,
-          },
-          { label: t("layout.breadcrumbs.playerVsPlayer"), path: null },
-        ],
-        showBack: true,
-        backPath: ROUTES.user.battlePanel.statistics,
-      };
-    }
-
-    const normalizedPath = path.replace(/\/$/, "");
-    const battlesDetailsPath = `${ROUTES.user.battlePanel.base}/battles`;
-
-    if (normalizedPath.startsWith(`${battlesDetailsPath}/`)) {
-      const battleId = normalizedPath.split("/").pop();
-      if (battleId && battleId.length > 0) {
-        return {
-          breadcrumbs: [
-            {
-              label: t("layout.navigation.battlePanel"),
-              path: ROUTES.user.battlePanel.base,
-            },
-            {
-              label: t("layout.breadcrumbs.battles"),
-              path: ROUTES.user.battlePanel.base,
-            },
-            {
-              label: t("battlePanel.navigation.battleFallback", {
-                id: battleId,
-              }),
-              path: null,
-            },
-          ],
-          showBack: true,
-          backPath: ROUTES.user.battlePanel.base,
-        };
-      }
-    }
-
-    if (path.startsWith(ROUTES.user.settings.base)) {
-      return {
-        breadcrumbs: [{ label: t("layout.navigation.settings"), path: null }],
-        showBack: false,
-      };
-    }
-
-    if (path.startsWith(ROUTES.user.notifications.base)) {
-      return {
-        breadcrumbs: [
-          { label: t("layout.navigation.notifications"), path: null },
-        ],
-        showBack: false,
-      };
-    }
-
-    if (path === "/@me/kills") {
-      return {
-        breadcrumbs: [
-          {
-            label: t("layout.navigation.dashboard"),
-            path: ROUTES.user.dashboard,
-          },
-          { label: t("layout.breadcrumbs.npcRanking"), path: null },
-        ],
-        showBack: true,
-        backPath: ROUTES.user.dashboard,
-      };
-    }
-
-    return {
-      breadcrumbs: [{ label: t("layout.navigation.dashboard"), path: null }],
-      showBack: false,
-    };
-  };
-
-  const navigationInfo = getNavigationInfo();
+  const navigationInfo = getUserNavigationInfo({
+    path: location.pathname,
+    t,
+  });
   const isFullHeightContent =
     location.pathname === ROUTES.user.battlePanel.h2h ||
     location.pathname === ROUTES.user.battlePanel.matchmakingH2h ||

--- a/apps/web/src/components/router/document-title-updater.tsx
+++ b/apps/web/src/components/router/document-title-updater.tsx
@@ -1,0 +1,62 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { useMatches } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { getGuildsControllerGetGuildByIdQueryKey } from "@/lib/api/generated/main/guilds/guilds";
+import { resolveDocumentTitle } from "@/lib/router/document-title";
+
+type DocumentTitleUpdaterProps = {
+  queryClient: QueryClient;
+};
+
+type CachedGuild = {
+  name?: string;
+};
+
+function getGuildIdFromMatches(
+  matches: ReturnType<typeof useMatches>,
+): string | undefined {
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const match = matches[index];
+    const guildId = match?.params.guildId;
+
+    if (typeof guildId === "string") {
+      return guildId;
+    }
+  }
+}
+
+export function DocumentTitleUpdater({
+  queryClient,
+}: DocumentTitleUpdaterProps) {
+  const matches = useMatches();
+  const guildId = getGuildIdFromMatches(matches);
+  const guildQueryKey = guildId
+    ? getGuildsControllerGetGuildByIdQueryKey({ guildId })
+    : undefined;
+  const guildQueryKeyHash = guildQueryKey ? JSON.stringify(guildQueryKey) : "";
+  const [, setCacheVersion] = useState(0);
+  const cachedGuildName = guildQueryKey
+    ? queryClient.getQueryData<CachedGuild>(guildQueryKey)?.name
+    : undefined;
+  const title = resolveDocumentTitle(matches, { guildName: cachedGuildName });
+
+  useEffect(() => {
+    if (!guildQueryKeyHash) {
+      return undefined;
+    }
+
+    return queryClient.getQueryCache().subscribe((event) => {
+      if (JSON.stringify(event.query.queryKey) !== guildQueryKeyHash) {
+        return;
+      }
+
+      setCacheVersion((version) => version + 1);
+    });
+  }, [guildQueryKeyHash, queryClient]);
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  return null;
+}

--- a/apps/web/src/i18n/translations/common.json
+++ b/apps/web/src/i18n/translations/common.json
@@ -1,4 +1,14 @@
 {
+  "documentTitle": {
+    "appName": "Lootlog.pl",
+    "template": "{{title}} | {{appName}}",
+    "contextTemplate": "{{title}} - {{context}} | {{appName}}",
+    "signin": "Logowanie",
+    "init": "Start",
+    "publicBattle": "Walka #{{id}}",
+    "battle": "Walka #{{id}}",
+    "fallback": "Lootlog"
+  },
   "devPermissionOverride": {
     "trigger": "Dev permisje",
     "title": "Dev permisje",
@@ -39,6 +49,7 @@
     "all": "Wszystko"
   },
   "breadcrumbs": {
+    "guild": "Lootlog",
     "lootsList": "Lista łupów",
     "timers": "Timery",
     "reservations": "Rezerwacje",
@@ -64,7 +75,7 @@
     "notificationEdit": "Edycja reguły",
     "notificationHistory": "Historia",
     "info": "Informacje",
-    "npcs": "Ustawienia potworów i NPC"
+    "settingsNpcs": "Ustawienia potworów i NPC"
   },
   "greeting": "Cześć, {{name}}!",
   "routeErrors": {

--- a/apps/web/src/lib/router/document-title.spec.ts
+++ b/apps/web/src/lib/router/document-title.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDocumentTitle,
+  type DocumentTitleMatch,
+} from "./document-title";
+
+function createMatch(
+  overrides: Partial<DocumentTitleMatch>,
+): DocumentTitleMatch {
+  return {
+    params: {},
+    pathname: "/",
+    routeId: "__root__",
+    status: "success",
+    ...overrides,
+  };
+}
+
+describe("resolveDocumentTitle", () => {
+  it("uses the sign in title for the public auth route", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({ routeId: "__root__" }),
+        createMatch({ pathname: "/signin", routeId: "/signin" }),
+      ]),
+    ).toBe("Logowanie | Lootlog.pl");
+  });
+
+  it("uses user breadcrumbs with the top-level section as context", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({ routeId: "__root__" }),
+        createMatch({
+          pathname: "/@me/battle-panel/statistics/h2h",
+          routeId: "/_authenticated/@me/battle-panel/statistics_/h2h",
+        }),
+      ]),
+    ).toBe("Bilans H2H - Panel walk | Lootlog.pl");
+  });
+
+  it("uses the guild name as context for regular guild pages", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({
+          loaderData: { guild: { name: "Nocna Straż" } },
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1",
+          routeId: "/_authenticated/$guildId",
+        }),
+        createMatch({
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1/timers",
+          routeId: "/_authenticated/$guildId/timers",
+        }),
+      ]),
+    ).toBe("Timery - Nocna Straż | Lootlog.pl");
+  });
+
+  it("uses specific titles for guild stats child pages", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({
+          loaderData: { guild: { name: "Nocna Straż" } },
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1",
+          routeId: "/_authenticated/$guildId",
+        }),
+        createMatch({
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1/stats/kills",
+          routeId: "/_authenticated/$guildId/stats/kills",
+        }),
+      ]),
+    ).toBe("Statystyki killi - Nocna Straż | Lootlog.pl");
+
+    expect(
+      resolveDocumentTitle([
+        createMatch({
+          loaderData: { guild: { name: "Nocna Straż" } },
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1",
+          routeId: "/_authenticated/$guildId",
+        }),
+        createMatch({
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1/stats/loots",
+          routeId: "/_authenticated/$guildId/stats/loots",
+        }),
+      ]),
+    ).toBe("Statystyki lootów - Nocna Straż | Lootlog.pl");
+  });
+
+  it("treats trailing slashes as the same guild page", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({
+          loaderData: { guild: { name: "Nocna Straż" } },
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1",
+          routeId: "/_authenticated/$guildId",
+        }),
+        createMatch({
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1/reservations/",
+          routeId: "/_authenticated/$guildId/reservations/",
+        }),
+      ]),
+    ).toBe("Rezerwacje - Nocna Straż | Lootlog.pl");
+  });
+
+  it("uses the event name as context for event child pages", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({
+          loaderData: { guild: { name: "Nocna Straż" } },
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1",
+          routeId: "/_authenticated/$guildId",
+        }),
+        createMatch({
+          loaderData: {
+            event: { name: "Letni event", heroNpcs: [] },
+            rankings: [],
+          },
+          params: { eventId: "event-1", guildId: "guild-1" },
+          pathname: "/guild-1/events/event-1",
+          routeId: "/_authenticated/$guildId/events_/$eventId_",
+        }),
+        createMatch({
+          params: { eventId: "event-1", guildId: "guild-1" },
+          pathname: "/guild-1/events/event-1/ranking",
+          routeId: "/_authenticated/$guildId/events_/$eventId_/ranking",
+        }),
+      ]),
+    ).toBe("Ranking - Letni event | Lootlog.pl");
+  });
+
+  it("uses fallback detail labels when loader data does not include a name", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({
+          loaderData: { guild: { name: "Nocna Straż" } },
+          params: { guildId: "guild-1" },
+          pathname: "/guild-1",
+          routeId: "/_authenticated/$guildId",
+        }),
+        createMatch({
+          params: { guildId: "guild-1", memberId: "123" },
+          pathname: "/guild-1/stats/members/123",
+          routeId: "/_authenticated/$guildId/stats/members/$memberId",
+        }),
+      ]),
+    ).toBe("Członek #123 | Lootlog.pl");
+  });
+
+  it("uses the not found title for not found route matches", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({ routeId: "__root__" }),
+        createMatch({
+          pathname: "/missing",
+          routeId: "/missing",
+          status: "notFound",
+        }),
+      ]),
+    ).toBe("Nie znaleziono strony | Lootlog.pl");
+  });
+});

--- a/apps/web/src/lib/router/document-title.ts
+++ b/apps/web/src/lib/router/document-title.ts
@@ -1,0 +1,289 @@
+import i18n from "@/i18n/config";
+import { getNavigationInfo } from "@/components/layout/get-navigation-info";
+import { getUserNavigationInfo } from "@/components/layout/get-user-navigation-info";
+import type { Breadcrumb } from "@/components/layout/get-navigation-info";
+
+export type DocumentTitleMatch = {
+  routeId: string;
+  pathname: string;
+  params?: Record<string, string | undefined>;
+  status?: string;
+  globalNotFound?: boolean;
+  loaderData?: unknown;
+};
+
+type ResolveDocumentTitleOptions = {
+  guildName?: string;
+};
+
+type GuildRouteLoaderData = {
+  guild?: {
+    name?: string;
+  };
+};
+
+type EventRouteLoaderData = {
+  event?: {
+    name?: string;
+    heroNpcs?: Array<{
+      id: number | string;
+      npcName: string;
+    }>;
+  };
+  rankings?: Array<{
+    memberId: number;
+    member?: {
+      name?: string;
+    };
+  }>;
+};
+
+const ROOT_ROUTE_ID = "__root__";
+const GUILD_ROUTE_ID = "/_authenticated/$guildId";
+const EVENT_ROUTE_ID = "/_authenticated/$guildId/events_/$eventId_";
+const USER_ROUTE_PREFIX = "/_authenticated/@me";
+const GUILD_ROUTE_PREFIX = "/_authenticated/$guildId";
+const FALLBACK_ID_PATTERN = /#\S+/;
+
+function t(key: string, options?: Record<string, unknown>) {
+  return i18n.t(key, options);
+}
+
+function formatDocumentTitle(title: string, context?: string) {
+  const appName = t("common.documentTitle.appName");
+
+  if (context && context !== title) {
+    return t("common.documentTitle.contextTemplate", {
+      appName,
+      context,
+      title,
+    });
+  }
+
+  return t("common.documentTitle.template", {
+    appName,
+    title,
+  });
+}
+
+function getLastMatch(matches: readonly DocumentTitleMatch[]) {
+  for (let index = matches.length - 1; index >= 0; index -= 1) {
+    const match = matches[index];
+
+    if (!match) {
+      continue;
+    }
+
+    if (match.routeId !== ROOT_ROUTE_ID) {
+      return match;
+    }
+  }
+}
+
+function getMatchByRouteId(
+  matches: readonly DocumentTitleMatch[],
+  routeId: string,
+) {
+  return matches.find((match) => match.routeId === routeId);
+}
+
+function getPathname(match: DocumentTitleMatch | undefined) {
+  return match?.pathname ?? "/";
+}
+
+function hasRouteStatus(
+  matches: readonly DocumentTitleMatch[],
+  status: string,
+) {
+  return matches.some((match) => match.status === status);
+}
+
+function getStatusTitle(matches: readonly DocumentTitleMatch[]) {
+  const lastMatch = getLastMatch(matches);
+
+  if (lastMatch?.status === "notFound" || lastMatch?.globalNotFound) {
+    return formatDocumentTitle(t("common.routeErrors.status.404.title"));
+  }
+
+  if (hasRouteStatus(matches, "error")) {
+    return formatDocumentTitle(t("common.routeErrors.status.500.title"));
+  }
+}
+
+function getRouteParams(match: DocumentTitleMatch | undefined) {
+  return match?.params ?? {};
+}
+
+function getPublicRouteTitle(lastMatch: DocumentTitleMatch) {
+  const params = getRouteParams(lastMatch);
+
+  if (lastMatch.routeId === "/signin") {
+    return formatDocumentTitle(t("common.documentTitle.signin"));
+  }
+
+  if (lastMatch.routeId === "/init") {
+    return formatDocumentTitle(t("common.documentTitle.init"));
+  }
+
+  if (lastMatch.routeId === "/battles/$id") {
+    return formatDocumentTitle(
+      t("common.documentTitle.publicBattle", { id: params.id }),
+    );
+  }
+}
+
+function getCurrentBreadcrumb(breadcrumbs: Breadcrumb[]) {
+  for (let index = breadcrumbs.length - 1; index >= 0; index -= 1) {
+    const breadcrumb = breadcrumbs[index];
+
+    if (!breadcrumb) {
+      continue;
+    }
+
+    if (!breadcrumb.path) {
+      return breadcrumb;
+    }
+  }
+
+  return breadcrumbs[breadcrumbs.length - 1];
+}
+
+function getUserRouteTitle(lastMatch: DocumentTitleMatch) {
+  const navigationInfo = getUserNavigationInfo({
+    path: getPathname(lastMatch),
+    t,
+  });
+  const currentBreadcrumb = getCurrentBreadcrumb(navigationInfo.breadcrumbs);
+  const sectionBreadcrumb = navigationInfo.breadcrumbs[0];
+
+  if (!currentBreadcrumb) {
+    return formatDocumentTitle(t("layout.navigation.dashboard"));
+  }
+
+  if (
+    sectionBreadcrumb &&
+    sectionBreadcrumb.label !== currentBreadcrumb.label
+  ) {
+    return formatDocumentTitle(
+      currentBreadcrumb.label,
+      sectionBreadcrumb.label,
+    );
+  }
+
+  return formatDocumentTitle(currentBreadcrumb.label);
+}
+
+function getGuildName(
+  matches: readonly DocumentTitleMatch[],
+  options: ResolveDocumentTitleOptions,
+) {
+  if (options.guildName) {
+    return options.guildName;
+  }
+
+  const guildLoaderData = getMatchByRouteId(matches, GUILD_ROUTE_ID)
+    ?.loaderData as GuildRouteLoaderData | undefined;
+
+  return guildLoaderData?.guild?.name;
+}
+
+function getEventRouteData(matches: readonly DocumentTitleMatch[]) {
+  const eventLoaderData = getMatchByRouteId(matches, EVENT_ROUTE_ID)
+    ?.loaderData as EventRouteLoaderData | undefined;
+  const eventHeroNpcs = eventLoaderData?.event?.heroNpcs?.map((hero) => ({
+    id: String(hero.id),
+    npcName: hero.npcName,
+  }));
+
+  return {
+    eventHeroNpcs,
+    eventName: eventLoaderData?.event?.name,
+    eventRankings: eventLoaderData?.rankings ?? [],
+  };
+}
+
+function shouldUseGuildContext(title: string, guildName?: string) {
+  if (!guildName || title === guildName) {
+    return false;
+  }
+
+  return !FALLBACK_ID_PATTERN.test(title);
+}
+
+function getGuildRouteTitle(
+  matches: readonly DocumentTitleMatch[],
+  lastMatch: DocumentTitleMatch,
+  options: ResolveDocumentTitleOptions,
+) {
+  const params = getRouteParams(lastMatch);
+  const guildName = getGuildName(matches, options);
+  const eventData = getEventRouteData(matches);
+  const navigationInfo = getNavigationInfo({
+    path: getPathname(lastMatch),
+    params: {
+      eventId: params.eventId,
+      guildId: params.guildId,
+      heroId: params.heroId,
+      killId: params.killId,
+      memberId: params.memberId,
+      npcId: params.npcId,
+      reservationId: params.reservationId,
+      roleId: params.roleId,
+    },
+    eventHeroNpcs: eventData.eventHeroNpcs,
+    eventName: eventData.eventName,
+    eventRankings: eventData.eventRankings,
+    guildName,
+    t,
+  });
+  const currentBreadcrumb = getCurrentBreadcrumb(navigationInfo.breadcrumbs);
+  const title =
+    currentBreadcrumb?.label ?? guildName ?? t("common.breadcrumbs.guild");
+
+  if (eventData.eventName) {
+    if (title === eventData.eventName) {
+      return formatDocumentTitle(title);
+    }
+
+    return formatDocumentTitle(title, eventData.eventName);
+  }
+
+  if (shouldUseGuildContext(title, guildName)) {
+    return formatDocumentTitle(title, guildName);
+  }
+
+  return formatDocumentTitle(title);
+}
+
+export function resolveDocumentTitle(
+  matches: readonly DocumentTitleMatch[],
+  options: ResolveDocumentTitleOptions = {},
+): string {
+  const statusTitle = getStatusTitle(matches);
+
+  if (statusTitle) {
+    return statusTitle;
+  }
+
+  const lastMatch = getLastMatch(matches);
+
+  if (!lastMatch) {
+    return t("common.documentTitle.appName");
+  }
+
+  const publicRouteTitle = getPublicRouteTitle(lastMatch);
+
+  if (publicRouteTitle) {
+    return publicRouteTitle;
+  }
+
+  if (lastMatch.routeId.startsWith(USER_ROUTE_PREFIX)) {
+    return getUserRouteTitle(lastMatch);
+  }
+
+  if (lastMatch.routeId.startsWith(GUILD_ROUTE_PREFIX)) {
+    return getGuildRouteTitle(matches, lastMatch, options);
+  }
+
+  return formatDocumentTitle(t("common.documentTitle.fallback"));
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,12 +1,18 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
-import { createRootRouteWithContext, Outlet } from "@tanstack/react-router";
+import {
+  createRootRouteWithContext,
+  HeadContent,
+  Outlet,
+} from "@tanstack/react-router";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { GlobalContextProvider } from "@/contexts/global-context";
 import { ThemeProvider } from "@/contexts/theme-context";
 import type { RouterContext } from "@/App";
+import { DocumentTitleUpdater } from "@/components/router/document-title-updater";
 import { RootRouteError } from "@/components/router/root-route-error";
 import { RootRouteNotFound } from "@/components/router/root-route-not-found";
+import { resolveDocumentTitle } from "@/lib/router/document-title";
 import { ThemeRootEffects, ThemeSpinnerProvider } from "@/themes";
 
 import "@lootlog/ui/globals.css";
@@ -55,27 +61,34 @@ function RootComponent() {
   }, []);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <ThemeSpinnerProvider>
-          <NuqsAdapter>
-            <GlobalContextProvider>
-              <Outlet />
-              {!prefersReducedMotion && <ThemeRootEffects />}
-              {import.meta.env.DEV ? (
-                <Suspense fallback={null}>
-                  <ReactQueryDevtools initialIsOpen={false} />
-                </Suspense>
-              ) : null}
-            </GlobalContextProvider>
-          </NuqsAdapter>
-        </ThemeSpinnerProvider>
-      </ThemeProvider>
-    </QueryClientProvider>
+    <>
+      <HeadContent />
+      <DocumentTitleUpdater queryClient={queryClient} />
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <ThemeSpinnerProvider>
+            <NuqsAdapter>
+              <GlobalContextProvider>
+                <Outlet />
+                {!prefersReducedMotion && <ThemeRootEffects />}
+                {import.meta.env.DEV ? (
+                  <Suspense fallback={null}>
+                    <ReactQueryDevtools initialIsOpen={false} />
+                  </Suspense>
+                ) : null}
+              </GlobalContextProvider>
+            </NuqsAdapter>
+          </ThemeSpinnerProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </>
   );
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({
+  head: ({ matches }) => ({
+    meta: [{ title: resolveDocumentTitle(matches) }],
+  }),
   component: RootComponent,
   errorComponent: RootRouteError,
   notFoundComponent: RootRouteNotFound,


### PR DESCRIPTION
## Summary
- Add centralized TanStack Router document title resolution for web routes, including guild, event, user, auth, error, and not-found cases.
- Reuse extracted user navigation helpers and existing guild navigation info for consistent breadcrumbs and titles.
- Fix guild stats/reservations title edge cases and add missing i18n keys.
- Stabilize the first-page loot list cache by reviving cached `createdAt`/`updatedAt` ISO strings back to `Date` before Zod response serialization.

## Why
The web app needed route-specific `document.title` values in the `Page | Lootlog.pl` format. During verification, the guild loot endpoint also showed flaky `500` responses after the first successful request because cached JSON changed date fields from `Date` objects into strings.

## Impact
- Browser tabs now show meaningful titles across the web app.
- Guild route titles update after guild data becomes available.
- `/guilds/:guildId/loots` no longer fails on cached first-page responses.

## Validation
- `pnpm --filter @lootlog/web exec vitest run src/lib/router/document-title.spec.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web build`
- `pnpm --filter @lootlog/api test -- loots.service.spec.ts`
- `pnpm --filter @lootlog/api lint`
- `pnpm --filter @lootlog/api build`
- Local API verification: repeated requests to `/guilds/uwu/loots?limit=20&world=gordion` returned `200` after the cache fix.