### PR TITLE
[codex] simplify item stat parsing

### DIFF
--- a/apps/search/src/items/utils/create-item-search-fields.spec.ts
+++ b/apps/search/src/items/utils/create-item-search-fields.spec.ts
@@ -1,0 +1,39 @@
+import { createItemSearchFields } from "./create-item-search-fields";
+
+describe("createItemSearchFields", () => {
+  it("normalizes scalar stat values and keeps default required professions", () => {
+    expect(
+      createItemSearchFields(
+        "lvl=10;upgraded=true;soulbound=false;ratio=-1.5;rarity=heroic;ignored",
+      ),
+    ).toEqual({
+      stats: {
+        lvl: 10,
+        upgraded: true,
+        soulbound: false,
+        ratio: -1.5,
+        rarity: "heroic",
+      },
+      numericStats: {
+        lvl: 10,
+        ratio: -1.5,
+      },
+      statsKeys: ["lvl", "upgraded", "soulbound", "ratio", "rarity"],
+      requiredProfessions: ["w", "p", "h", "m", "b", "t"],
+    });
+  });
+
+  it("uses reqp as the required profession list", () => {
+    expect(createItemSearchFields("reqp=wm;lvl=20")).toEqual({
+      stats: {
+        reqp: ["w", "m"],
+        lvl: 20,
+      },
+      numericStats: {
+        lvl: 20,
+      },
+      statsKeys: ["reqp", "lvl"],
+      requiredProfessions: ["w", "m"],
+    });
+  });
+});

--- a/apps/search/src/items/utils/create-item-search-fields.ts
+++ b/apps/search/src/items/utils/create-item-search-fields.ts
@@ -27,10 +27,14 @@ const normalizeStatValue = (value: string): string | number | boolean => {
   return value;
 };
 
+const parseRequiredProfessions = (value: string): string[] =>
+  value.split("").filter(Boolean);
+
 export const createItemSearchFields = (statRaw: string): ItemSearchFields => {
   const stats: Record<string, ItemStatValue> = {};
   const numericStats: Record<string, number> = {};
   const statsKeys: string[] = [];
+  let requiredProfessions: string[] = [...DEFAULT_REQUIRED_PROFESSIONS];
 
   for (const statEntry of statRaw.split(";")) {
     const [key, value] = statEntry.split("=");
@@ -42,8 +46,9 @@ export const createItemSearchFields = (statRaw: string): ItemSearchFields => {
     statsKeys.push(key);
 
     if (key === "reqp") {
-      const requiredProfessions = value.split("").filter(Boolean);
-      stats[key] = requiredProfessions;
+      const parsedRequiredProfessions = parseRequiredProfessions(value);
+      stats[key] = parsedRequiredProfessions;
+      requiredProfessions = [...parsedRequiredProfessions];
       continue;
     }
 
@@ -54,10 +59,6 @@ export const createItemSearchFields = (statRaw: string): ItemSearchFields => {
       numericStats[key] = normalizedValue;
     }
   }
-
-  const requiredProfessions = Array.isArray(stats["reqp"])
-    ? [...stats["reqp"]]
-    : [...DEFAULT_REQUIRED_PROFESSIONS];
 
   return {
     stats,


### PR DESCRIPTION
## Summary

- Refactors `createItemSearchFields` so required-profession parsing is tracked directly during stat parsing instead of inferred from the `stats` record after the loop.
- Adds focused coverage for scalar stat normalization, malformed entries, default required professions, and explicit `reqp` parsing.

## Impact

This preserves the existing search indexing output while making the helper easier to reason about and typecheck.

## Verification

- `corepack pnpm --dir apps/search exec vitest run --config ./vitest.config.ts src/items/utils/create-item-search-fields.spec.ts`
- `corepack pnpm --filter @lootlog/search test`
- `corepack pnpm format:check`
- `corepack pnpm exec oxlint apps/search/src/items/utils/create-item-search-fields.ts apps/search/src/items/utils/create-item-search-fields.spec.ts`
- `corepack pnpm --dir apps/search exec tsc --noEmit --project tsconfig.json`
- `corepack pnpm turbo run build --filter=@lootlog/search...`
- `corepack pnpm lint` (passes with existing warnings)
- `sh .husky/pre-commit`
- `git commit` hooks