### PR TITLE
[codex] remove API events interface barrel

### DIFF
--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -22,12 +22,11 @@ import type { UpdateLocationDto } from "./dto/update-location.dto";
 import type {
   CheckEventHeroKillParams,
   EventHeroKillJobData,
-  KillTimerData,
-} from "./interfaces";
+} from "./interfaces/check-event-hero-kill-params.interface";
+import type { KillTimerData } from "./interfaces/kill-timer-data.interface";
 import type {
   CloseRespawnWindowOptions,
   OpenRespawnWindowOptions,
-  MapStatus,
 } from "./interfaces/respawn-window.interface";
 import {
   EVENT_HERO_KILL_JOB_NAME,

--- a/apps/api/src/events/interfaces/index.ts
+++ b/apps/api/src/events/interfaces/index.ts
@@ -1,4 +1,0 @@
-export * from "./kill-timer-data.interface";
-export * from "./check-event-hero-kill-params.interface";
-export * from "./presence-log.interface";
-export * from "./respawn-window.interface";

--- a/apps/api/src/events/interfaces/presence-log.interface.ts
+++ b/apps/api/src/events/interfaces/presence-log.interface.ts
@@ -1,5 +1,0 @@
-import type { EventPresenceLog, Member } from "src/generated/prisma/client";
-
-interface PresenceLogWithMember extends EventPresenceLog {
-  member: Pick<Member, "id" | "name" | "avatar" | "userId">;
-}

--- a/apps/api/src/events/services/event-timer-hooks.service.ts
+++ b/apps/api/src/events/services/event-timer-hooks.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from "@nestjs/common";
 import type { Queue } from "bullmq";
 import type { Event, EventHeroNpc } from "src/generated/prisma/client";
 import { PrismaService } from "src/db/prisma.service";
-import type { CheckEventHeroKillParams } from "../interfaces";
+import type { CheckEventHeroKillParams } from "../interfaces/check-event-hero-kill-params.interface";
 import { EVENT_HERO_KILL_QUEUE } from "../constants/event-hero-kill-queue.constant";
 import {
   EVENT_HERO_KILL_JOB_NAME,


### PR DESCRIPTION
## Summary

- Replaced the API events interface barrel import with direct type imports in the two consumers.
- Deleted the now-unused `apps/api/src/events/interfaces/index.ts` re-export-only wrapper.
- Deleted the dead `presence-log.interface.ts` file, which only declared a non-exported unused type.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt apps/api/src/events/events.service.ts apps/api/src/events/services/event-timer-hooks.service.ts`
- `corepack pnpm exec oxfmt --check apps/api/src/events/events.service.ts apps/api/src/events/services/event-timer-hooks.service.ts`
- `corepack pnpm --filter @lootlog/api exec oxlint src/events/events.service.ts src/events/services/event-timer-hooks.service.ts`
- `corepack pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/events/events.service.spec.ts src/events/services/event-timer-hooks.service.spec.ts`
- `corepack pnpm turbo run build --filter=@lootlog/api --force`
- `corepack pnpm turbo run lint '--filter=[HEAD]'` (passes with existing warnings)
- `corepack pnpm turbo run test '--filter=[HEAD]'`
- Commit hook: `pnpm lint-staged`, `pnpm turbo run lint --filter=[HEAD]`, `pnpm turbo run format:check --filter=[HEAD]`, `pnpm turbo run test --filter=[HEAD]`

Note: the Turbo `format:check --filter=[HEAD]` step reports no package task for `@lootlog/api`; touched files were checked directly with `oxfmt --check`.