### PR TITLE
fix: align abyss season filter height

### DIFF
--- a/apps/web/src/features/user/battle-panel/battle-panel-abyss/abyss-hub.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-abyss/abyss-hub.tsx
@@ -308,7 +308,7 @@ export function AbyssHub() {
                 onValueChange={handleSeasonChange}
                 disabled={isLoadingSeasons || seasons.length === 0}
               >
-                <SelectTrigger className="h-10 w-full lg:w-[260px]">
+                <SelectTrigger size="lg" className="w-full lg:w-[260px]">
                   <SelectValue
                     placeholder={t("battlePanel.abyss.selectSeason")}
                   />

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -30,14 +30,14 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default";
+  size?: "sm" | "default" | "lg";
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 data-[size=lg]:h-10 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}


### PR DESCRIPTION
## What changed

- Added a `lg` size variant to the shared `SelectTrigger` component.
- Updated the Abyss season filter to use the new large select trigger size.

## Why

The season filter in the Abyss panel rendered shorter than the neighboring character selector, level inputs, and H2H button. The local `h-10` class did not win against the select trigger's default `data-[size=default]:h-9` height rule.

## Impact

The Abyss filter row now uses consistent 40px control height without changing existing default or small select usages.

## Checks

- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web build`
- `pnpm --filter @lootlog/ui lint`