### PR TITLE
[codex] refactor: centralize role color formatting

### DIFF
--- a/apps/web/src/features/guild/events/components/kills/kill-participants-card.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-participants-card.tsx
@@ -23,6 +23,7 @@ import { Users, ChevronDown, Frown, MapPin, Pencil, Info } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/utils/cn";
 import { getDiscordAvatarUrl } from "@/utils/get-avatar-url";
+import { getCustomRoleCssColor } from "@/utils/get-color-from-role";
 import { useEventsRankingControllerUpdateKillPoint } from "@/lib/api/generated/main/events/events";
 import type { KillDetailParticipant } from "../../hooks/queries/use-kill-detail";
 import { invalidateKillQueries } from "../../hooks/mutations/invalidate-kill-queries";
@@ -86,10 +87,10 @@ const ParticipantRow = ({
     participant.member.avatar,
     32,
   );
-  const roleColor = participant.member.roles?.[0]?.color;
-  const nameStyle = roleColor
-    ? { color: `#${roleColor.toString(16).padStart(6, "0")}` }
-    : undefined;
+  const roleCssColor = getCustomRoleCssColor(
+    participant.member.roles?.[0]?.color,
+  );
+  const nameStyle = roleCssColor ? { color: roleCssColor } : undefined;
 
   const aggregatedMaps = participant.mapData
     ? aggregateMapData(participant.mapData)

--- a/apps/web/src/features/guild/events/utils/get-api-error-message.spec.ts
+++ b/apps/web/src/features/guild/events/utils/get-api-error-message.spec.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it } from "vitest";
+import { ApiError } from "@/lib/api-client/api-client";
 import { getApiErrorMessage } from "./get-api-error-message";
 
 describe("getApiErrorMessage", () => {
   it("returns the first API validation message", () => {
     expect(
-      getApiErrorMessage({
-        response: {
+      getApiErrorMessage(
+        new ApiError({
           data: {
             message: ["First validation error", "Second validation error"],
           },
-        },
-      }),
+          message: "Request failed",
+          method: "POST",
+          status: 400,
+          url: "http://localhost/api/test",
+        }),
+      ),
     ).toBe("First validation error");
   });
 

--- a/apps/web/src/features/guild/loots-list/components/loots-list/loot-single-comment.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-list/loot-single-comment.tsx
@@ -1,6 +1,7 @@
 import type { LootComment } from "@/lib/loots/loot-types";
 import { getRelativeTime } from "@/utils/date/get-relative-time";
 import { getDiscordAvatarUrl } from "@/utils/get-avatar-url";
+import { getColorFromRole } from "@/utils/get-color-from-role";
 import { Avatar, AvatarImage } from "@lootlog/ui/components/avatar";
 import type { FC } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,9 +17,7 @@ export const LootSingleComment: FC<LootSingleCommentProps> = ({ comment }) => {
     comment.member.avatar,
   );
   const relativeTime = getRelativeTime(comment.createdAt);
-  const roleColor = comment.member.roles?.[0]?.color ?? 0;
-  const color =
-    roleColor === 0 ? "FFF" : roleColor.toString(16).padStart(6, "0");
+  const color = getColorFromRole(comment.member.roles);
 
   return (
     <li className="text-sm border-b border-border/50 px-4 py-3 flex flex-row gap-3 bg-card/10 hover:bg-card/30 transition-colors">

--- a/apps/web/src/features/guild/notifications/components/notification-template-editor.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-template-editor.tsx
@@ -30,6 +30,7 @@ import {
   SCHEDULED_PRESET_SIMPLE,
   SCHEDULED_PRESET_MINIMAL,
 } from "../utils/notification-settings.utils";
+import { getCustomRoleCssColor } from "@/utils/get-color-from-role";
 import { Button } from "@lootlog/ui/components/button";
 import {
   Command,
@@ -57,7 +58,6 @@ import {
 import {
   createPreviewTemplateValues,
   renderTemplatePreview,
-  getGuildRoleHexColor,
   createTemplateEditorNodes,
   serializeTemplateEditorValue,
   getBackspaceTemplateTokenNode,
@@ -346,7 +346,7 @@ export const NotificationTemplateEditor = ({
         nextSelection.insertNodes([
           $createNotificationTemplateRoleNode({
             roleColor: suggestion.role
-              ? getGuildRoleHexColor(suggestion.role)
+              ? getCustomRoleCssColor(suggestion.role.color)
               : null,
             roleId: suggestion.role?.id ?? suggestion.key,
             roleName: suggestion.role?.name ?? suggestion.label.slice(1),

--- a/apps/web/src/features/guild/notifications/components/notification-template-editor.utils.ts
+++ b/apps/web/src/features/guild/notifications/components/notification-template-editor.utils.ts
@@ -9,6 +9,7 @@ import {
   type LexicalNode,
 } from "lexical";
 import type { RoleResponseDtoOutput as GuildRole } from "@/lib/api/generated/main/model";
+import { getCustomRoleCssColor } from "@/utils/get-color-from-role";
 import {
   $createNotificationTemplateRoleNode,
   $isNotificationTemplateRoleNode,
@@ -49,11 +50,6 @@ export const renderTemplatePreview = (
     ) => values[placeholder] ?? "",
   );
 
-export const getGuildRoleHexColor = (role: GuildRole) =>
-  role.color == null || role.color === 0
-    ? null
-    : `#${role.color.toString(16).padStart(6, "0").toUpperCase()}`;
-
 export const createTemplateEditorNodes = (
   value: string,
   roles: GuildRole[],
@@ -80,7 +76,7 @@ export const createTemplateEditorNodes = (
         const role = roleById.get(match[2]);
         paragraphNode.append(
           $createNotificationTemplateRoleNode({
-            roleColor: role ? getGuildRoleHexColor(role) : null,
+            roleColor: role ? getCustomRoleCssColor(role.color) : null,
             roleId: match[2],
             roleName: role?.name ?? match[2],
           }),

--- a/apps/web/src/features/guild/notifications/utils/notification-rule-form-preview.utils.tsx
+++ b/apps/web/src/features/guild/notifications/utils/notification-rule-form-preview.utils.tsx
@@ -1,6 +1,6 @@
 import { defaultUrlTransform, type Components } from "react-markdown";
-import { getGuildRoleHexColor } from "../components/notification-template-editor.utils";
 import type { RoleResponseDtoOutput as GuildRole } from "@/lib/api/generated/main/model";
+import { getCustomRoleCssColor } from "@/utils/get-color-from-role";
 
 const ROLE_LINK_PREFIX = "role:";
 
@@ -11,7 +11,7 @@ export const replaceRoleMentions = (text: string, roles: GuildRole[]) => {
     .replace(/<@&(\d+)>/g, (_match, roleId: string) => {
       const role = roleById.get(roleId);
       const name = role ? `@${role.name}` : `@${roleId}`;
-      const color = role ? (getGuildRoleHexColor(role) ?? "") : "";
+      const color = role ? (getCustomRoleCssColor(role.color) ?? "") : "";
       return `[${name}](${ROLE_LINK_PREFIX}${color})`;
     })
     .replace(/@(everyone|here)/g, (_match, keyword: string) => {

--- a/apps/web/src/features/guild/settings/members/components/member-data.tsx
+++ b/apps/web/src/features/guild/settings/members/components/member-data.tsx
@@ -25,6 +25,7 @@ import {
   isMemberProblematic,
 } from "@/features/guild/settings/members/member-list-item.utils";
 import { getMemberDiscordSyncPresentation } from "@/features/guild/settings/members/member-discord-sync.utils";
+import { getColorFromRoleColor } from "@/utils/get-color-from-role";
 
 export type MemberDataProps = {
   member: GuildMember;
@@ -308,11 +309,7 @@ export const MemberData = ({
         ) : (
           <div className="divide-y divide-border/60">
             {member.roles.map((role) => {
-              const roleColor = role.color ?? 0;
-              const color =
-                roleColor === 0
-                  ? "FFF"
-                  : roleColor.toString(16).padStart(6, "0");
+              const color = getColorFromRoleColor(role.color);
               const filteredPermissions = role.permissions.filter(
                 (permission) => permission !== "OWNER",
               ) as Permission[];

--- a/apps/web/src/utils/get-color-from-role.ts
+++ b/apps/web/src/utils/get-color-from-role.ts
@@ -1,11 +1,33 @@
-import type { MemberResponseDto as GuildMember } from "@/lib/api/generated/main/model";
+const DEFAULT_ROLE_COLOR_HEX = "FFF";
 
-export const getColorFromRoleColor = (color: number | null | undefined) => {
-  return color === 0 || color == null
-    ? "FFF"
-    : color.toString(16).padStart(6, "0");
+type RoleColorSource = {
+  color?: number | null;
 };
 
-export const getColorFromRole = (roles: GuildMember["roles"]) => {
+const hasCustomRoleColor = (
+  color: number | null | undefined,
+): color is number => color !== null && color !== undefined && color !== 0;
+
+export const getColorFromRoleColor = (color: number | null | undefined) => {
+  if (!hasCustomRoleColor(color)) {
+    return DEFAULT_ROLE_COLOR_HEX;
+  }
+
+  return color.toString(16).padStart(6, "0");
+};
+
+export const getCustomRoleCssColor = (
+  color: number | null | undefined,
+): string | null => {
+  if (!hasCustomRoleColor(color)) {
+    return null;
+  }
+
+  return `#${getColorFromRoleColor(color).toUpperCase()}`;
+};
+
+export const getColorFromRole = (
+  roles: readonly RoleColorSource[] | null | undefined,
+) => {
   return getColorFromRoleColor(roles?.[0]?.color);
 };


### PR DESCRIPTION
## Summary
- Centralizes Discord role color formatting in `get-color-from-role` for default and custom CSS-color cases.
- Replaces duplicated role hex formatting across loot comments, member details, kill participant rows, and notification template rendering.
- Updates the API error message spec fixture to use the current `ApiError` contract so the web Vitest suite stays green.

## Verification
- `corepack pnpm format:check`
- `corepack pnpm turbo run lint --filter=@lootlog/web...`
- `corepack pnpm turbo run build --filter=@lootlog/web...`
- `VITE_AUTH_SERVICE_URL=http://localhost/api/auth corepack pnpm --filter @lootlog/web exec vitest run`
- Commit pre-commit hook passed

Notes: filtered lint still replays an existing cached warning in `@lootlog/ui` for `src/components/npc-tile.tsx` using `<img>`, with no errors.