### PR TITLE
[codex] refactor react library type resolution

### DIFF
--- a/packages/typescript-config/react-library.json
+++ b/packages/typescript-config/react-library.json
@@ -3,6 +3,8 @@
   "display": "React Library",
   "extends": "./base.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
   }
 }

--- a/packages/ui/src/components/bento.tsx
+++ b/packages/ui/src/components/bento.tsx
@@ -101,7 +101,7 @@ const ParticleCard: React.FC<{
 }) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const particlesRef = useRef<HTMLDivElement[]>([]);
-  const timeoutsRef = useRef<NodeJS.Timeout[]>([]);
+  const timeoutsRef = useRef<ReturnType<typeof window.setTimeout>[]>([]);
   const isHoveredRef = useRef(false);
   const memoizedParticles = useRef<HTMLDivElement[]>([]);
   const particlesInitialized = useRef(false);

--- a/packages/ui/src/components/liquid-ether-bg.tsx
+++ b/packages/ui/src/components/liquid-ether-bg.tsx
@@ -444,7 +444,7 @@ export default function LiquidEther({
     varying vec2 uv;
     void main(){
     vec2 ratio = max(fboSize.x, fboSize.y) / fboSize;
-    if(isBFECC == false){
+    if (!isBFECC) {
         vec2 vel = texture2D(velocity, uv).xy;
         vec2 uv2 = uv - vel * dt * ratio;
         vec2 newVel = texture2D(velocity, uv2).xy;


### PR DESCRIPTION
## Summary
- Align the shared React library TypeScript preset with frontend bundler resolution.
- Replace a browser UI timeout ref type with a DOM-safe `window.setTimeout` return type.
- Simplify the LiquidEther GLSL BFECC guard from a loose boolean comparison to a direct guard.

## Verification
- `CI=true corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec tsc -p packages/ui/tsconfig.json --noEmit`
- `corepack pnpm --filter @lootlog/ui lint`
- `corepack pnpm exec oxfmt --check packages/ui/src/components/liquid-ether-bg.tsx packages/ui/src/components/bento.tsx packages/typescript-config/react-library.json pnpm-workspace.yaml`
- `corepack pnpm exec turbo run lint --filter=...@lootlog/ui`
- `corepack pnpm --filter @lootlog/developer typecheck`
- `corepack pnpm --filter @lootlog/landing typecheck`
- `corepack pnpm --filter @lootlog/web exec tsc -b`
- `corepack pnpm --filter @lootlog/wiki test`
- `corepack pnpm --filter @lootlog/developer build`
- `corepack pnpm --filter @lootlog/wiki build`
- `corepack pnpm --filter @lootlog/web build`
- `corepack pnpm --filter @lootlog/landing build`
- `.husky/pre-commit`
- `git commit` hook reran the same pre-commit checks successfully