### PR TITLE
[codex] Use strict battle utility null checks

### DIFF
--- a/apps/web/src/components/battle/utils/battle-log-search.ts
+++ b/apps/web/src/components/battle/utils/battle-log-search.ts
@@ -58,7 +58,7 @@ const ACTION_SEARCH_LABELS: Record<string, readonly string[]> = {
 };
 
 const appendSearchPart = (parts: string[], value: unknown): void => {
-  if (value == null) {
+  if (value === null || value === undefined) {
     return;
   }
 

--- a/apps/web/src/components/battle/utils/raw-battle-events.ts
+++ b/apps/web/src/components/battle/utils/raw-battle-events.ts
@@ -15,7 +15,7 @@ type BattleMoveSide = {
 };
 
 const parseHpPercentage = (value: string | undefined): number | null => {
-  if (value == null || value === "") {
+  if (value === undefined || value === "") {
     return null;
   }
 

--- a/apps/web/src/components/battle/utils/value-utils.ts
+++ b/apps/web/src/components/battle/utils/value-utils.ts
@@ -15,7 +15,7 @@ export const roundValue = (value: string | number): string => {
 export const roundHpPercentage = (
   value: string | number | null | undefined,
 ): string => {
-  if (value == null) {
+  if (value === null || value === undefined) {
     return "-";
   }
 


### PR DESCRIPTION
## Summary

- Replaced loose null checks in battle log utility helpers with explicit `null`/`undefined` comparisons.
- Kept the cleanup scoped to three related battle utility files with no behavior change.

## Verification

- `pnpm --filter @lootlog/web exec vitest run src/components/battle/utils/battle-log-search.spec.ts src/components/battle/utils/raw-battle-events.spec.ts src/components/battle/utils/value-utils.spec.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm exec oxfmt --check apps/web/src/components/battle/utils/battle-log-search.ts apps/web/src/components/battle/utils/raw-battle-events.ts apps/web/src/components/battle/utils/value-utils.ts`
- `pnpm turbo run build --filter=@lootlog/web...`
- Pre-commit hook during commit: `pnpm lint-staged`, `pnpm turbo run lint --filter=[HEAD]`, `pnpm turbo run format:check --filter=[HEAD]`, `pnpm turbo run test --filter=[HEAD]`

Note: the Turbo `format:check` and `test` changed-package tasks reported no package task to execute for `@lootlog/web`; focused formatting and Vitest specs were run directly above.