### PR TITLE
[codex] Share notification settings key resolution

### DIFF
--- a/apps/game-client/src/features/notifications/components/single-notification.tsx
+++ b/apps/game-client/src/features/notifications/components/single-notification.tsx
@@ -31,15 +31,17 @@ import {
   getBackgroundColor,
   getBorderColor,
 } from "@/utils/notifications-and-detector/background";
-import { getNpcTypeByWt } from "@lootlog/types";
 import { format } from "date-fns";
 import { LoaderCircle, Swords, XIcon } from "lucide-react";
 import { type FC, type ReactNode, useEffect, useRef } from "react";
-import { NpcType } from "@/api/npcs.api";
 import { SingleNotificationMessage } from "@/features/notifications/components/single-notification-message";
 import { SingleNotificationNpc } from "@/features/notifications/components/single-notification-npc";
 import { SingleNotificationPartyGathering } from "@/features/notifications/components/single-notification-party-gathering";
 import { useTranslation } from "react-i18next";
+import {
+  getNotificationSettingsKey,
+  isNotificationSettingsKey,
+} from "@/features/notifications/utils/get-notification-settings-key";
 
 const AUTO_HIDE_RING_PATH =
   "M 50 0 H 2 A 2 2 0 0 0 0 2 V 38 A 2 2 0 0 0 2 40 H 98 A 2 2 0 0 0 100 38 V 2 A 2 2 0 0 0 98 0 H 50";
