### PR TITLE
[codex] simplify notification rule updates

### DIFF
--- a/apps/api/src/notifications/notification-rule.service.ts
+++ b/apps/api/src/notifications/notification-rule.service.ts
@@ -384,6 +384,11 @@ export class NotificationRuleService {
       existingRule.triggerType;
     const isScheduledMessage =
       nextTriggerType === DbNotificationTriggerType.SCHEDULED_MESSAGE;
+    const hasFilterSelectionUpdate =
+      data.npcId !== undefined ||
+      data.npcIds !== undefined ||
+      data.itemId !== undefined ||
+      data.itemIds !== undefined;
 
     if (!isScheduledMessage) {
       this.validateRuleNpcSelection(data);
@@ -397,28 +402,36 @@ export class NotificationRuleService {
         })
       : null;
 
+    let nextWorld = existingRule.world;
+
+    if (isScheduledMessage) {
+      nextWorld = null;
+    } else if (hasWorld) {
+      nextWorld = data.world ?? null;
+    }
+
+    let nextFilters:
+      | Prisma.InputJsonObject
+      | Prisma.JsonValue
+      | typeof Prisma.DbNull = existingRule.filters;
+
+    if (isScheduledMessage) {
+      nextFilters = Prisma.DbNull;
+    } else if (hasFilterSelectionUpdate) {
+      nextFilters = this.buildFilters(data);
+    }
+
     await this.prisma.$transaction(async (tx) => {
       await tx.notificationRule.update({
         where: { id: ruleId },
         data: {
           triggerType: nextTriggerType,
-          world: isScheduledMessage
-            ? null
-            : hasWorld
-              ? (data.world ?? null)
-              : existingRule.world,
+          world: nextWorld,
           name: hasName ? (data.name ?? null) : existingRule.name,
           contentTemplate: hasContentTemplate
             ? this.normalizeContentTemplate(data.contentTemplate)
             : existingRule.contentTemplate,
-          filters: isScheduledMessage
-            ? Prisma.DbNull
-            : data.npcId !== undefined ||
-                data.npcIds !== undefined ||
-                data.itemId !== undefined ||
-                data.itemIds !== undefined
-              ? this.buildFilters(data)
-              : existingRule.filters,
+          filters: nextFilters,
           ...this.resolveScheduleConfig({
             triggerType: nextTriggerType,
             data,
@@ -747,14 +760,18 @@ export class NotificationRuleService {
       data.scheduleWeekday ?? existingRule?.scheduleWeekday ?? null;
     const timeOfDay =
       data.scheduleTimeOfDay ?? existingRule?.scheduleTimeOfDay ?? null;
-    const scheduledUntil = Object.prototype.hasOwnProperty.call(
+    const hasScheduledUntil = Object.prototype.hasOwnProperty.call(
       data,
       "scheduledUntil",
-    )
-      ? data.scheduledUntil
+    );
+    let scheduledUntil = existingRule?.scheduledUntil ?? null;
+
+    if (hasScheduledUntil) {
+      scheduledUntil = data.scheduledUntil
         ? new Date(data.scheduledUntil)
-        : null
-      : (existingRule?.scheduledUntil ?? null);
+        : null;
+    }
+
     const scheduleTimezone = this.resolveNotificationScheduleTimeZone({
       ownerType,
       providedTimeZone: data.scheduleTimezone,


### PR DESCRIPTION
## Summary

Simplifies notification rule update handling by naming the next `world` and `filters` values before the Prisma update payload instead of embedding chained conditionals inline.

Also rewrites scheduled-message `scheduledUntil` resolution into an explicit presence check so partial updates and explicit clears are easier to read without changing behavior.

## Impact

This is a behavior-preserving refactor in `NotificationRuleService`. Scheduled-message rules still clear rule scope fields, non-scheduled partial updates still preserve existing values, and explicit update fields still override as before.

## Verification

- `pnpm turbo run build --filter=@lootlog/api... --force`
- `pnpm --filter @lootlog/api exec vitest run src/notifications/notifications.service.spec.ts --config ./vitest.config.ts`
- `pnpm --filter @lootlog/api lint`
- `pnpm format:check`
- `git diff --check`
- normal pre-commit hook, including `lint-staged`, changed-package lint, format check, and API test suite (`79` files, `857` tests)