### PR TITLE
fix: tolerate incomplete battle warrior snapshots

### DIFF
--- a/apps/battlelog-service/src/battles/dto/create-battle.dto.ts
+++ b/apps/battlelog-service/src/battles/dto/create-battle.dto.ts
@@ -22,6 +22,32 @@ const CreateBattleFightEventWarriorSchema = z.object({
   team: z.number(),
 });
 
+const requiredWarriorSnapshotFields = [
+  "originalId",
+  "name",
+  "lvl",
+  "prof",
+  "icon",
+  "team",
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const hasCompleteWarriorSnapshotShape = (value: unknown): boolean =>
+  isRecord(value) &&
+  requiredWarriorSnapshotFields.every((field) => field in value);
+
+const removeIncompleteWarriorSnapshots = (value: unknown): unknown => {
+  if (!isRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([, warrior]) =>
+      hasCompleteWarriorSnapshotShape(warrior),
+    ),
+  );
+};
+
 export const WarriorsRecordSchema = z
   .record(z.string(), CreateBattleFightEventWarriorSchema)
   .refine(
@@ -35,12 +61,19 @@ export const WarriorsRecordSchema = z
     { message: "w must be a valid Record of warriors" },
   );
 
+const OptionalWarriorsRecordSchema = z.preprocess((value) => {
+  const warriors = removeIncompleteWarriorSnapshots(value);
+  if (!isRecord(warriors)) return warriors;
+
+  return Object.keys(warriors).length > 0 ? warriors : undefined;
+}, WarriorsRecordSchema.optional());
+
 const CreateBattleFightEventSchema = z.object({
   m: z.array(z.string()).optional(),
   endBattle: z.number().optional(),
   init: z.string().optional(),
   auto: z.string().optional(),
-  w: WarriorsRecordSchema.optional(),
+  w: OptionalWarriorsRecordSchema,
 });
 
 const CreateBattleMatchSummarySchema = z.object({
@@ -75,7 +108,7 @@ const CreateBattleEventsSchema = z.object({
   match_summary: CreateBattleMatchSummarySchema.optional(),
 });
 
-const CreateBattleSchema = z.object({
+export const CreateBattleSchema = z.object({
   accountId: z.string(),
   characterId: z.string(),
   world: z.string(),

--- a/apps/battlelog-service/src/battles/validators/battle-warriors.validator.spec.ts
+++ b/apps/battlelog-service/src/battles/validators/battle-warriors.validator.spec.ts
@@ -1,4 +1,7 @@
-import { WarriorsRecordSchema } from "../dto/create-battle.dto";
+import {
+  CreateBattleSchema,
+  WarriorsRecordSchema,
+} from "../dto/create-battle.dto";
 
 describe("WarriorsRecordSchema", () => {
   it("should accept valid warriors record with two teams", () => {
@@ -134,5 +137,53 @@ describe("WarriorsRecordSchema", () => {
     const result = WarriorsRecordSchema.safeParse({});
 
     expect(result.success).toBe(false);
+  });
+
+  it("should drop incomplete warrior snapshots from battle events", () => {
+    const result = CreateBattleSchema.safeParse({
+      accountId: "9822301",
+      characterId: "617",
+      world: "gordion",
+      events: [
+        {
+          ev: 1,
+          f: {
+            w: {
+              "52785": {
+                originalId: 52785,
+                name: "Warrior1",
+                lvl: 85,
+                prof: "w",
+                icon: "icon1",
+                team: 1,
+              },
+              "161562": {
+                originalId: 161562,
+                name: "Warrior2",
+                lvl: 83,
+                prof: "p",
+                icon: "icon2",
+                team: 2,
+              },
+            },
+          },
+        },
+        {
+          ev: 2,
+          f: {
+            m: ["52785=100;161562=90;+dmg=10"],
+            w: {
+              "52785": {},
+              "161562": { hpp: 90 },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.events[1]?.f.w).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What changed

- Relaxed battle creation validation so incomplete `events[*].f.w` warrior snapshots are filtered out before validating the remaining full snapshots.
- Treats an `f.w` record that only contains incomplete snapshots as omitted for that event.
- Added a regression test covering later battle events that send empty or partial warrior entries for existing warrior IDs.

## Why

Production was rejecting battle payloads with `400 Validation failed` when later fight events contained incomplete warrior updates under `f.w`. The client already sends full warrior snapshots earlier in the battle payload, so the service can safely ignore incomplete follow-up snapshot entries without requiring a client release.

## Impact

Clients do not need to change. Fully invalid complete warrior snapshots still fail validation, while partial/empty warrior update entries no longer block battle ingestion.

## Validation

- `pnpm --filter @lootlog/battlelog-service test`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm --filter @lootlog/battlelog-service build`
- pre-commit hook: lint and test for `@lootlog/battlelog-service`