@@ -191,19 +193,10 @@ export const SingleNotification: FC<SingleNotificationProps> = ({
       ? notification
       : null;
 
-  const npcType = regularNotification?.npc
-    ? getNpcTypeByWt(NpcType, regularNotification.npc.wt)
+  const key = getNotificationSettingsKey(notification);
+  const categorySettings = isNotificationSettingsKey(key)
+    ? settings[key]
     : undefined;
-
-  let key: Extract<keyof typeof settings, string> = "message";
-
-  if (isPartyGathering) {
-    key = "party-gathering";
-  } else if (npcType) {
-    key = npcType as Extract<keyof typeof settings, string>;
-  }
-
-  const categorySettings = settings[key];
   const autoHideTimeout = categorySettings?.autoHideTimeout ?? 0;
   const autoHideDurationMs = autoHideTimeout > 0 ? autoHideTimeout * 1000 : 0;
 

--- a/apps/game-client/src/features/notifications/hooks/use-notifications.tsx
+++ b/apps/game-client/src/features/notifications/hooks/use-notifications.tsx
@@ -10,9 +10,11 @@ import { useNotificationsStore } from "@/store/notifications.store";
 import { useWindowsStore } from "@/store/windows.store";
 import type { GameNpc } from "@lootlog/margonem/npcs";
 import { useRef } from "react";
-import { getNpcTypeByWt } from "@lootlog/types";
-import { NpcType } from "@/api/npcs.api";
 import { useSoundPlayback } from "@/hooks/use-sound-playback";
+import {
+  getNotificationSettingsKey,
+  isNotificationSettingsKey,
+} from "@/features/notifications/utils/get-notification-settings-key";
 
 export type Notification = {
   npc?: GameNpc & { location: string; name: string };
@@ -23,11 +25,6 @@ export type Notification = {
   world: string;
   createdAt: string;
   isGatheringParty?: boolean;
-};
-
-const getNotificationType = (n: Notification) => {
-  if (!n.npc || !n.npc.wt) return "message" as const;
-  return getNpcTypeByWt(NpcType, n.npc.wt);
 };
 
 export const useNotifications = () => {
@@ -62,15 +59,15 @@ export const useNotifications = () => {
     }
 
     const currentSettings = settingsRef.current;
-    const notificationType = getNotificationType(data);
-    const typeSettings =
-      currentSettings[notificationType as keyof typeof currentSettings];
+    const notificationSettingsKey = getNotificationSettingsKey(data);
 
-    if (!typeSettings) {
+    if (!isNotificationSettingsKey(notificationSettingsKey)) {
       setOpen("notifications", true);
       pushNotification({ ...data, servers: [data.guildId] });
       return;
     }
+
+    const typeSettings = currentSettings[notificationSettingsKey];
 
     if (!typeSettings.show) return;
     if (typeSettings.ignoreOtherWorlds && data.world !== worldRef.current)
@@ -81,7 +78,7 @@ export const useNotifications = () => {
     pushNotification({ ...data, servers: [data.guildId] });
 
     if (typeSettings.sound) {
-      playSound("notifications", notificationType);
+      playSound("notifications", notificationSettingsKey);
     }
   };
 

--- a/apps/game-client/src/features/notifications/hooks/use-visible-notifications.ts
+++ b/apps/game-client/src/features/notifications/hooks/use-visible-notifications.ts
@@ -1,15 +1,15 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import {
   type MentionNotification,
   type StoredNotification,
   useNotificationsStore,
-  type PartyGatheringNotification,
 } from "@/store/notifications.store";
 import { useCurrentGameAccountNotificationSettings } from "@/hooks/use-current-game-account-notification-settings";
-import { getNpcTypeByWt } from "@lootlog/types";
-import type { Notification } from "@/features/notifications/hooks/use-notifications";
-import { NpcType } from "@/api/npcs.api";
 import { Game } from "@/lib/game";
+import {
+  getNotificationSettingsKey,
+  isNotificationSettingsKey,
+} from "@/features/notifications/utils/get-notification-settings-key";
 
 interface UseVisibleNotificationsOptions {
   autoCleanup?: boolean;
@@ -19,14 +19,6 @@ interface UseVisibleNotificationsResult {
   notifications: StoredNotification[];
   all: StoredNotification[];
 }
-
-const getKey = (n: Notification | PartyGatheringNotification) => {
-  if ("type" in n && n.type === "party-gathering")
-    return "party-gathering" as const;
-  const notification = n as Notification;
-  if (!notification.npc || !notification.npc.wt) return "message" as const;
-  return getNpcTypeByWt(NpcType, notification.npc.wt);
-};
 
 const isMentionNotification = (
   notification: StoredNotification,
@@ -58,7 +50,12 @@ const getScheduledExpirationTimeMs = ({
   >;
   settings: Record<string, { autoHideTimeout?: number }>;
 }) => {
-  const key = getKey(notification);
+  const key = getNotificationSettingsKey(notification);
+
+  if (!isNotificationSettingsKey(key)) {
+    return null;
+  }
+
   const notificationSettings = settings[key];
 
   if (!notificationSettings?.autoHideTimeout) {
@@ -139,22 +136,25 @@ export const useVisibleNotifications = ({
     };
   }, [autoCleanup, notificationAutoHideByListKey, notifications, settings]);
 
-  const visible = useMemo(() => {
-    return notifications.filter((n) => {
-      if (isMentionNotification(n)) {
-        return true;
-      }
-
-      const key = getKey(n) as keyof typeof settings;
-      const s = settings[key];
-      if (!s) return false;
-      if (!s.show) return false;
-      if (s.ignoreOtherWorlds && n.world !== world) return false;
-      if (Array.isArray(s.guildIds) && !s.guildIds.includes(n.guildId))
-        return false;
+  const visible = notifications.filter((n) => {
+    if (isMentionNotification(n)) {
       return true;
-    });
-  }, [notifications, settings, world]);
+    }
+
+    const key = getNotificationSettingsKey(n);
+
+    if (!isNotificationSettingsKey(key)) {
+      return false;
+    }
+
+    const s = settings[key];
+    if (!s) return false;
+    if (!s.show) return false;
+    if (s.ignoreOtherWorlds && n.world !== world) return false;
+    if (Array.isArray(s.guildIds) && !s.guildIds.includes(n.guildId))
+      return false;
+    return true;
+  });
 
   return { notifications: visible, all: notifications };
 };

--- a/apps/game-client/src/features/notifications/utils/get-notification-settings-key.test.ts
+++ b/apps/game-client/src/features/notifications/utils/get-notification-settings-key.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { NpcType } from "@/api/npcs.api";
+import {
+  getNotificationSettingsKey,
+  isNotificationSettingsKey,
+} from "./get-notification-settings-key";
+
+describe("getNotificationSettingsKey", () => {
+  it("resolves party gathering notifications to their dedicated settings key", () => {
+    expect(getNotificationSettingsKey({ type: "party-gathering" })).toBe(
+      "party-gathering",
+    );
+  });
+
+  it("uses message settings when an NPC category is unavailable", () => {
+    expect(getNotificationSettingsKey({})).toBe("message");
+    expect(getNotificationSettingsKey({ npc: { wt: 0 } })).toBe("message");
+  });
+
+  it("returns the NPC category when the notification has NPC weight", () => {
+    expect(getNotificationSettingsKey({ npc: { wt: 20 } })).toBe(
+      NpcType.ELITE2,
+    );
+    expect(getNotificationSettingsKey({ npc: { wt: 100 } })).toBe(
+      NpcType.TITAN,
+    );
+  });
+});
+
+describe("isNotificationSettingsKey", () => {
+  it("accepts configured notification settings keys", () => {
+    expect(isNotificationSettingsKey("party-gathering")).toBe(true);
+    expect(isNotificationSettingsKey(NpcType.TITAN)).toBe(true);
+  });
+
+  it("rejects NPC categories without notification settings", () => {
+    expect(isNotificationSettingsKey(NpcType.COMMON)).toBe(false);
+    expect(isNotificationSettingsKey(NpcType.ELITE3)).toBe(false);
+  });
+});

--- a/apps/game-client/src/features/notifications/utils/get-notification-settings-key.ts
+++ b/apps/game-client/src/features/notifications/utils/get-notification-settings-key.ts
@@ -1,0 +1,40 @@
+import { NpcType } from "@/api/npcs.api";
+import { getNpcTypeByWt, type NotificationType } from "@lootlog/types";
+
+const notificationSettingsKeys = [
+  NpcType.ELITE2,
+  NpcType.HERO,
+  NpcType.COLOSSUS,
+  NpcType.TITAN,
+  "message",
+  "party-gathering",
+] as const satisfies readonly NotificationType[];
+
+const notificationSettingsKeySet = new Set<string>(notificationSettingsKeys);
+
+type NotificationSettingsKeySource = {
+  type?: string;
+  npc?: {
+    wt?: number | null;
+  } | null;
+};
+
+export const isNotificationSettingsKey = (
+  key: string,
+): key is NotificationType => {
+  return notificationSettingsKeySet.has(key);
+};
+
+export const getNotificationSettingsKey = (
+  notification: NotificationSettingsKeySource,
+) => {
+  if (notification.type === "party-gathering") {
+    return "party-gathering";
+  }
+
+  if (!notification.npc?.wt) {
+    return "message";
+  }
+
+  return getNpcTypeByWt(NpcType, notification.npc.wt);
+};


### PR DESCRIPTION
## Summary

- Added a shared `getNotificationSettingsKey` helper for game-client notification categories.
- Reused it in notification ingestion, visibility filtering, and single-notification rendering.
- Removed duplicated key resolution and the `useMemo` around visible notification filtering.
- Added focused coverage for configured and unsupported notification category keys.

## Verification

- `pnpm install --frozen-lockfile` linked dependencies, but exited with pnpm's existing ignored-builds approval warning.
- `pnpm turbo run build --filter=@lootlog/game-client... --force`
- `pnpm --filter @lootlog/game-client exec vitest run src/features/notifications/utils/get-notification-settings-key.test.ts src/features/notifications/hooks/use-visible-notifications.test.tsx src/features/notifications/hooks/use-notifications.test.tsx`
- `pnpm --filter @lootlog/game-client test`
- `pnpm turbo run lint --affected` (Turbo could not infer a base branch, so it linted broadly; existing warnings only, no errors.)
- `pnpm format:check`
- `git diff --check`
- `.husky/pre-commit`

## Notes

Game-client has no package `lint` or `format:check` script, so the pre-commit Turbo lint/format tasks report no package task execution for that package. `lint-staged` still ran `oxlint` and `oxfmt` on the changed files.