### PR TITLE
[codex] simplify draggable window cursor logic

### DIFF
--- a/apps/game-client/src/components/draggable-window.tsx
+++ b/apps/game-client/src/components/draggable-window.tsx
@@ -186,6 +186,24 @@ const sanitizeMaxContentHeight = (height: number | undefined) => {
   return Math.max(1, Math.round(height as number));
 };
 
+const getWindowCursor = ({
+  isLocked,
+  isDragging,
+}: {
+  isLocked: boolean;
+  isDragging: boolean;
+}) => {
+  if (isLocked) {
+    return "default";
+  }
+
+  if (isDragging) {
+    return "grabbing";
+  }
+
+  return "grab";
+};
+
 const measureWindowContent = ({
   windowBody,
   contentElement,
@@ -699,7 +717,7 @@ export const DraggableWindow: FC<DraggableWindowProps> = ({
         top: position.y,
         left: position.x,
         zIndex,
-        cursor: isLocked ? "default" : isDragging ? "grabbing" : "grab",
+        cursor: getWindowCursor({ isLocked, isDragging }),
       }}
       onMouseDownCapture={onMouseDownCapture}
       onTouchStartCapture={onTouchStartCapture}


### PR DESCRIPTION
## Summary

- Extracted the draggable window cursor selection into a named `getWindowCursor` helper.
- Replaced the inline chained ternary in `DraggableWindow` with the helper to match the repo style while preserving behavior.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt --check apps/game-client/src/components/draggable-window.tsx`
- `corepack pnpm exec oxlint apps/game-client/src/components/draggable-window.tsx`
- `git diff --check`
- `corepack pnpm turbo run build --filter=@lootlog/game-client... --force`
- `corepack pnpm --filter @lootlog/game-client test`
- `corepack pnpm turbo run lint --filter=@lootlog/game-client...` (no package lint task configured for this scope)
- `corepack pnpm turbo run format:check --filter=@lootlog/game-client...` (no package format task configured for this scope)
- `corepack pnpm format:check`
- `.husky/pre-commit`
- normal `git commit` hook

Notes: the game-client build still emits existing Vite/CSS asset warnings, but the build completed successfully. The game-client tests still print existing React `act(...)` and logging stderr messages, but all tests passed.