### PR TITLE
[codex] simplify item search hit count mapping

### DIFF
--- a/apps/search/src/items/items.service.spec.ts
+++ b/apps/search/src/items/items.service.spec.ts
@@ -8,18 +8,18 @@ describe("ItemsService", () => {
   let service: ItemsService;
 
   const loggerMock = {
-    error: vi.fn(),
-    warn: vi.fn(),
+    error: vi.fn<(message: string, context?: unknown) => void>(),
+    warn: vi.fn<(message: string, context?: unknown) => void>(),
   };
 
   const indexMock = {
-    search: vi.fn(),
-    addDocuments: vi.fn(),
-    getDocument: vi.fn(),
+    search: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    addDocuments: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
+    getDocument: vi.fn<(...args: unknown[]) => Promise<unknown>>(),
   };
 
   const meilisearchMock = {
-    index: vi.fn(),
+    index: vi.fn<() => typeof indexMock>(),
   };
 
   beforeEach(async () => {
@@ -142,6 +142,26 @@ describe("ItemsService", () => {
           'numericStats.dmg >= 40 AND requiredProfessions = "w" AND (worlds = "Berufs" OR world = "Berufs")',
         facets: ["rarity", "requiredProfessions"],
         sort: ["lvl:desc"],
+      });
+    });
+
+    it("should use total hits when estimated total hits are missing", async () => {
+      indexMock.search.mockResolvedValue({
+        hits: [{ id: 1, name: "Sword", stat: "dmg=50" }],
+        totalHits: 42,
+      });
+
+      await expect(
+        service.searchItems({
+          limit: 10,
+          offset: 0,
+          search: "sword",
+        }),
+      ).resolves.toEqual({
+        hits: [{ id: 1, name: "Sword", stat: "dmg=50" }],
+        estimatedTotalHits: 42,
+        facetDistribution: {},
+        facetStats: {},
       });
     });
 

--- a/apps/search/src/items/items.service.ts
+++ b/apps/search/src/items/items.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import type { Logger } from "winston";
-import { Meilisearch, type SearchParams } from "meilisearch";
+import type { Meilisearch, SearchParams } from "meilisearch";
 import type { z } from "zod";
 import { MEILISEARCH_CLIENT } from "src/meilisearch/meilisearch.constants";
 import { getMeilisearchErrorCode } from "src/meilisearch/meilisearch.utils";
@@ -172,7 +172,6 @@ export class ItemsService {
       });
     } catch (error) {
       this.logger.error("Error indexing items", { error });
-      return;
     }
   }
 
@@ -195,9 +194,7 @@ export class ItemsService {
     return {
       hits: data.hits,
       estimatedTotalHits:
-        "estimatedTotalHits" in data
-          ? (data.estimatedTotalHits ?? data.totalHits ?? data.hits.length)
-          : (data.totalHits ?? data.hits.length),
+        data.estimatedTotalHits ?? data.totalHits ?? data.hits.length,
       facetDistribution: data.facetDistribution ?? {},
       facetStats: data.facetStats ?? {},
     };


### PR DESCRIPTION
## Summary
- Simplify item search response count mapping to a direct nullish fallback chain.
- Add coverage for the legacy `totalHits` response shape when `estimatedTotalHits` is absent.
- Clean touched-file lint warnings in the item search service/spec.

## Verification
- `pnpm exec oxfmt --check apps/search/src/items/items.service.ts apps/search/src/items/items.service.spec.ts`
- `pnpm exec oxlint apps/search/src/items/items.service.ts apps/search/src/items/items.service.spec.ts`
- `pnpm --filter @lootlog/search test`
- `pnpm turbo run build --filter=@lootlog/search`
- Pre-commit hook passed during commit, including lint-staged and changed-package tests.