### PR TITLE
[codex] remove sync external store shim wrappers

### DIFF
--- a/apps/game-client/src/shims/use-sync-external-store-shim.ts
+++ b/apps/game-client/src/shims/use-sync-external-store-shim.ts
@@ -1,3 +1,0 @@
-// React 19 has native useSyncExternalStore, so we re-export it directly
-// This shim redirects use-sync-external-store/shim imports to the native API
-export { useSyncExternalStore } from "react";

--- a/apps/game-client/vite.config.ts
+++ b/apps/game-client/vite.config.ts
@@ -38,10 +38,7 @@ export default defineConfig(({ mode }) => {
         },
         {
           find: /^use-sync-external-store\/shim(\/index)?(\.js)?$/,
-          replacement: path.resolve(
-            __dirname,
-            "./src/shims/use-sync-external-store-shim.ts",
-          ),
+          replacement: "react",
         },
       ],
     },

--- a/apps/web/src/shims/use-sync-external-store-shim.ts
+++ b/apps/web/src/shims/use-sync-external-store-shim.ts
@@ -1,3 +1,0 @@
-// React 19 has useSyncExternalStore built-in
-// This shim redirects the old shim package to React's native implementation
-export { useSyncExternalStore } from "react";

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -104,10 +104,7 @@ export default defineConfig({
       },
       {
         find: /^use-sync-external-store\/shim(\/index)?(\.js)?$/,
-        replacement: path.resolve(
-          __dirname,
-          "./src/shims/use-sync-external-store-shim.ts",
-        ),
+        replacement: "react",
       },
       // Path aliases
       {


### PR DESCRIPTION
## Summary

- Alias `use-sync-external-store/shim` directly to `react` in the web and game-client Vite configs.
- Delete the two now-redundant React 19 wrapper modules.
- Keep the selector shim in place because it still contains local selector logic.

## Verification

- `pnpm turbo run build --filter=@lootlog/web... --filter=@lootlog/game-client...`
- `pnpm --filter @lootlog/web lint`
- `pnpm format:check`
- `pnpm turbo run lint --filter=@lootlog/web --filter=@lootlog/game-client`
- `pnpm --filter @lootlog/game-client test`
- `git diff --check`
- Pre-commit hook via `git commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal module resolution and dependency management across multiple applications to improve code organization and maintainability. Updated build configuration to consolidate external dependencies, resulting in cleaner codebase structure and simplified import paths. These changes enhance code efficiency with no impact to application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->