### PR TITLE
[codex] simplify gateway npc routing

### DIFF
--- a/apps/gateway/src/gateway/gateway.service.ts
+++ b/apps/gateway/src/gateway/gateway.service.ts
@@ -22,6 +22,7 @@ import { GatewayEvent } from "src/gateway/enums/gateway-event.enum";
 import { Gateway } from "src/gateway/gateway";
 import { isOwnerOrAdminFromRoles } from "src/guilds/utils/is-administrative-user";
 import { RedisService } from "@lootlog/nest-shared/redis";
+import { getNpcRoutingTier, type NpcRoutingData } from "@lootlog/types";
 import { GuildsService } from "src/guilds/guilds.service";
 import type { UserGuildData } from "src/guilds/types/guild.types";
 import type {
@@ -33,7 +34,6 @@ import type {
 import {
   buildRoomName,
   calculateUserRooms,
-  getNpcTier,
   hasFeatureRoomAccess,
   type FeatureName,
   type TierName,
@@ -46,6 +46,10 @@ type FetchedSocket = Awaited<
 type FeatureRouting = {
   tier: TierName;
   npcLevel?: number;
+};
+
+type RoutedNpcData = NpcRoutingData & {
+  lvl?: number;
 };
 
 type RoutedDeleteTimerDto = DeleteTimerDto;
@@ -452,18 +456,13 @@ export class GatewayService {
     });
   }
 
-  private getNpcFeatureRouting(npc?: {
-    lvl?: number;
-    prof?: string;
-    type?: number | string;
-    wt?: number | string;
-  }): FeatureRouting {
+  private getNpcFeatureRouting(npc?: RoutedNpcData): FeatureRouting {
     if (!npc) {
       return { tier: "base" };
     }
 
     return {
-      tier: getNpcTier(npc),
+      tier: getNpcRoutingTier(npc),
       npcLevel: npc.lvl,
     };
   }

--- a/apps/gateway/src/gateway/utils/room-utils.spec.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.spec.ts
@@ -4,7 +4,6 @@ import type { GuildRole, UserGuildData } from "src/guilds/types/guild.types";
 import {
   buildRoomName,
   calculateUserRooms,
-  getNpcTier,
   hasFeatureRoomAccess,
 } from "./room-utils";
 
@@ -37,38 +36,6 @@ function createGuildData(
 }
 
 describe("room-utils", () => {
-  describe("getNpcTier", () => {
-    it("returns titans for numeric NPC payloads resolved from weight", () => {
-      expect(
-        getNpcTier({
-          type: 2,
-          wt: "120",
-          prof: "w",
-        }),
-      ).toBe("titans");
-    });
-
-    it("returns heroes for explicit event hero type", () => {
-      expect(
-        getNpcTier({
-          type: "EVENT_HERO",
-          wt: "85",
-          prof: "m",
-        }),
-      ).toBe("heroes");
-    });
-
-    it("falls back to base when type cannot be resolved", () => {
-      expect(
-        getNpcTier({
-          type: "unknown",
-          wt: "invalid",
-          prof: "m",
-        }),
-      ).toBe("base");
-    });
-  });
-
   describe("hasFeatureRoomAccess", () => {
     it("allows base feature access without npc level when permission matches", () => {
       expect(

--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -1,9 +1,4 @@
-import {
-  getNpcRoutingTier,
-  Permission,
-  type NpcRoutingData,
-  type NpcRoutingTier,
-} from "@lootlog/types";
+import { Permission, type NpcRoutingTier } from "@lootlog/types";
 import type { UserGuildData, GuildRole } from "src/guilds/types/guild.types";
 import { isOwnerOrAdminFromRoles } from "src/guilds/utils/is-administrative-user";
 import { Platform } from "src/gateway/enums/platform.enum";
@@ -112,8 +107,7 @@ export function calculateUserRooms(
 
       // Calculate based on specific permissions
       for (const { feature, tier } of applicableFeatures) {
-        const requiredPermission = FEATURE_ROOMS[feature][tier];
-        if (hasPermission(roles, requiredPermission)) {
+        if (hasFeatureRoomAccess(roles, feature, tier)) {
           guildRooms.push(buildRoomName(guild.id, feature, tier));
         }
       }
@@ -135,10 +129,6 @@ export function getFeaturePermission(
   tier: TierName,
 ): Permission {
   return FEATURE_ROOMS[feature][tier];
-}
-
-export function getNpcTier(npc?: NpcRoutingData): TierName {
-  return getNpcRoutingTier(npc);
 }
 
 function isLevelWithinRoleRange(role: GuildRole, npcLevel: number): boolean {


### PR DESCRIPTION
## Summary

- Removed the local `getNpcTier` wrapper in gateway room utilities and call `getNpcRoutingTier` from `@lootlog/types` directly.
- Reused `hasFeatureRoomAccess` inside `calculateUserRooms` so room calculation and access checks share the same permission helper.
- Dropped room-utils tests that only exercised the removed wrapper.

## Validation

- `corepack pnpm --filter @lootlog/gateway lint`
- `corepack pnpm --filter @lootlog/gateway test`
- `corepack pnpm turbo run build --filter=@lootlog/gateway...`
- `corepack pnpm format:check`
- `corepack pnpm --filter @lootlog/gateway build`
- pre-commit hook: lint-staged, changed-package lint, changed-package tests

Note: a fresh install required `CI=true corepack pnpm install` after the global `pnpm` v11 path attempted to add an unrelated approval scaffold; that scaffold was removed and is not part of this PR.