### PR TITLE
[codex] expose api helper auth entry directly

### DIFF
--- a/apps/auth/src/auth/auth.service.spec.ts
+++ b/apps/auth/src/auth/auth.service.spec.ts
@@ -4,13 +4,13 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { validateToken } from "@lootlog/api-helpers";
+import { validateToken } from "@lootlog/api-helpers/auth";
 import { APIError } from "better-auth/api";
 import { AuthService } from "./auth.service";
 import { idpTokenRequestSchema } from "./dto/idp-token-request.dto";
 import { auth } from "./better-auth";
 
-vi.mock("@lootlog/api-helpers", () => ({
+vi.mock("@lootlog/api-helpers/auth", () => ({
   validateToken:
     vi.fn<(input: unknown) => Promise<{ userId: string; discordId: string }>>(),
 }));

--- a/apps/auth/src/auth/auth.service.ts
+++ b/apps/auth/src/auth/auth.service.ts
@@ -6,7 +6,7 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import { APIError } from "better-auth/api";
-import { type JwksKeys, validateToken } from "@lootlog/api-helpers";
+import { type JwksKeys, validateToken } from "@lootlog/api-helpers/auth";
 import { fromNodeHeaders } from "better-auth/node";
 import type { IncomingHttpHeaders } from "node:http";
 import { env } from "src/config/env";

--- a/packages/api-helpers/README.md
+++ b/packages/api-helpers/README.md
@@ -1,18 +1,18 @@
 # @lootlog/api-helpers
 
-Shared auth and request-context helpers for backend services.
+Shared auth and permission helpers for backend services.
 
 ## Overview
 
-- Provides reusable helpers for validating Auth-issued JWTs and extracting user metadata from trusted headers.
-- Supports the Hono services used in this monorepo and keeps auth-adjacent logic out of individual apps.
-- Ships an additional `permissions` subpath export for permission-related helpers.
+- Provides reusable helpers for validating Auth-issued JWTs.
+- Keeps auth-adjacent and permission-related logic out of individual apps.
+- Ships focused `auth` and `permissions` subpath exports.
 
 ## Exports
 
-- `userMetadataFromHeaders`
-- `validateToken`
-- JWT verification types from `verify-jwt.types`
+- `@lootlog/api-helpers/auth`
+  - `validateToken`
+  - JWT verification types from `verify-jwt.types`
 - `@lootlog/api-helpers/permissions`
 
 ## Development
@@ -25,5 +25,5 @@ pnpm --filter @lootlog/api-helpers build
 
 ## Notes
 
-- Main exports are defined in `src/index.ts`.
+- Public exports are defined as direct package subpaths.
 - Token verification is implemented with `jose` and expects either a JWKS object or a remote JWKS URL.

--- a/packages/api-helpers/package.json
+++ b/packages/api-helpers/package.json
@@ -3,21 +3,21 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "auth": [
+        "./dist/auth.d.ts"
+      ],
       "permissions": [
         "./dist/permissions.d.ts"
       ]
     }
   },
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+    "./auth": {
+      "types": "./dist/auth.d.ts",
+      "import": "./dist/auth.mjs",
+      "require": "./dist/auth.js"
     },
     "./permissions": {
       "types": "./dist/permissions.d.ts",
@@ -29,7 +29,6 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "hono": "^4.12.25",
     "jose": "^6.2.2"
   },
   "devDependencies": {

--- a/packages/api-helpers/src/index.ts
+++ b/packages/api-helpers/src/index.ts
@@ -1,4 +1,0 @@
-export * from "./lib/auth/middleware/user-metadata.middleware.js";
-export * from "./lib/auth/utils/verify-jwt.js";
-export * from "./lib/auth/utils/verify-jwt.types.js";
-export * from "./lib/permissions/can-view-npc-timer";

--- a/packages/api-helpers/src/lib/auth/middleware/user-metadata.middleware.ts
+++ b/packages/api-helpers/src/lib/auth/middleware/user-metadata.middleware.ts
@@ -1,8 +1,0 @@
-import { createMiddleware } from "hono/factory";
-
-export const userMetadataFromHeaders = createMiddleware(async (c, next) => {
-  c.set("userId", c.req.raw.headers.get("X-Auth-User-Id"));
-  c.set("discordId", c.req.raw.headers.get("X-Auth-Discord-Id"));
-
-  await next();
-});

--- a/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
+++ b/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
@@ -1,5 +1,12 @@
-import { VerifyTokenOptions, VerifyTokenResponse } from "./verify-jwt.types.js";
-import { jwtVerify, createRemoteJWKSet, createLocalJWKSet } from "jose";
+import { createLocalJWKSet, createRemoteJWKSet, jwtVerify } from "jose";
+import type {
+  Jwks,
+  JwksKeys,
+  VerifyTokenOptions,
+  VerifyTokenResponse,
+} from "./verify-jwt.types.js";
+
+export type { Jwks, JwksKeys, VerifyTokenOptions, VerifyTokenResponse };
 
 export async function validateToken({
   token,

--- a/packages/api-helpers/tsdown.config.ts
+++ b/packages/api-helpers/tsdown.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
+  dts: true,
   entry: {
-    index: "src/index.ts",
+    auth: "src/lib/auth/utils/verify-jwt.ts",
     permissions: "src/lib/permissions/can-view-npc-timer.ts",
   },
   format: ["esm", "cjs"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1374,9 +1374,6 @@ importers:
 
   packages/api-helpers:
     dependencies:
-      hono:
-        specifier: ^4.12.25
-        version: 4.12.25
       jose:
         specifier: ^6.2.2
         version: 6.2.2
@@ -1861,16 +1858,8 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
-  '@axiomhq/js@1.6.0':
-    resolution: {integrity: sha512-qm0ObduIpI6PJUOYwakH5WV3E7IF0qXE/wh5N1JWGAzxKtCZryk+YwA0aW3lPZSGPQeLHyEzN+9pXsOIjoPiRg==}
-    engines: {node: '>=20'}
-
   '@axiomhq/js@1.6.1':
     resolution: {integrity: sha512-iNWOnGvP+R2lIWYk9jkfvRI/rfhOR9hlWJOBJhMKwZ9mfpE0KdnFnG2XPLoMcrbyrOBKj6Jw0hpIH5GhPucLog==}
-    engines: {node: '>=20'}
-
-  '@axiomhq/winston@1.6.0':
-    resolution: {integrity: sha512-7f35MXE7yHP9np47bLvVJ2w/qkW6/o/Zu3+QNDzy5MMa+OLawtZ2l353wpAtxWYbxA/5laJDzP81Iq1yhYNZIQ==}
     engines: {node: '>=20'}
 
   '@axiomhq/winston@1.6.1':
@@ -13567,18 +13556,9 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
-  '@axiomhq/js@1.6.0':
-    dependencies:
-      fetch-retry: 6.0.0
-
   '@axiomhq/js@1.6.1':
     dependencies:
       fetch-retry: 6.0.0
-
-  '@axiomhq/winston@1.6.0':
-    dependencies:
-      '@axiomhq/js': 1.6.0
-      winston-transport: 4.9.0
 
   '@axiomhq/winston@1.6.1':
     dependencies:
@@ -15307,7 +15287,6 @@ snapshots:
 
   '@lootlog/api-helpers@file:packages/api-helpers':
     dependencies:
-      hono: 4.12.25
       jose: 6.2.3
 
   '@lootlog/nest-shared@file:packages/nest-shared(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(ioredis@5.10.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':


### PR DESCRIPTION
## Summary

- Replace the root `@lootlog/api-helpers` barrel with a focused `@lootlog/api-helpers/auth` subpath export.
- Delete the unused Hono user metadata middleware and remove the now-unused `hono` dependency from `api-helpers`.
- Enable declaration output for `api-helpers` so the new `auth` and existing `permissions` subpaths have generated type files.

## Verification

- `CI=true corepack pnpm install`
- `corepack pnpm --filter @lootlog/api-helpers build`
- `corepack pnpm --filter @lootlog/nest-shared build`
- `corepack pnpm --filter @lootlog/auth lint`
- `corepack pnpm --filter @lootlog/auth test`
- `corepack pnpm --filter @lootlog/auth build`
- `corepack pnpm --filter @lootlog/auth exec tsc --noEmit --pretty false`
- `corepack pnpm --filter @lootlog/api-helpers exec tsc --noEmit --pretty false`
- `corepack pnpm turbo run build --filter=@lootlog/auth...`
- `corepack pnpm turbo run lint '--filter=[HEAD]'`
- `corepack pnpm turbo run test '--filter=[HEAD]'`
- `corepack pnpm turbo run format:check '--filter=[HEAD]'` (no package tasks configured for changed packages)
- `corepack pnpm format:check`
- `.husky/pre-commit`