### PR TITLE
feat: improve battle panel battles UX

### DIFF
--- a/apps/battlelog-service/src/battles/interfaces/pagination.interface.ts
+++ b/apps/battlelog-service/src/battles/interfaces/pagination.interface.ts
@@ -5,6 +5,7 @@ export interface CursorPagination {
   hasNext: boolean;
   hasPrev: boolean;
   nextCursor?: string;
+  previousCursor?: string;
   total?: number;
 }
 

--- a/apps/battlelog-service/src/battles/services/pagination.service.spec.ts
+++ b/apps/battlelog-service/src/battles/services/pagination.service.spec.ts
@@ -100,6 +100,55 @@ describe("PaginationService", () => {
       });
     });
 
+    it("should return previous cursor when cursor has a previous page", async () => {
+      const currentCursor = `${new Date("2024-01-04").toISOString()}_4`;
+      const previousWindow = [
+        { ...mockBattles[0], id: "4", createdAt: new Date("2024-01-04") },
+        { ...mockBattles[0], id: "3", createdAt: new Date("2024-01-03") },
+        { ...mockBattles[0], id: "2", createdAt: new Date("2024-01-02") },
+      ];
+      drizzleService.db.query.battles.findMany
+        .mockResolvedValueOnce(mockBattles)
+        .mockResolvedValueOnce(previousWindow);
+
+      const result = await service.paginateBattles(() => undefined, {
+        cursor: currentCursor,
+        size: 2,
+        sortOrder: "desc",
+        includeTotal: false,
+      });
+
+      expect(result.pagination).toMatchObject({
+        size: 2,
+        hasPrev: true,
+        previousCursor: `${new Date("2024-01-02").toISOString()}_2`,
+      });
+    });
+
+    it("should not return previous cursor for the first cursor page", async () => {
+      const currentCursor = `${new Date("2024-01-02").toISOString()}_2`;
+      const previousWindow = [
+        { ...mockBattles[0], id: "2", createdAt: new Date("2024-01-02") },
+        { ...mockBattles[0], id: "1", createdAt: new Date("2024-01-01") },
+      ];
+      drizzleService.db.query.battles.findMany
+        .mockResolvedValueOnce(mockBattles)
+        .mockResolvedValueOnce(previousWindow);
+
+      const result = await service.paginateBattles(() => undefined, {
+        cursor: currentCursor,
+        size: 2,
+        sortOrder: "desc",
+        includeTotal: false,
+      });
+
+      expect(result.pagination).toMatchObject({
+        size: 2,
+        hasPrev: true,
+        previousCursor: undefined,
+      });
+    });
+
     it("should work without includeTotal", async () => {
       drizzleService.db.query.battles.findMany.mockResolvedValue(mockBattles);
 

--- a/apps/battlelog-service/src/battles/services/pagination.service.ts
+++ b/apps/battlelog-service/src/battles/services/pagination.service.ts
@@ -1,5 +1,16 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { and, count, gt, lt, or, eq, sql, type SQL } from "drizzle-orm";
+import {
+  and,
+  count,
+  gt,
+  gte,
+  lt,
+  lte,
+  or,
+  eq,
+  sql,
+  type SQL,
+} from "drizzle-orm";
 import { DrizzleService } from "src/shared/modules/drizzle/drizzle.service";
 import { battles } from "src/shared/modules/drizzle/schema";
 import type {
@@ -68,6 +79,7 @@ export class PaginationService {
       const lastItem = items[items.length - 1];
       nextCursor = this.encodeCursor(lastItem.createdAt, lastItem.id);
     }
+    const previousCursor = await this.getPreviousCursor(whereBuilder, options);
 
     let total: number | undefined;
     const countStartTime = Date.now();
@@ -81,6 +93,7 @@ export class PaginationService {
       hasNext,
       hasPrev: !!cursor,
       nextCursor,
+      previousCursor,
       total,
     };
 
@@ -122,6 +135,63 @@ export class PaginationService {
     )!;
 
     return where ? and(where, cursorCondition) : cursorCondition;
+  }
+
+  private async getPreviousCursor(
+    whereBuilder: WhereBuilder,
+    options: PaginationOptions,
+  ): Promise<string | undefined> {
+    if (!options.cursor) {
+      return undefined;
+    }
+
+    const decoded = this.decodeCursor(options.cursor);
+    if (!decoded) {
+      return undefined;
+    }
+
+    const size = options.size ?? 20;
+    const reverseOrder = options.sortOrder === "asc" ? "desc" : "asc";
+    const previousWindow = await this.drizzle.db.query.battles.findMany({
+      where: {
+        RAW: (table: typeof battles) => {
+          const base = whereBuilder(table);
+          return this.buildPreviousCursorWhere(table, base, decoded, options);
+        },
+      },
+      limit: size + 1,
+      orderBy: { createdAt: reverseOrder, id: reverseOrder },
+    });
+
+    if (previousWindow.length <= size) {
+      return undefined;
+    }
+
+    const previousBoundary = previousWindow[size];
+    if (!previousBoundary) {
+      return undefined;
+    }
+
+    return this.encodeCursor(previousBoundary.createdAt, previousBoundary.id);
+  }
+
+  private buildPreviousCursorWhere(
+    table: typeof battles,
+    where: SQL | undefined,
+    decoded: DecodedCursor,
+    options: PaginationOptions,
+  ): SQL | undefined {
+    const { createdAt, id } = decoded;
+    const createdAtComparator = options.sortOrder === "desc" ? gt : lt;
+    const idComparator = options.sortOrder === "desc" ? gte : lte;
+    const previousCursorCondition = or(
+      createdAtComparator(table.createdAt, createdAt),
+      and(eq(table.createdAt, createdAt), idComparator(table.id, id)),
+    )!;
+
+    return where
+      ? and(where, previousCursorCondition)
+      : previousCursorCondition;
   }
 
   private async getEstimatedCount(where: SQL | undefined): Promise<number> {

--- a/apps/web/src/components/layout/get-user-navigation-info.ts
+++ b/apps/web/src/components/layout/get-user-navigation-info.ts
@@ -2,6 +2,7 @@ import { ROUTES } from "@/config/routes";
 import type { NavigationInfo } from "./get-navigation-info";
 
 type GetUserNavigationInfoArgs = {
+  battleLabel?: string;
   path: string;
   t: (key: string, options?: Record<string, unknown>) => string;
 };
@@ -15,6 +16,7 @@ function normalizePath(path: string) {
 }
 
 export function getUserNavigationInfo({
+  battleLabel,
   path,
   t,
 }: GetUserNavigationInfoArgs): NavigationInfo {
@@ -122,9 +124,11 @@ export function getUserNavigationInfo({
             path: ROUTES.user.battlePanel.base,
           },
           {
-            label: t("battlePanel.navigation.battleFallback", {
-              id: battleId,
-            }),
+            label:
+              battleLabel ??
+              t("battlePanel.navigation.battleFallback", {
+                id: battleId,
+              }),
             path: null,
           },
         ],

--- a/apps/web/src/components/layout/user-shell.tsx
+++ b/apps/web/src/components/layout/user-shell.tsx
@@ -1,10 +1,14 @@
 import { PageHeader } from "@/components/layout/page-header";
 import { ROUTES } from "@/config/routes";
 import { UserHeaderActionsContext } from "@/contexts/user-header-actions-context";
+import {
+  getBattleRouteLabel,
+  type BattleRouteLabelMatch,
+} from "@/lib/battle/battle-route-label";
 import { Button } from "@lootlog/ui/components/button";
 import { ScrollArea } from "@lootlog/ui/components/scroll-area";
 import { SidebarTrigger } from "@lootlog/ui/components/sidebar";
-import { useLocation, useNavigate } from "@tanstack/react-router";
+import { useLocation, useMatches, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import { useState, type FC, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
@@ -17,13 +21,18 @@ type UserShellProps = {
 
 export const UserShell: FC<UserShellProps> = ({ children }) => {
   const location = useLocation();
+  const matches = useMatches();
   const navigate = useNavigate();
   const { t } = useTranslation();
   const [hoveredButton, setHoveredButton] = useState<string | null>(null);
   const [headerActionsElement, setHeaderActionsElement] =
     useState<HTMLElement | null>(null);
+  const currentMatch = matches[matches.length - 1] as
+    | BattleRouteLabelMatch
+    | undefined;
 
   const navigationInfo = getUserNavigationInfo({
+    battleLabel: getBattleRouteLabel(currentMatch, t),
     path: location.pathname,
     t,
   });
@@ -37,8 +46,8 @@ export const UserShell: FC<UserShellProps> = ({ children }) => {
 
   return (
     <UserHeaderActionsContext.Provider value={headerActionsElement}>
-      <div className="flex h-full min-h-0 w-full flex-row bg-background/70">
-        <div className="flex h-full min-h-0 w-full flex-col">
+      <div className="flex h-full min-h-0 min-w-0 flex-1 flex-row bg-background/70">
+        <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
           <PageHeader>
             <div className="flex w-full flex-row items-center justify-between gap-2">
               <div className="flex flex-row items-center gap-2">
@@ -124,8 +133,10 @@ export const UserShell: FC<UserShellProps> = ({ children }) => {
           {isFullHeightContent ? (
             <div className="flex-1 min-h-0 overflow-auto">{children}</div>
           ) : (
-            <ScrollArea className="flex h-full min-h-0 w-full max-w-full flex-1 flex-col gap-4">
-              <div className="h-full">{children}</div>
+            <ScrollArea className="flex h-full min-h-0 min-w-0 w-full max-w-full flex-1 flex-col gap-4 [&>[data-radix-scroll-area-viewport]>div]:!block [&>[data-radix-scroll-area-viewport]>div]:!w-full">
+              <div className="h-full min-w-0 w-full max-w-full overflow-x-hidden">
+                {children}
+              </div>
             </ScrollArea>
           )}
         </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/battle-panel-battles-list.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/battle-panel-battles-list.tsx
@@ -153,8 +153,8 @@ export const BattlePanelBattlesList = () => {
         </Drawer>
       )}
 
-      <div className="w-full flex flex-col h-full overflow-hidden bg-background/50">
-        <div className="flex-1 flex overflow-hidden">
+      <div className="w-full min-w-0 flex flex-col h-full overflow-hidden bg-background/50">
+        <div className="flex-1 min-w-0 flex overflow-hidden">
           <div className="flex-1 flex flex-col min-w-0 overflow-hidden p-3">
             <BattlesList
               battlesResponse={battlesResponse}
@@ -190,7 +190,7 @@ export const BattlePanelBattlesList = () => {
                   animate={{ width: 320, opacity: 1 }}
                   exit={{ width: 0, opacity: 0 }}
                   transition={{ duration: 0.2 }}
-                  className="overflow-hidden h-full"
+                  className="overflow-hidden h-full shrink-0"
                 >
                   <FiltersSidebar
                     filters={filters}

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list.tsx
@@ -72,7 +72,7 @@ export const BattlesList = ({
 
   const handlePreviousPage = () => {
     if (onCursorChange) {
-      onCursorChange(undefined);
+      onCursorChange(battlesResponse?.pagination.previousCursor);
     }
   };
 
@@ -107,7 +107,7 @@ export const BattlesList = ({
     <div
       ref={containerRef}
       className={cn(
-        "flex min-h-0 flex-col overflow-hidden",
+        "flex min-h-0 min-w-0 flex-col overflow-hidden",
         showPagination ? "h-full flex-1" : "w-full",
         showFilters && "gap-3",
       )}

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-table.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-table.tsx
@@ -64,13 +64,21 @@ import {
 import { useNavigate } from "@tanstack/react-router";
 import { format } from "date-fns";
 import {
+  Biohazard,
   Copy,
+  Flag,
+  Flame,
+  HeartCrack,
   Lock,
-  LockOpen,
   MoreHorizontal,
   Share2,
   Shield,
+  Snowflake,
   Trash2,
+  Trophy,
+  XCircle,
+  Zap,
+  type LucideIcon,
 } from "lucide-react";
 import {
   useEffect,
@@ -105,29 +113,58 @@ type BattlesTableProps = {
 
 type BattleTeamDamageTag = {
   badgeClassName: string;
+  icon: LucideIcon;
   key: BattleDamageTag;
 };
 
-const MOBILE_HIDDEN_COLUMN_IDS = new Set(["world", "tags", "mode"]);
-
-const DAMAGE_TAG_CLASS_NAMES: Record<
+const DAMAGE_TAG_CONFIG: Record<
   BattleDamageTag,
-  Pick<BattleTeamDamageTag, "badgeClassName">
+  Pick<BattleTeamDamageTag, "badgeClassName" | "icon">
 > = {
   fire: {
     badgeClassName: "border-red-500/20 bg-red-500/5 text-red-300",
+    icon: Flame,
   },
   frost: {
     badgeClassName: "border-cyan-500/20 bg-cyan-500/5 text-cyan-300",
+    icon: Snowflake,
   },
   lightning: {
     badgeClassName: "border-yellow-500/20 bg-yellow-500/5 text-yellow-300",
+    icon: Zap,
   },
   poison: {
     badgeClassName: "border-green-500/20 bg-green-500/5 text-green-300",
+    icon: Biohazard,
   },
   wound: {
     badgeClassName: "border-orange-500/20 bg-orange-500/5 text-orange-300",
+    icon: HeartCrack,
+  },
+};
+
+const BATTLE_RESULT_STATUS_CONFIG: Record<
+  BattleResult,
+  {
+    className: string;
+    icon: LucideIcon;
+    labelKey: string;
+  }
+> = {
+  won: {
+    className: "border-green-500/25 bg-green-500/10 text-green-400",
+    icon: Trophy,
+    labelKey: "battlePanel.list.results.won",
+  },
+  lost: {
+    className: "border-red-500/25 bg-red-500/10 text-red-400",
+    icon: XCircle,
+    labelKey: "battlePanel.list.results.lost",
+  },
+  flee: {
+    className: "border-yellow-500/25 bg-yellow-500/10 text-yellow-400",
+    icon: Flag,
+    labelKey: "battlePanel.list.results.flee",
   },
 };
 
@@ -184,24 +221,24 @@ const getTeamDamageTags = (
   const tags: BattleTeamDamageTag[] = [];
 
   if (sumWarriorValues(team, (warrior) => warrior.fireDamage) > 0) {
-    tags.push({ key: "fire", ...DAMAGE_TAG_CLASS_NAMES.fire });
+    tags.push({ key: "fire", ...DAMAGE_TAG_CONFIG.fire });
   }
 
   if (sumWarriorValues(team, (warrior) => warrior.frostDamage) > 0) {
-    tags.push({ key: "frost", ...DAMAGE_TAG_CLASS_NAMES.frost });
+    tags.push({ key: "frost", ...DAMAGE_TAG_CONFIG.frost });
   }
 
   if (sumWarriorValues(team, (warrior) => warrior.lightningDamage) > 0) {
     tags.push({
       key: "lightning",
-      ...DAMAGE_TAG_CLASS_NAMES.lightning,
+      ...DAMAGE_TAG_CONFIG.lightning,
     });
   }
 
   if (
     sumWarriorValues(opposingTeam, (warrior) => warrior.poisonDamageTaken) > 0
   ) {
-    tags.push({ key: "poison", ...DAMAGE_TAG_CLASS_NAMES.poison });
+    tags.push({ key: "poison", ...DAMAGE_TAG_CONFIG.poison });
   }
 
   if (
@@ -210,26 +247,10 @@ const getTeamDamageTags = (
       (warrior) => warrior.woundDamageTaken + warrior.critWoundDamageTaken,
     ) > 0
   ) {
-    tags.push({ key: "wound", ...DAMAGE_TAG_CLASS_NAMES.wound });
+    tags.push({ key: "wound", ...DAMAGE_TAG_CONFIG.wound });
   }
 
   return tags;
-};
-
-const mergeDamageTags = (
-  tagGroups: BattleTeamDamageTag[][],
-): BattleTeamDamageTag[] => {
-  const tagsByKey = new Map<BattleDamageTag, BattleTeamDamageTag>();
-
-  for (const tagGroup of tagGroups) {
-    for (const tag of tagGroup) {
-      if (!tagsByKey.has(tag.key)) {
-        tagsByKey.set(tag.key, tag);
-      }
-    }
-  }
-
-  return Array.from(tagsByKey.values());
 };
 
 const getRowClassName = (battle: Battle) => {
@@ -247,36 +268,28 @@ const getRowClassName = (battle: Battle) => {
 };
 
 const getColumnResponsiveClassName = (columnId: string) => {
-  if (MOBILE_HIDDEN_COLUMN_IDS.has(columnId)) {
-    return "hidden md:table-cell";
+  if (columnId === "select") {
+    return "relative w-[9%] px-0! md:w-12";
   }
 
-  if (columnId === "select") {
-    return "w-[9%] px-2 md:w-10";
+  if (columnId === "status") {
+    return "w-[10%] px-1 md:w-[64px]";
+  }
+
+  if (columnId === "battleInfo") {
+    return "w-[20%] px-1 md:w-[176px]";
   }
 
   if (columnId === "leftTeam" || columnId === "rightTeam") {
-    return "w-[27%] md:w-auto";
+    return "w-[24%] md:w-[240px]";
   }
 
   if (columnId === "createdAt") {
-    return "w-[22%] md:w-[112px]";
-  }
-
-  if (columnId === "world") {
-    return "md:w-[116px]";
-  }
-
-  if (columnId === "tags") {
-    return "md:w-[176px]";
-  }
-
-  if (columnId === "mode") {
-    return "md:w-[76px]";
+    return "w-[20%] md:w-[112px]";
   }
 
   if (columnId === "actions") {
-    return "w-[15%] md:w-[64px]";
+    return "w-[14%] md:w-[64px]";
   }
 
   return "";
@@ -290,9 +303,22 @@ const stopTableKeyboardAction = (event: KeyboardEvent<HTMLElement>) => {
   event.stopPropagation();
 };
 
+const getEventTargetElement = (target: EventTarget | null) => {
+  if (target instanceof Element) {
+    return target;
+  }
+
+  if (target instanceof Node) {
+    return target.parentElement;
+  }
+
+  return null;
+};
+
 const isTableActionEvent = (event: MouseEvent<HTMLElement>) =>
-  event.target instanceof Element &&
-  Boolean(event.target.closest("[data-battle-table-action]"));
+  Boolean(
+    getEventTargetElement(event.target)?.closest("[data-battle-table-action]"),
+  );
 
 export const BattlesTable = ({
   battles,
@@ -471,6 +497,19 @@ export const BattlesTable = ({
     setSelectedBattleIds(new Set(selectableVisibleBattleIds));
   };
 
+  const handleHeaderSelectionCellClick = (event: MouseEvent<HTMLElement>) => {
+    event.stopPropagation();
+    handleHeaderSelectionChange(!areAllSelectableRowsSelected);
+  };
+
+  const handleSelectionCellClick = (
+    event: MouseEvent<HTMLElement>,
+    battleId: string,
+  ) => {
+    event.stopPropagation();
+    handleSelectionChange(battleId, !selectedBattleIds.has(battleId));
+  };
+
   const handleBulkShare = async () => {
     if (selectedBattles.length === 0) {
       return;
@@ -589,58 +628,189 @@ export const BattlesTable = ({
     );
   };
 
-  const renderTeam = (team: BattleWarrior[], userWarrior?: BattleWarrior) => (
-    <div className="flex min-w-0 max-w-[112px] flex-col gap-1 md:min-w-[200px] md:max-w-[300px]">
-      {team.map((warrior) => (
-        <div key={warrior.id} className="flex min-w-0 items-center gap-1.5">
-          <PlayerTile player={warrior} className="scale-75" />
-          <span
-            className={cn("min-w-0 truncate text-xs font-medium", {
-              "text-green-500": warrior.originalId === userWarrior?.originalId,
-            })}
-          >
-            {warrior.name}{" "}
-            <span className="text-muted-foreground font-normal">
-              ({warrior.lvl}
-              {warrior.prof})
-            </span>
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-
-  const renderDamageTags = (
-    team: BattleWarrior[],
-    opposingTeam: BattleWarrior[],
-  ) => {
-    const tags = mergeDamageTags([
-      getTeamDamageTags(team, opposingTeam),
-      getTeamDamageTags(opposingTeam, team),
-    ]);
-
+  const renderDamageTagIcons = (tags: BattleTeamDamageTag[]) => {
     if (tags.length === 0) {
-      return (
-        <span className="text-xs text-muted-foreground/70">
-          {t("battlePanel.list.noTags")}
-        </span>
-      );
+      return null;
     }
 
     return (
-      <div className="flex max-w-[176px] flex-wrap gap-1">
-        {tags.map((tag) => (
-          <Badge
-            key={tag.key}
-            variant="outline"
-            className={cn(
-              "inline-flex h-5 items-center rounded-full px-2 py-0 text-[10px] font-medium shadow-none",
-              tag.badgeClassName,
-            )}
-          >
-            {t(`battlePanel.list.damageTags.${tag.key}`)}
-          </Badge>
+      <div
+        data-battle-table-action
+        onClick={stopTableAction}
+        onClickCapture={stopTableAction}
+        onKeyDown={stopTableKeyboardAction}
+        className="ml-1 flex shrink-0 items-center gap-0.5"
+      >
+        {tags.map((tag) => {
+          const Icon = tag.icon;
+          const tagLabel = t(`battlePanel.list.damageTags.${tag.key}`);
+
+          return (
+            <Tooltip key={tag.key}>
+              <TooltipTrigger asChild>
+                <Badge
+                  data-battle-table-action
+                  onClick={stopTableAction}
+                  onKeyDown={stopTableKeyboardAction}
+                  tabIndex={0}
+                  role="img"
+                  aria-label={tagLabel}
+                  variant="outline"
+                  className={cn(
+                    "inline-flex size-5 min-w-5 items-center justify-center rounded-full p-0 shadow-none",
+                    tag.badgeClassName,
+                  )}
+                >
+                  <Icon className="size-3" aria-hidden="true" />
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>{tagLabel}</TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderTeam = (
+    team: BattleWarrior[],
+    opposingTeam: BattleWarrior[],
+    userWarrior?: BattleWarrior,
+  ) => {
+    const tags = getTeamDamageTags(team, opposingTeam);
+    const tagIcons = renderDamageTagIcons(tags);
+    const shouldRenderInlineTags = team.length === 1;
+
+    return (
+      <div className="flex min-w-0 max-w-[120px] flex-col gap-1 md:min-w-[220px] md:max-w-[280px]">
+        {team.map((warrior) => (
+          <div key={warrior.id} className="flex min-w-0 items-center gap-1.5">
+            <PlayerTile player={warrior} className="origin-center scale-75" />
+            <div className="flex min-w-0 flex-col gap-0.5 leading-tight">
+              <span
+                className={cn("min-w-0 truncate text-xs font-medium", {
+                  "text-green-500":
+                    warrior.originalId === userWarrior?.originalId,
+                })}
+              >
+                {warrior.name}
+              </span>
+              <span className="truncate text-[11px] font-normal text-muted-foreground">
+                ({warrior.lvl}
+                {warrior.prof})
+              </span>
+            </div>
+            {shouldRenderInlineTags && tagIcons}
+          </div>
         ))}
+        {!shouldRenderInlineTags && tagIcons && (
+          <div className="ml-7 flex min-w-0">{tagIcons}</div>
+        )}
+      </div>
+    );
+  };
+
+  const renderBattleStatus = (battle: Battle) => {
+    const result = getBattleResult(battle);
+    const resultConfig = BATTLE_RESULT_STATUS_CONFIG[result];
+    const ResultIcon = resultConfig.icon;
+    const resultLabel = t(resultConfig.labelKey);
+
+    return (
+      <div
+        data-battle-table-action
+        onClick={stopTableAction}
+        onKeyDown={stopTableKeyboardAction}
+        className="mx-auto flex w-6 items-center justify-center"
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              role="img"
+              aria-label={resultLabel}
+              className={cn(
+                "inline-flex size-6 items-center justify-center rounded-md border",
+                resultConfig.className,
+              )}
+            >
+              <ResultIcon className="size-3.5" aria-hidden="true" />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>{resultLabel}</TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  };
+
+  const renderBattleInfo = (battle: Battle) => {
+    const visibilityLabel = battle.public
+      ? t("battleUi.metadata.public")
+      : t("battleUi.metadata.private");
+    const userWarrior = battle.warriors.find(
+      (warrior) => warrior.originalId === battle.characterId,
+    );
+
+    return (
+      <div
+        data-battle-table-action
+        onClick={stopTableAction}
+        onKeyDown={stopTableKeyboardAction}
+        className="flex max-w-[168px] flex-wrap items-center gap-1"
+      >
+        <button
+          type="button"
+          data-battle-table-action
+          onClick={(event) => handleWorldBadgeClick(event, battle.world)}
+          onKeyDown={stopTableKeyboardAction}
+          className="inline-flex max-w-[92px] items-center truncate rounded-md border border-foreground/30 bg-background/40 px-2 py-0 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-background/70 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        >
+          {capitalizeFirstLetter(battle.world)}
+        </button>
+        <span className="inline-flex max-w-[92px] items-center truncate rounded-md border border-foreground/30 bg-background/40 px-2 py-0 text-[10px] font-semibold text-muted-foreground">
+          {visibilityLabel}
+        </span>
+        {userWarrior?.ph !== 0 && userWarrior?.ph !== undefined && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                onClick={handlePhBadgeClick}
+                onKeyDown={(event) =>
+                  handleFilterBadgeKeyDown(event, () => onPhClick?.())
+                }
+                role="button"
+                tabIndex={0}
+                variant="outline"
+                className="inline-flex size-6 min-w-6 cursor-pointer items-center justify-center rounded-md border-foreground/40 p-0 text-[9px]"
+              >
+                {t("battlePanel.bulk.honorPointsShort")}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t("battlePanel.filters.honorPoints")}
+            </TooltipContent>
+          </Tooltip>
+        )}
+        {battle.matchmaking && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                onClick={handleMatchmakingBadgeClick}
+                onKeyDown={(event) =>
+                  handleFilterBadgeKeyDown(event, () => onMatchmakingClick?.())
+                }
+                role="button"
+                tabIndex={0}
+                variant="outline"
+                className="inline-flex h-6 cursor-pointer items-center justify-center rounded-md border-purple-500/50 bg-purple-500/10 px-1.5 py-0 text-[10px] font-semibold text-purple-400 hover:bg-purple-500/20"
+              >
+                {t("battlePanel.filters.matchmaking")}
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t("battlePanel.filters.matchmaking")}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
     );
   };
@@ -649,10 +819,17 @@ export const BattlesTable = ({
     {
       id: "select",
       header: () => (
-        <div className="flex items-center justify-center">
+        <div
+          data-battle-table-action
+          className="absolute inset-0 flex cursor-pointer items-center justify-center transition-colors hover:bg-primary/10"
+          onClick={handleHeaderSelectionCellClick}
+          onKeyDown={stopTableKeyboardAction}
+        >
           <Checkbox
             checked={headerCheckboxState}
             aria-label={t("battlePanel.bulk.selectRows")}
+            className="size-5"
+            onClick={stopTableAction}
             onCheckedChange={(checked) =>
               handleHeaderSelectionChange(checked === true)
             }
@@ -662,13 +839,19 @@ export const BattlesTable = ({
       cell: ({ row }) => (
         <div
           data-battle-table-action
-          className="flex items-center justify-center"
-          onClick={stopTableAction}
+          className={cn(
+            "absolute inset-0 flex cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-primary/10",
+            selectedBattleIds.has(row.original.id) &&
+              "bg-primary/10 text-primary ring-1 ring-inset ring-primary/40",
+          )}
+          onClick={(event) => handleSelectionCellClick(event, row.original.id)}
           onKeyDown={stopTableKeyboardAction}
         >
           <Checkbox
             checked={selectedBattleIds.has(row.original.id)}
             aria-label={t("battlePanel.bulk.selectRow")}
+            className="size-5"
+            onClick={stopTableAction}
             onCheckedChange={(checked) =>
               handleSelectionChange(row.original.id, checked === true)
             }
@@ -678,12 +861,20 @@ export const BattlesTable = ({
       enableSorting: false,
     },
     {
+      id: "status",
+      header: () => null,
+      cell: ({ row }) => renderBattleStatus(row.original),
+      enableSorting: false,
+    },
+    {
       id: "leftTeam",
       header: t("battlePanel.list.columns.yourTeam"),
       cell: ({ row }) => {
-        const { leftTeam, userWarrior } = getBattleTeams(row.original);
+        const { leftTeam, rightTeam, userWarrior } = getBattleTeams(
+          row.original,
+        );
 
-        return renderTeam(leftTeam, userWarrior);
+        return renderTeam(leftTeam, rightTeam, userWarrior);
       },
       enableSorting: false,
     },
@@ -691,40 +882,18 @@ export const BattlesTable = ({
       id: "rightTeam",
       header: t("battlePanel.list.columns.opponents"),
       cell: ({ row }) => {
-        const { rightTeam } = getBattleTeams(row.original);
-
-        return renderTeam(rightTeam);
-      },
-      enableSorting: false,
-    },
-    {
-      id: "world",
-      header: t("battlePanel.list.columns.world"),
-      cell: ({ row }) => {
-        const battle = row.original;
-
-        return (
-          <button
-            type="button"
-            data-battle-table-action
-            onClick={(event) => handleWorldBadgeClick(event, battle.world)}
-            onKeyDown={stopTableKeyboardAction}
-            className="inline-flex max-w-[108px] items-center truncate rounded-md border border-foreground/30 bg-background/40 px-2 py-0 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-background/70 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-          >
-            {capitalizeFirstLetter(battle.world)}
-          </button>
-        );
-      },
-      enableSorting: false,
-    },
-    {
-      id: "tags",
-      header: t("battlePanel.list.columns.tags"),
-      cell: ({ row }) => {
         const { leftTeam, rightTeam } = getBattleTeams(row.original);
 
-        return renderDamageTags(leftTeam, rightTeam);
+        return renderTeam(rightTeam, leftTeam);
       },
+      enableSorting: false,
+    },
+    {
+      id: "battleInfo",
+      header: () => (
+        <div className="text-left">{t("battlePanel.list.columns.info")}</div>
+      ),
+      cell: ({ row }) => renderBattleInfo(row.original),
       enableSorting: false,
     },
     {
@@ -747,87 +916,6 @@ export const BattlesTable = ({
               </TooltipTrigger>
               <TooltipContent>{exactTime}</TooltipContent>
             </Tooltip>
-          </div>
-        );
-      },
-      enableSorting: false,
-    },
-    {
-      id: "mode",
-      header: () => (
-        <div className="text-center">{t("battlePanel.list.columns.mode")}</div>
-      ),
-      cell: ({ row }) => {
-        const battle = row.original;
-        const userWarrior = battle.warriors.find(
-          (warrior) => warrior.originalId === battle.characterId,
-        );
-        const visibilityLabel = battle.public
-          ? t("battleUi.metadata.public")
-          : t("battleUi.metadata.private");
-
-        return (
-          <div className="flex min-w-[72px] flex-wrap items-center justify-center gap-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  role="img"
-                  aria-label={visibilityLabel}
-                  className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground"
-                >
-                  {battle.public ? (
-                    <LockOpen className="size-3.5" />
-                  ) : (
-                    <Lock className="size-3.5" />
-                  )}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>{visibilityLabel}</TooltipContent>
-            </Tooltip>
-            {userWarrior?.ph !== 0 && userWarrior?.ph !== undefined && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    onClick={handlePhBadgeClick}
-                    onKeyDown={(event) =>
-                      handleFilterBadgeKeyDown(event, () => onPhClick?.())
-                    }
-                    role="button"
-                    tabIndex={0}
-                    variant="outline"
-                    className="cursor-pointer rounded-md border-foreground/40 px-1.5 py-0 text-[10px]"
-                  >
-                    {t("battlePanel.bulk.honorPointsShort")}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t("battlePanel.filters.honorPoints")}
-                </TooltipContent>
-              </Tooltip>
-            )}
-            {battle.matchmaking && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    onClick={handleMatchmakingBadgeClick}
-                    onKeyDown={(event) =>
-                      handleFilterBadgeKeyDown(event, () =>
-                        onMatchmakingClick?.(),
-                      )
-                    }
-                    role="button"
-                    tabIndex={0}
-                    variant="outline"
-                    className="cursor-pointer rounded-md border-purple-500/50 bg-purple-500/10 px-1.5 py-0 text-[10px] text-purple-500 hover:bg-purple-500/20"
-                  >
-                    {t("battlePanel.bulk.matchmakingShort")}
-                  </Badge>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t("battlePanel.filters.matchmaking")}
-                </TooltipContent>
-              </Tooltip>
-            )}
           </div>
         );
       },
@@ -909,7 +997,7 @@ export const BattlesTable = ({
     <>
       <Card
         className={cn(
-          "min-h-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm gap-0",
+          "min-h-0 min-w-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm gap-0",
           showPagination ? "flex h-full flex-1 flex-col" : "flex flex-col",
         )}
       >
@@ -959,7 +1047,10 @@ export const BattlesTable = ({
         </div>
 
         <ScrollArea
-          className={cn("relative w-full", showPagination && "flex-1 min-h-0")}
+          className={cn(
+            "relative min-w-0 w-full",
+            showPagination && "flex-1 min-h-0",
+          )}
         >
           {isLoading ? (
             <TableRowsSkeleton rows={showPagination ? 10 : 4} />
@@ -983,7 +1074,7 @@ export const BattlesTable = ({
               </Empty>
             </div>
           ) : (
-            <Table className="min-w-full table-fixed border-b md:min-w-[840px] md:table-auto">
+            <Table className="min-w-full table-fixed border-b md:min-w-[960px] md:table-auto">
               <TanStackTableHeader
                 table={table}
                 className="sticky top-0 z-10 bg-background"
@@ -1002,7 +1093,7 @@ export const BattlesTable = ({
                     "h-14 cursor-pointer border-b border-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
                     getRowClassName(row.original),
                     selectedBattleIds.has(row.original.id) &&
-                      "ring-1 ring-inset ring-primary/30",
+                      "ring-2 ring-inset ring-primary/45",
                   )
                 }
                 cellClassName={(cell) =>
@@ -1024,8 +1115,9 @@ export const BattlesTable = ({
                   },
                   onKeyDown: (event) => {
                     if (
-                      event.target instanceof Element &&
-                      event.target.closest("[data-battle-table-action]")
+                      getEventTargetElement(event.target)?.closest(
+                        "[data-battle-table-action]",
+                      )
                     ) {
                       return;
                     }

--- a/apps/web/src/features/user/battle-panel/battle-panel-layout/battle-panel-layout.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-layout/battle-panel-layout.tsx
@@ -25,7 +25,7 @@ export const BattlePanelLayout = () => {
   ];
 
   return (
-    <div className="flex h-[calc(100vh-3.5rem)] min-h-0 w-full flex-col bg-background/50">
+    <div className="flex h-[calc(100vh-3.5rem)] min-h-0 min-w-0 w-full flex-col bg-background/50">
       {showTopLevelNavigation && (
         <HorizontalMenu
           items={navigationItems}
@@ -33,7 +33,7 @@ export const BattlePanelLayout = () => {
           className="shrink-0 pb-0"
         />
       )}
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
         <Outlet />
       </div>
     </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle-skeleton.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle-skeleton.tsx
@@ -4,9 +4,10 @@ import { Skeleton } from "@lootlog/ui/components/skeleton";
 import type { CSSProperties } from "react";
 
 const layoutStyle = {
-  "--battle-side-sticky-top": "368px",
+  "--battle-chart-height": "360px",
+  "--battle-scroll-viewport-height": "calc(100dvh - 3.5rem)",
   "--battle-side-card-height":
-    "max(560px, calc(100dvh - var(--battle-side-sticky-top) - 8px))",
+    "max(0px, calc(var(--battle-scroll-viewport-height) - var(--battle-chart-height) - 32px))",
 } as CSSProperties;
 
 const teamRows = Array.from({ length: 3 });
@@ -98,121 +99,123 @@ export const BattlePanelSingleBattleSkeleton = () => {
           </div>
         </Card>
 
-        <div className="sticky top-3 z-30 bg-background">
-          <Card className="gap-3 border-border bg-card p-3">
-            <div className="flex flex-wrap items-start justify-between gap-3 px-1">
-              <div className="flex items-center gap-2">
-                <Skeleton className="size-4 rounded-sm" />
-                <div className="space-y-1.5">
-                  <Skeleton className="h-4 w-40" />
-                  <Skeleton className="h-3 w-64 max-w-[60vw]" />
-                </div>
-              </div>
-              <Skeleton className="h-8 w-28 rounded-sm" />
-            </div>
-
-            <div className="relative h-64 w-full overflow-hidden rounded-md border border-border/60 bg-background/45 px-4 py-5">
-              <div className="absolute inset-x-4 top-1/2 h-px bg-border/70" />
-              <div className="absolute inset-x-4 top-1/4 h-px bg-border/40" />
-              <div className="absolute inset-x-4 top-3/4 h-px bg-border/40" />
-              <div className="flex h-full items-end justify-between gap-2">
-                {chartTicks.map((_, index) => (
-                  <div
-                    key={index}
-                    className="flex h-full flex-1 flex-col justify-end gap-2"
-                  >
-                    <Skeleton
-                      className={`w-full rounded-sm ${chartBarHeights[index] ?? "h-16"}`}
-                    />
-                    <Skeleton className="mx-auto h-2 w-8" />
-                  </div>
-                ))}
-              </div>
-            </div>
-          </Card>
-        </div>
-
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.3fr)] xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)_minmax(300px,0.9fr)]">
-          <div className="min-w-0 lg:sticky lg:[top:var(--battle-side-sticky-top)] lg:self-start">
-            <Card className="flex w-full flex-col gap-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm lg:h-[var(--battle-side-card-height)] lg:min-h-0">
-              <div className="flex min-h-[57px] items-center justify-between gap-3 border-b bg-background px-3 py-3">
-                <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex flex-col gap-3 lg:sticky lg:top-3 lg:z-20">
+          <div className="bg-background">
+            <Card className="gap-3 border-border bg-card p-3">
+              <div className="flex flex-wrap items-start justify-between gap-3 px-1">
+                <div className="flex items-center gap-2">
                   <Skeleton className="size-4 rounded-sm" />
-                  <Skeleton className="h-4 w-32" />
-                </div>
-                <div className="flex shrink-0 gap-1.5">
-                  <Skeleton className="size-9 rounded-sm" />
-                  <Skeleton className="size-9 rounded-sm" />
-                </div>
-              </div>
-              <div className="min-h-0 flex-1 space-y-0 overflow-hidden">
-                {statsRows.map((_, index) => (
-                  <div
-                    key={index}
-                    className="grid grid-cols-[minmax(0,1fr)_72px] items-center gap-3 border-b border-border/70 px-3 py-2.5"
-                  >
-                    <Skeleton className="h-3.5 w-full" />
-                    <Skeleton className="h-3.5 w-full" />
+                  <div className="space-y-1.5">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-3 w-64 max-w-[60vw]" />
                   </div>
-                ))}
+                </div>
+                <Skeleton className="h-8 w-28 rounded-sm" />
               </div>
-            </Card>
-          </div>
 
-          <div className="flex min-w-0 flex-col gap-3 lg:sticky lg:[top:var(--battle-side-sticky-top)] lg:self-start">
-            <Card className="overflow-hidden border-border bg-card p-0 lg:flex lg:h-[var(--battle-side-card-height)] lg:min-h-0 lg:w-full lg:flex-col">
-              <div className="flex min-h-[52px] items-center gap-2 border-b bg-background px-3 py-2.5">
-                <Skeleton className="h-9 flex-1 rounded-sm" />
-                <Skeleton className="size-9 rounded-sm" />
-                <Skeleton className="size-9 rounded-sm" />
-              </div>
-              <div className="min-h-0 flex-1 overflow-hidden">
-                {logTurns.map((_, index) => (
-                  <div
-                    key={index}
-                    className="space-y-2 border-b border-border/70 px-4 py-3"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Skeleton className="h-3.5 w-28" />
-                      <Skeleton className="h-3.5 w-16" />
-                    </div>
-                    <Skeleton className="h-3.5 w-11/12" />
-                    <Skeleton className="h-3.5 w-7/12" />
-                  </div>
-                ))}
-              </div>
-            </Card>
-          </div>
-
-          <div className="hidden min-w-0 xl:block xl:self-start">
-            <div className="sticky lg:[top:var(--battle-side-sticky-top)]">
-              <Card className="flex max-h-[420px] min-h-0 w-full flex-col gap-0 overflow-hidden border-border bg-card p-0 xl:h-[var(--battle-side-card-height)] xl:max-h-none">
-                <div className="flex min-h-[61px] shrink-0 items-center justify-between gap-3 border-b bg-background px-3 py-3">
-                  <div className="flex min-w-0 flex-1 items-center gap-2">
-                    <Skeleton className="size-4 rounded-sm" />
-                    <div className="min-w-0 flex-1 space-y-1.5">
-                      <Skeleton className="h-4 w-36" />
-                      <Skeleton className="h-3 w-44" />
-                    </div>
-                  </div>
-                  <Skeleton className="h-8 w-20 rounded-sm" />
-                </div>
-                <div className="min-h-0 flex-1 overflow-hidden">
-                  {recentRows.map((_, index) => (
+              <div className="relative h-64 w-full overflow-hidden rounded-md border border-border/60 bg-background/45 px-4 py-5">
+                <div className="absolute inset-x-4 top-1/2 h-px bg-border/70" />
+                <div className="absolute inset-x-4 top-1/4 h-px bg-border/40" />
+                <div className="absolute inset-x-4 top-3/4 h-px bg-border/40" />
+                <div className="flex h-full items-end justify-between gap-2">
+                  {chartTicks.map((_, index) => (
                     <div
                       key={index}
-                      className="grid grid-cols-[40px_minmax(0,1fr)_56px] items-center gap-3 border-b border-border/70 px-3 py-3"
+                      className="flex h-full flex-1 flex-col justify-end gap-2"
                     >
-                      <Skeleton className="size-8 rounded-sm" />
-                      <div className="min-w-0 space-y-1.5">
-                        <Skeleton className="h-3.5 w-full" />
-                        <Skeleton className="h-3 w-2/3" />
-                      </div>
-                      <Skeleton className="h-4 w-full" />
+                      <Skeleton
+                        className={`w-full rounded-sm ${chartBarHeights[index] ?? "h-16"}`}
+                      />
+                      <Skeleton className="mx-auto h-2 w-8" />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </Card>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.3fr)] xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)_minmax(300px,0.9fr)]">
+            <div className="min-w-0">
+              <Card className="flex w-full flex-col gap-0 overflow-hidden border-border bg-card/40 p-0 backdrop-blur-sm lg:h-[var(--battle-side-card-height)] lg:min-h-0">
+                <div className="flex min-h-[57px] items-center justify-between gap-3 border-b bg-background px-3 py-3">
+                  <div className="flex min-w-0 flex-1 items-center gap-2">
+                    <Skeleton className="size-4 rounded-sm" />
+                    <Skeleton className="h-4 w-32" />
+                  </div>
+                  <div className="flex shrink-0 gap-1.5">
+                    <Skeleton className="size-9 rounded-sm" />
+                    <Skeleton className="size-9 rounded-sm" />
+                  </div>
+                </div>
+                <div className="min-h-0 flex-1 space-y-0 overflow-hidden">
+                  {statsRows.map((_, index) => (
+                    <div
+                      key={index}
+                      className="grid grid-cols-[minmax(0,1fr)_72px] items-center gap-3 border-b border-border/70 px-3 py-2.5"
+                    >
+                      <Skeleton className="h-3.5 w-full" />
+                      <Skeleton className="h-3.5 w-full" />
                     </div>
                   ))}
                 </div>
               </Card>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-3">
+              <Card className="overflow-hidden border-border bg-card p-0 lg:flex lg:h-[var(--battle-side-card-height)] lg:min-h-0 lg:w-full lg:flex-col">
+                <div className="flex min-h-[52px] items-center gap-2 border-b bg-background px-3 py-2.5">
+                  <Skeleton className="h-9 flex-1 rounded-sm" />
+                  <Skeleton className="size-9 rounded-sm" />
+                  <Skeleton className="size-9 rounded-sm" />
+                </div>
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  {logTurns.map((_, index) => (
+                    <div
+                      key={index}
+                      className="space-y-2 border-b border-border/70 px-4 py-3"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Skeleton className="h-3.5 w-28" />
+                        <Skeleton className="h-3.5 w-16" />
+                      </div>
+                      <Skeleton className="h-3.5 w-11/12" />
+                      <Skeleton className="h-3.5 w-7/12" />
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </div>
+
+            <div className="hidden min-w-0 xl:block xl:self-start">
+              <div>
+                <Card className="flex max-h-[420px] min-h-0 w-full flex-col gap-0 overflow-hidden border-border bg-card p-0 xl:h-[var(--battle-side-card-height)] xl:max-h-none">
+                  <div className="flex min-h-[61px] shrink-0 items-center justify-between gap-3 border-b bg-background px-3 py-3">
+                    <div className="flex min-w-0 flex-1 items-center gap-2">
+                      <Skeleton className="size-4 rounded-sm" />
+                      <div className="min-w-0 flex-1 space-y-1.5">
+                        <Skeleton className="h-4 w-36" />
+                        <Skeleton className="h-3 w-44" />
+                      </div>
+                    </div>
+                    <Skeleton className="h-8 w-20 rounded-sm" />
+                  </div>
+                  <div className="min-h-0 flex-1 overflow-hidden">
+                    {recentRows.map((_, index) => (
+                      <div
+                        key={index}
+                        className="grid grid-cols-[40px_minmax(0,1fr)_56px] items-center gap-3 border-b border-border/70 px-3 py-3"
+                      >
+                        <Skeleton className="size-8 rounded-sm" />
+                        <div className="min-w-0 space-y-1.5">
+                          <Skeleton className="h-3.5 w-full" />
+                          <Skeleton className="h-3 w-2/3" />
+                        </div>
+                        <Skeleton className="h-4 w-full" />
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle.tsx
@@ -27,6 +27,7 @@ import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@lootlog/ui/lib/utils";
 import {
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -41,7 +42,8 @@ import {
 } from "@lootlog/ui/components/tooltip";
 
 const STICKY_TOP_OFFSET_PX = 12;
-const STICKY_CONTENT_GAP_PX = 16;
+const STICKY_CONTENT_GAP_PX = 12;
+const SIDE_CARD_BOTTOM_OFFSET_PX = 8;
 const SCROLL_AREA_VIEWPORT_SELECTOR = '[data-slot="scroll-area-viewport"]';
 
 export const BattlePanelSingleBattle = () => {
@@ -64,13 +66,13 @@ export const BattlePanelSingleBattle = () => {
   const [scrollTargetRequestId, setScrollTargetRequestId] = useState(0);
   const [isChartPinned, setIsChartPinned] = useState(true);
   const [chartHeight, setChartHeight] = useState(0);
-  const [scrollViewportTop, setScrollViewportTop] = useState(0);
+  const [scrollViewportHeight, setScrollViewportHeight] = useState(0);
   const scrollViewportRef = useRef<HTMLDivElement>(null);
   const chartWrapperRef = useRef<HTMLDivElement>(null);
   const battleLogWrapperRef = useRef<HTMLDivElement>(null);
   const selectedTurnRef = useRef<number | null>(null);
   const chartHeightRef = useRef(0);
-  const scrollViewportTopRef = useRef(0);
+  const scrollViewportHeightRef = useRef(0);
   const scrollAnimationFrameRef = useRef<number | null>(null);
 
   const {
@@ -93,17 +95,15 @@ export const BattlePanelSingleBattle = () => {
   const selectedTurnNumber = selectedTurnExists
     ? selectedTurn
     : (timeline?.timeline[0]?.turn ?? null);
-  const sideStickyTop =
-    isChartPinned && chartHeight > 0
-      ? scrollViewportTop +
-        STICKY_TOP_OFFSET_PX +
-        chartHeight +
-        STICKY_CONTENT_GAP_PX
-      : STICKY_TOP_OFFSET_PX;
+  const hasTimeline = Boolean(timeline?.timeline.length);
   const layoutStyle = {
-    "--battle-side-sticky-top": `${sideStickyTop}px`,
-    "--battle-side-card-height":
-      "max(560px, calc(100dvh - var(--battle-side-sticky-top) - 8px))",
+    "--battle-chart-height": `${chartHeight}px`,
+    "--battle-scroll-viewport-height": scrollViewportHeight
+      ? `${scrollViewportHeight}px`
+      : "100dvh",
+    "--battle-side-card-height": `max(0px, calc(var(--battle-scroll-viewport-height) - var(--battle-chart-height) - ${
+      STICKY_TOP_OFFSET_PX + STICKY_CONTENT_GAP_PX + SIDE_CARD_BOTTOM_OFFSET_PX
+    }px))`,
   } as CSSProperties;
 
   const setMeasuredChartHeight = (value: number) => {
@@ -115,42 +115,62 @@ export const BattlePanelSingleBattle = () => {
     setChartHeight(value);
   };
 
-  const setMeasuredScrollViewportTop = (value: number) => {
-    if (scrollViewportTopRef.current === value) {
+  const setMeasuredScrollViewportHeight = (value: number) => {
+    if (scrollViewportHeightRef.current === value) {
       return;
     }
 
-    scrollViewportTopRef.current = value;
-    setScrollViewportTop(value);
+    scrollViewportHeightRef.current = value;
+    setScrollViewportHeight(value);
   };
 
   const updateStickyMeasurements = () => {
     const chartElement = chartWrapperRef.current;
     const scrollElement = scrollViewportRef.current;
 
-    setMeasuredScrollViewportTop(
-      scrollElement ? Math.ceil(scrollElement.getBoundingClientRect().top) : 0,
-    );
-
-    if (!chartElement) {
-      setMeasuredChartHeight(0);
-      return;
-    }
-
     setMeasuredChartHeight(
-      Math.ceil(chartElement.getBoundingClientRect().height),
+      chartElement ? Math.ceil(chartElement.getBoundingClientRect().height) : 0,
     );
+    setMeasuredScrollViewportHeight(scrollElement?.clientHeight ?? 0);
   };
 
   useEffect(() => {
     selectedTurnRef.current = selectedTurn;
   }, [selectedTurn]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (scrollAnimationFrameRef.current != null) {
+      cancelAnimationFrame(scrollAnimationFrameRef.current);
+      scrollAnimationFrameRef.current = null;
+    }
+
+    selectedTurnRef.current = null;
+    setSelectedTurn(null);
+    setScrollTargetTurn(null);
+    setScrollTargetRequestId(0);
+
+    scrollViewportRef.current?.scrollTo({
+      top: 0,
+      left: 0,
+    });
+    scrollViewportRef.current
+      ?.querySelectorAll<HTMLElement>(SCROLL_AREA_VIEWPORT_SELECTOR)
+      .forEach((scrollViewport) => {
+        scrollViewport.scrollTo({
+          top: 0,
+          left: 0,
+        });
+      });
+  }, [battleId]);
+
+  useLayoutEffect(() => {
     const chartElement = chartWrapperRef.current;
 
     if (!chartElement) {
       setMeasuredChartHeight(0);
+      setMeasuredScrollViewportHeight(
+        scrollViewportRef.current?.clientHeight ?? 0,
+      );
       return;
     }
 
@@ -174,7 +194,7 @@ export const BattlePanelSingleBattle = () => {
       resizeObserver.disconnect();
       window.removeEventListener("resize", handleWindowResize);
     };
-  }, [isChartPinned, timeline?.timeline.length]);
+  }, [timeline?.timeline.length]);
 
   useEffect(
     () => () => {
@@ -352,119 +372,127 @@ export const BattlePanelSingleBattle = () => {
         <div className="px-3 py-3 flex flex-col gap-4" style={layoutStyle}>
           {battle && <BattleOverview battle={battle} showHeader={false} />}
 
-          {timeline?.timeline.length ? (
-            <div
-              ref={chartWrapperRef}
-              className={cn(isChartPinned && "sticky top-3 z-30 bg-background")}
-            >
-              <BattleHpTimelineChart
-                timeline={timeline.timeline}
-                warriors={timeline.warriors}
-                characterId={battle?.characterId ?? null}
-                isPinned={isChartPinned}
-                selectedTurn={selectedTurnNumber}
-                onPinnedChange={setIsChartPinned}
-                onTurnSelect={handleTurnSelect}
-              />
-            </div>
-          ) : null}
-
           <div
-            className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.3fr)] xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)_minmax(300px,0.9fr)]"
-            onWheelCapture={handleSideCardsWheelCapture}
+            className={cn(
+              "flex flex-col gap-3",
+              hasTimeline && isChartPinned && "lg:sticky lg:top-3 lg:z-20",
+            )}
           >
-            <div className="min-w-0 lg:sticky lg:[top:var(--battle-side-sticky-top)] lg:self-start">
-              {battle && (
-                <BattleStatsTable
-                  battle={battle}
-                  cardClassName="lg:h-[var(--battle-side-card-height)] lg:min-h-0"
-                  compact
-                  scrollClassName="lg:min-h-0 lg:flex-1 lg:pr-2"
-                  headerTitle={t("battlePanel.single.statistics.title")}
-                  headerActions={
-                    is1v1 ? (
-                      <div className="flex shrink-0 items-center gap-1.5">
-                        <StatsCustomizationModal
-                          config={config}
-                          defaultCategories={STAT_CATEGORIES}
-                          onUpdateCategoryOrder={updateCategoryOrder}
-                          onToggleCategoryVisibility={toggleCategoryVisibility}
-                          onUpdateCategoryName={updateCategoryName}
-                          onUpdateStatOrder={updateStatOrder}
-                          onAddStatToCategory={addStatToCategory}
-                          onRemoveStatFromCategory={removeStatFromCategory}
-                          onAddCategory={addCategory}
-                          onRemoveCategory={removeCategory}
-                          onResetToDefaults={resetToDefaults}
-                          compactTrigger
-                        />
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              onClick={() => setHideZeros(!hideZeros)}
-                              aria-label={
-                                hideZeros
-                                  ? t("battlePanel.single.statistics.showAll")
-                                  : t("battlePanel.single.statistics.hideZeros")
-                              }
-                              className="size-9"
-                            >
-                              {hideZeros ? (
-                                <Eye className="h-4 w-4" />
-                              ) : (
-                                <EyeOff className="h-4 w-4" />
-                              )}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            {hideZeros
-                              ? t("battlePanel.single.statistics.showAll")
-                              : t("battlePanel.single.statistics.hideZeros")}
-                          </TooltipContent>
-                        </Tooltip>
-                      </div>
-                    ) : undefined
-                  }
-                  hideZeros={is1v1 ? hideZeros : undefined}
-                  onHideZerosChange={is1v1 ? setHideZeros : undefined}
-                  statsCustomizationConfig={is1v1 ? config : undefined}
+            {timeline?.timeline.length ? (
+              <div ref={chartWrapperRef} className="bg-background">
+                <BattleHpTimelineChart
+                  timeline={timeline.timeline}
+                  warriors={timeline.warriors}
+                  characterId={battle?.characterId ?? null}
+                  isPinned={isChartPinned}
+                  selectedTurn={selectedTurnNumber}
+                  onPinnedChange={setIsChartPinned}
+                  onTurnSelect={handleTurnSelect}
                 />
-              )}
-            </div>
+              </div>
+            ) : null}
 
             <div
-              ref={battleLogWrapperRef}
-              className="flex min-w-0 flex-col gap-3 lg:sticky lg:[top:var(--battle-side-sticky-top)] lg:self-start"
+              className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(280px,0.9fr)_minmax(0,1.3fr)] xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)_minmax(300px,0.9fr)]"
+              onWheelCapture={handleSideCardsWheelCapture}
             >
-              {rawBattle && battle && (
-                <BattleLog
-                  rawBattle={rawBattle.rawData}
-                  warriors={battle.warriors}
-                  showHeader={false}
-                  className="lg:flex lg:h-[var(--battle-side-card-height)] lg:min-h-0 lg:w-full lg:flex-col"
-                  listScrollClassName="lg:min-h-0 lg:flex-1 lg:pr-2"
-                  selectedTurn={selectedTurnNumber}
-                  scrollToSelectedTurnRequestId={
-                    scrollTargetTurn !== null &&
-                    scrollTargetTurn === selectedTurnNumber
-                      ? scrollTargetRequestId
-                      : 0
-                  }
-                  onListScroll={handleBattleScroll}
-                  onSelectedTurnScrollComplete={
-                    handleSelectedTurnScrollComplete
-                  }
-                  onTurnSelect={handleTurnSelect}
-                  onTurnFocus={handleTurnFocus}
-                />
-              )}
-            </div>
+              <div className="min-w-0">
+                {battle && (
+                  <BattleStatsTable
+                    battle={battle}
+                    cardClassName="lg:h-[var(--battle-side-card-height)] lg:min-h-0"
+                    compact
+                    scrollClassName="lg:min-h-0 lg:flex-1 lg:pr-2"
+                    headerTitle={t("battlePanel.single.statistics.title")}
+                    headerActions={
+                      is1v1 ? (
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          <StatsCustomizationModal
+                            config={config}
+                            defaultCategories={STAT_CATEGORIES}
+                            onUpdateCategoryOrder={updateCategoryOrder}
+                            onToggleCategoryVisibility={
+                              toggleCategoryVisibility
+                            }
+                            onUpdateCategoryName={updateCategoryName}
+                            onUpdateStatOrder={updateStatOrder}
+                            onAddStatToCategory={addStatToCategory}
+                            onRemoveStatFromCategory={removeStatFromCategory}
+                            onAddCategory={addCategory}
+                            onRemoveCategory={removeCategory}
+                            onResetToDefaults={resetToDefaults}
+                            compactTrigger
+                          />
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => setHideZeros(!hideZeros)}
+                                aria-label={
+                                  hideZeros
+                                    ? t("battlePanel.single.statistics.showAll")
+                                    : t(
+                                        "battlePanel.single.statistics.hideZeros",
+                                      )
+                                }
+                                className="size-9"
+                              >
+                                {hideZeros ? (
+                                  <Eye className="h-4 w-4" />
+                                ) : (
+                                  <EyeOff className="h-4 w-4" />
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {hideZeros
+                                ? t("battlePanel.single.statistics.showAll")
+                                : t("battlePanel.single.statistics.hideZeros")}
+                            </TooltipContent>
+                          </Tooltip>
+                        </div>
+                      ) : undefined
+                    }
+                    hideZeros={is1v1 ? hideZeros : undefined}
+                    onHideZerosChange={is1v1 ? setHideZeros : undefined}
+                    statsCustomizationConfig={is1v1 ? config : undefined}
+                  />
+                )}
+              </div>
 
-            <div className="hidden min-w-0 xl:block xl:self-start">
-              <div className="sticky lg:[top:var(--battle-side-sticky-top)]">
-                <RecentOpponentBattlesCard battle={battle} />
+              <div
+                ref={battleLogWrapperRef}
+                className="flex min-w-0 flex-col gap-3"
+              >
+                {rawBattle && battle && (
+                  <BattleLog
+                    rawBattle={rawBattle.rawData}
+                    warriors={battle.warriors}
+                    showHeader={false}
+                    className="lg:flex lg:h-[var(--battle-side-card-height)] lg:min-h-0 lg:w-full lg:flex-col"
+                    listScrollClassName="lg:min-h-0 lg:flex-1 lg:pr-2"
+                    selectedTurn={selectedTurnNumber}
+                    scrollToSelectedTurnRequestId={
+                      scrollTargetTurn !== null &&
+                      scrollTargetTurn === selectedTurnNumber
+                        ? scrollTargetRequestId
+                        : 0
+                    }
+                    onListScroll={handleBattleScroll}
+                    onSelectedTurnScrollComplete={
+                      handleSelectedTurnScrollComplete
+                    }
+                    onTurnSelect={handleTurnSelect}
+                    onTurnFocus={handleTurnFocus}
+                  />
+                )}
+              </div>
+
+              <div className="hidden min-w-0 xl:block xl:self-start">
+                <div>
+                  <RecentOpponentBattlesCard battle={battle} />
+                </div>
               </div>
             </div>
           </div>

--- a/apps/web/src/i18n/translations/battle-panel.json
+++ b/apps/web/src/i18n/translations/battle-panel.json
@@ -7,6 +7,7 @@
     "headToHead": "Bilans H2H",
     "matchmakingHeadToHead": "Matchmaking H2H",
     "playerVsPlayer": "Gracz vs Gracz",
+    "battleDuel": "{{first}} vs {{second}}",
     "battleFallback": "Walka #{{id}}"
   },
   "filters": {
@@ -90,14 +91,11 @@
     "totalBattles": "Łącznie walk: {{count}}",
     "openBattle": "Otwórz walkę",
     "columns": {
-      "result": "Wynik",
+      "info": "Tagi",
       "yourTeam": "Twoja drużyna",
       "opponents": "Przeciwnicy",
-      "world": "Świat",
-      "tags": "Tagi",
       "time": "Czas",
       "duration": "Długość",
-      "mode": "Tryb",
       "actions": "Akcje"
     },
     "noTags": "-",
@@ -107,6 +105,11 @@
       "lightning": "Błyskawice",
       "poison": "Trucizna",
       "wound": "Głęboka rana"
+    },
+    "results": {
+      "won": "Wygrana",
+      "lost": "Przegrana",
+      "flee": "Ucieczka"
     }
   },
   "bulk": {
@@ -116,7 +119,6 @@
     "selectRows": "Zaznacz walki",
     "selectRow": "Zaznacz walkę",
     "honorPointsShort": "PH",
-    "matchmakingShort": "O",
     "deleteDialog": {
       "title": "Usunąć zaznaczone walki?",
       "description": "Usuniesz zaznaczone walki: {{count}}. Tej operacji nie można cofnąć.",

--- a/apps/web/src/lib/battle/battle-route-label.ts
+++ b/apps/web/src/lib/battle/battle-route-label.ts
@@ -1,0 +1,65 @@
+import type { Battle } from "@/lib/api/battlelog-types";
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+export type BattleRouteLabelMatch = {
+  loaderData?: unknown;
+  params?: Record<string, string | undefined>;
+};
+
+type BattleRouteLoaderData = {
+  battle?: Battle;
+};
+
+function getBattleFromLoaderData(loaderData: unknown) {
+  if (!loaderData || typeof loaderData !== "object") {
+    return;
+  }
+
+  return (loaderData as BattleRouteLoaderData).battle;
+}
+
+function getOneVsOneBattleLabel(battle: Battle | undefined, t: Translate) {
+  if (!battle || battle.type !== "1v1" || !Array.isArray(battle.warriors)) {
+    return;
+  }
+
+  const teamOneWarriors = battle.warriors.filter(
+    (warrior) => warrior.team === 1,
+  );
+  const teamTwoWarriors = battle.warriors.filter(
+    (warrior) => warrior.team === 2,
+  );
+  const teamOneWarrior = teamOneWarriors[0];
+  const teamTwoWarrior = teamTwoWarriors[0];
+
+  if (
+    teamOneWarriors.length !== 1 ||
+    teamTwoWarriors.length !== 1 ||
+    !teamOneWarrior ||
+    !teamTwoWarrior
+  ) {
+    return;
+  }
+
+  return t("battlePanel.navigation.battleDuel", {
+    first: teamOneWarrior.name,
+    second: teamTwoWarrior.name,
+  });
+}
+
+export function getBattleRouteLabel(
+  match: BattleRouteLabelMatch | undefined,
+  t: Translate,
+) {
+  const battleId = match?.params?.battleId;
+
+  if (!battleId) {
+    return;
+  }
+
+  return (
+    getOneVsOneBattleLabel(getBattleFromLoaderData(match?.loaderData), t) ??
+    t("battlePanel.navigation.battleFallback", { id: battleId })
+  );
+}

--- a/apps/web/src/lib/router/document-title.spec.ts
+++ b/apps/web/src/lib/router/document-title.spec.ts
@@ -38,6 +38,52 @@ describe("resolveDocumentTitle", () => {
     ).toBe("Bilans H2H - Panel walk | Lootlog.pl");
   });
 
+  it("uses 1v1 battle participants for user battle detail titles", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({ routeId: "__root__" }),
+        createMatch({
+          loaderData: {
+            battle: {
+              id: "battle-1",
+              type: "1v1",
+              warriors: [
+                { name: "gorilla banana", team: 1 },
+                { name: "imbi woj", team: 2 },
+              ],
+            },
+          },
+          params: { battleId: "battle-1" },
+          pathname: "/@me/battle-panel/battles/battle-1",
+          routeId: "/_authenticated/@me/battle-panel/battles_/$battleId",
+        }),
+      ]),
+    ).toBe("gorilla banana vs imbi woj - Panel walk | Lootlog.pl");
+  });
+
+  it("uses the battle id fallback for non-1v1 user battle detail titles", () => {
+    expect(
+      resolveDocumentTitle([
+        createMatch({ routeId: "__root__" }),
+        createMatch({
+          loaderData: {
+            battle: {
+              id: "battle-1",
+              type: "group",
+              warriors: [
+                { name: "gorilla banana", team: 1 },
+                { name: "imbi woj", team: 2 },
+              ],
+            },
+          },
+          params: { battleId: "battle-1" },
+          pathname: "/@me/battle-panel/battles/battle-1",
+          routeId: "/_authenticated/@me/battle-panel/battles_/$battleId",
+        }),
+      ]),
+    ).toBe("Walka #battle-1 - Panel walk | Lootlog.pl");
+  });
+
   it("uses the guild name as context for regular guild pages", () => {
     expect(
       resolveDocumentTitle([

--- a/apps/web/src/lib/router/document-title.ts
+++ b/apps/web/src/lib/router/document-title.ts
@@ -2,6 +2,7 @@ import i18n from "@/i18n/config";
 import { getNavigationInfo } from "@/components/layout/get-navigation-info";
 import { getUserNavigationInfo } from "@/components/layout/get-user-navigation-info";
 import type { Breadcrumb } from "@/components/layout/get-navigation-info";
+import { getBattleRouteLabel } from "@/lib/battle/battle-route-label";
 
 export type DocumentTitleMatch = {
   routeId: string;
@@ -150,6 +151,7 @@ function getCurrentBreadcrumb(breadcrumbs: Breadcrumb[]) {
 
 function getUserRouteTitle(lastMatch: DocumentTitleMatch) {
   const navigationInfo = getUserNavigationInfo({
+    battleLabel: getBattleRouteLabel(lastMatch, t),
     path: getPathname(lastMatch),
     t,
   });

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute(
   loader: ({ abortController, context, params }) =>
     withRouteLoaderCancellation(abortController, async () => {
       try {
-        await Promise.all([
+        const [battle] = await Promise.all([
           context.queryClient.ensureQueryData(
             getBattlesControllerGetBattleQueryOptions({
               battleId: params.battleId,
@@ -29,7 +29,7 @@ export const Route = createFileRoute(
           ),
         ]);
 
-        return null;
+        return { battle };
       } catch (error) {
         throwNotFoundIfResponseMatches(error);
       }


### PR DESCRIPTION
## Summary
- improves the battle panel battles table UX with compact inline status/tag indicators and wider, easier-to-select rows
- updates battle detail behavior: resets scroll between battles, shows 1v1 participants in breadcrumbs and document title, and restructures the pinned chart/cards layout
- adjusts battle pagination handling in the battlelog service with coverage for cursor behavior

## Validation
- pnpm exec oxfmt --check apps/battlelog-service/src/battles/interfaces/pagination.interface.ts apps/battlelog-service/src/battles/services/pagination.service.spec.ts apps/battlelog-service/src/battles/services/pagination.service.ts apps/web/src/components/layout/get-user-navigation-info.ts apps/web/src/components/layout/user-shell.tsx apps/web/src/features/user/battle-panel/battle-panel-battles-list/battle-panel-battles-list.tsx apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list.tsx apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-table.tsx apps/web/src/features/user/battle-panel/battle-panel-layout/battle-panel-layout.tsx apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle-skeleton.tsx apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle.tsx apps/web/src/i18n/translations/battle-panel.json apps/web/src/lib/router/document-title.spec.ts apps/web/src/lib/router/document-title.ts apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx apps/web/src/lib/battle/battle-route-label.ts
- pnpm --filter web lint
- pnpm --filter web exec tsc --noEmit --pretty false
- pnpm --filter web exec vitest run src/lib/router/document-title.spec.ts
- pnpm --filter @lootlog/battlelog-service lint
- pnpm --filter @lootlog/battlelog-service test
- git commit pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added backward pagination support for battles list
  - Battle titles now display opponent names in breadcrumbs
  - Redesigned battles table with damage and result status icons

* **Bug Fixes**
  - Fixed battle detail page data retrieval

* **Style**
  - Improved responsive layout and overflow handling across battle panels

* **Tests**
  - Added tests for backward pagination and battle title functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->