### PR TITLE
[codex] simplify event date updates

### DIFF
--- a/apps/api/src/events/services/event-catalog.service.ts
+++ b/apps/api/src/events/services/event-catalog.service.ts
@@ -60,6 +60,21 @@ const memberSelectWithTopRole = {
   },
 };
 
+function resolveUpdatedEventDate(
+  value: string | null | undefined,
+  currentDate: Date | null,
+): Date | null {
+  if (value === undefined) {
+    return currentDate;
+  }
+
+  if (!value) {
+    return null;
+  }
+
+  return new Date(value);
+}
+
 @Injectable()
 export class EventCatalogService {
   constructor(
@@ -357,14 +372,8 @@ export class EventCatalogService {
           : null;
     }
 
-    const newStartDate =
-      startsAt !== undefined
-        ? startsAt
-          ? new Date(startsAt)
-          : null
-        : event.startsAt;
-    const newEndDate =
-      endsAt !== undefined ? (endsAt ? new Date(endsAt) : null) : event.endsAt;
+    const newStartDate = resolveUpdatedEventDate(startsAt, event.startsAt);
+    const newEndDate = resolveUpdatedEventDate(endsAt, event.endsAt);
 
     if (newEndDate && newStartDate && newEndDate <= newStartDate) {
       throw new BadRequestException("End date must be after start date");


### PR DESCRIPTION
## Summary

- Extracted event update date resolution into `resolveUpdatedEventDate`.
- Replaced duplicated nested ternaries for `startsAt` and `endsAt` with named calls.
- Preserves existing behavior for omitted, cleared, and provided date values while making the update path easier to read.

## Verification

- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/events/events.service.spec.ts` (72 tests passed)
- `pnpm --filter @lootlog/api lint` (0 errors; existing warnings only)
- `pnpm exec turbo run build --filter=@lootlog/api` (Nest build passed; TSC found 0 issues)
- `.husky/pre-commit` (lint-staged, Turbo lint, format check, full API tests: 82 files / 869 tests passed)

## Notes

- Fresh dependency setup required `pnpm install`; pnpm reported blocked build-script approvals, but the needed toolchain installed and workspace dependency builds were run to sync injected package copies before verification.