### PR TITLE
[codex] Remove manual stats customization callbacks

### DIFF
--- a/apps/web/src/hooks/use-stats-customization.ts
+++ b/apps/web/src/hooks/use-stats-customization.ts
@@ -1,5 +1,4 @@
 import { useLocalStorage } from "usehooks-ts";
-import { useCallback } from "react";
 import type {
   CategoryCustomization,
   StatsCustomizationConfig,
@@ -39,163 +38,139 @@ export const useStatsCustomization = (defaultCategories: StatCategory[]) => {
     createDefaultConfig(defaultCategories),
   );
 
-  const updateCategoryOrder = useCallback(
-    (newOrder: string[]) => {
-      setConfig((prev) => ({
+  const updateCategoryOrder = (newOrder: string[]) => {
+    setConfig((prev) => ({
+      ...prev,
+      categoryOrder: newOrder,
+    }));
+  };
+
+  const toggleCategoryVisibility = (categoryId: string) => {
+    setConfig((prev) => {
+      const category = prev.categories[categoryId];
+      if (!category) return prev;
+
+      return {
         ...prev,
-        categoryOrder: newOrder,
-      }));
-    },
-    [setConfig],
-  );
-
-  const toggleCategoryVisibility = useCallback(
-    (categoryId: string) => {
-      setConfig((prev) => {
-        const category = prev.categories[categoryId];
-        if (!category) return prev;
-
-        return {
-          ...prev,
-          categories: {
-            ...prev.categories,
-            [categoryId]: {
-              ...category,
-              visible: !category.visible,
-            },
+        categories: {
+          ...prev.categories,
+          [categoryId]: {
+            ...category,
+            visible: !category.visible,
           },
-        };
-      });
-    },
-    [setConfig],
-  );
+        },
+      };
+    });
+  };
 
-  const updateCategoryName = useCallback(
-    (categoryId: string, newName: string) => {
-      setConfig((prev) => {
-        const category = prev.categories[categoryId];
-        if (!category) return prev;
+  const updateCategoryName = (categoryId: string, newName: string) => {
+    setConfig((prev) => {
+      const category = prev.categories[categoryId];
+      if (!category) return prev;
 
-        return {
-          ...prev,
-          categories: {
-            ...prev.categories,
-            [categoryId]: {
-              ...category,
-              name: newName,
-            },
+      return {
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [categoryId]: {
+            ...category,
+            name: newName,
           },
-        };
-      });
-    },
-    [setConfig],
-  );
+        },
+      };
+    });
+  };
 
-  const updateStatOrder = useCallback(
-    (categoryId: string, newOrder: string[]) => {
-      setConfig((prev) => {
-        const category = prev.categories[categoryId];
-        if (!category) return prev;
+  const updateStatOrder = (categoryId: string, newOrder: string[]) => {
+    setConfig((prev) => {
+      const category = prev.categories[categoryId];
+      if (!category) return prev;
 
-        return {
-          ...prev,
-          categories: {
-            ...prev.categories,
-            [categoryId]: {
-              ...category,
-              statOrder: newOrder,
-            },
+      return {
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [categoryId]: {
+            ...category,
+            statOrder: newOrder,
           },
-        };
-      });
-    },
-    [setConfig],
-  );
+        },
+      };
+    });
+  };
 
-  const addStatToCategory = useCallback(
-    (categoryId: string, statKey: string) => {
-      setConfig((prev) => {
-        const category = prev.categories[categoryId];
-        if (!category || category.statOrder.includes(statKey)) return prev;
+  const addStatToCategory = (categoryId: string, statKey: string) => {
+    setConfig((prev) => {
+      const category = prev.categories[categoryId];
+      if (!category || category.statOrder.includes(statKey)) return prev;
 
-        return {
-          ...prev,
-          categories: {
-            ...prev.categories,
-            [categoryId]: {
-              ...category,
-              statOrder: [...category.statOrder, statKey],
-            },
+      return {
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [categoryId]: {
+            ...category,
+            statOrder: [...category.statOrder, statKey],
           },
-        };
-      });
-    },
-    [setConfig],
-  );
+        },
+      };
+    });
+  };
 
-  const removeStatFromCategory = useCallback(
-    (categoryId: string, statKey: string) => {
-      setConfig((prev) => {
-        const category = prev.categories[categoryId];
-        if (!category) return prev;
+  const removeStatFromCategory = (categoryId: string, statKey: string) => {
+    setConfig((prev) => {
+      const category = prev.categories[categoryId];
+      if (!category) return prev;
 
-        return {
-          ...prev,
-          categories: {
-            ...prev.categories,
-            [categoryId]: {
-              ...category,
-              statOrder: category.statOrder.filter((key) => key !== statKey),
-            },
+      return {
+        ...prev,
+        categories: {
+          ...prev.categories,
+          [categoryId]: {
+            ...category,
+            statOrder: category.statOrder.filter((key) => key !== statKey),
           },
-        };
-      });
-    },
-    [setConfig],
-  );
+        },
+      };
+    });
+  };
 
-  const addCategory = useCallback(
-    (categoryName: string) => {
-      setConfig((prev) => {
-        const categoryId = `custom-${Date.now()}`;
+  const addCategory = (categoryName: string) => {
+    setConfig((prev) => {
+      const categoryId = `custom-${Date.now()}`;
 
-        return {
-          ...prev,
-          categoryOrder: [...prev.categoryOrder, categoryId],
-          categories: {
-            ...prev.categories,
-            [categoryId]: {
-              id: categoryId,
-              name: categoryName,
-              visible: true,
-              statOrder: [],
-            },
+      return {
+        ...prev,
+        categoryOrder: [...prev.categoryOrder, categoryId],
+        categories: {
+          ...prev.categories,
+          [categoryId]: {
+            id: categoryId,
+            name: categoryName,
+            visible: true,
+            statOrder: [],
           },
-        };
-      });
-    },
-    [setConfig],
-  );
+        },
+      };
+    });
+  };
 
-  const removeCategory = useCallback(
-    (categoryId: string) => {
-      setConfig((prev) => {
-        const { [categoryId]: _removed, ...remainingCategories } =
-          prev.categories;
+  const removeCategory = (categoryId: string) => {
+    setConfig((prev) => {
+      const { [categoryId]: _removed, ...remainingCategories } =
+        prev.categories;
 
-        return {
-          ...prev,
-          categoryOrder: prev.categoryOrder.filter((id) => id !== categoryId),
-          categories: remainingCategories,
-        };
-      });
-    },
-    [setConfig],
-  );
+      return {
+        ...prev,
+        categoryOrder: prev.categoryOrder.filter((id) => id !== categoryId),
+        categories: remainingCategories,
+      };
+    });
+  };
 
-  const resetToDefaults = useCallback(() => {
+  const resetToDefaults = () => {
     setConfig(createDefaultConfig(defaultCategories));
-  }, [setConfig, defaultCategories]);
+  };
 
   return {
     config,


### PR DESCRIPTION
## Summary

- Removed explicit `useCallback` wrappers from the stats customization hook actions.
- Kept the same updater logic and returned action names while relying on the React Compiler for memoization.

## Verification

- `pnpm exec oxfmt --check apps/web/src/hooks/use-stats-customization.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web...`
- `pnpm turbo run test --filter=@lootlog/web...` (no `@lootlog/web` test task; dependency build tasks were cache hits)
- `.husky/pre-commit`

Notes: the first direct `pnpm --filter @lootlog/web build` failed before dependency builds because workspace package outputs were missing, then passed via Turborepo's dependency-aware build. `pnpm install` populated dependencies but exited nonzero after pnpm requested build-script approval; the needed tooling and builds still ran successfully afterward.