### PR TITLE
[codex] Clarify timer permission guard

### DIFF
--- a/apps/api/src/shared/utils/can-view-chat-message.spec.ts
+++ b/apps/api/src/shared/utils/can-view-chat-message.spec.ts
@@ -46,7 +46,7 @@ function createMessage(
 
 describe("canViewChatMessage", () => {
   it("returns false when data is missing", () => {
-    expect(canViewChatMessage(undefined as never, [])).toBe(false);
+    expect(canViewChatMessage(undefined, [])).toBe(false);
   });
 
   it("returns false without base chat permission", () => {

--- a/apps/api/src/shared/utils/can-view-chat-message.ts
+++ b/apps/api/src/shared/utils/can-view-chat-message.ts
@@ -22,7 +22,10 @@ const hasNpcPermission = (npc: NpcData, roles: Role[]) => {
   );
 };
 
-export const canViewChatMessage = (data: ChatStoredMessage, roles: Role[]) => {
+export const canViewChatMessage = (
+  data: ChatStoredMessage | null | undefined,
+  roles: Role[],
+) => {
   if (!data) return false;
   const canReadChatMessages = roles.some((role) =>
     role.permissions.includes(Permission.LOOTLOG_CHAT_READ),

--- a/apps/api/src/shared/utils/can-view-npc-timer.spec.ts
+++ b/apps/api/src/shared/utils/can-view-npc-timer.spec.ts
@@ -1,0 +1,88 @@
+import { Permission } from "src/generated/prisma/client";
+import {
+  canViewNpcTimer,
+  type NpcPermissionData,
+  type RolePermissionData,
+} from "@lootlog/api-helpers/permissions";
+
+function createRole(
+  permissions: string[],
+  lvlRangeFrom = 1,
+  lvlRangeTo = 500,
+): RolePermissionData {
+  return {
+    permissions,
+    lvlRangeFrom,
+    lvlRangeTo,
+  };
+}
+
+function createNpc(
+  overrides: Partial<NpcPermissionData> = {},
+): NpcPermissionData {
+  return {
+    lvl: 100,
+    type: "ELITE2",
+    ...overrides,
+  };
+}
+
+describe("canViewNpcTimer", () => {
+  it("returns false when npc data is missing", () => {
+    expect(
+      canViewNpcTimer(null, [createRole([Permission.LOOTLOG_TIMERS_READ])]),
+    ).toBe(false);
+  });
+
+  it("allows base timer access when permission and level match", () => {
+    const roles = [createRole([Permission.LOOTLOG_TIMERS_READ], 50, 150)];
+
+    expect(canViewNpcTimer(createNpc(), roles)).toBe(true);
+  });
+
+  it("requires level range for base timer access", () => {
+    const roles = [createRole([Permission.LOOTLOG_TIMERS_READ], 1, 99)];
+
+    expect(canViewNpcTimer(createNpc(), roles)).toBe(false);
+  });
+
+  it("requires titan timer permission for titan NPCs", () => {
+    const roles = [createRole([Permission.LOOTLOG_TIMERS_READ], 1, 500)];
+
+    expect(canViewNpcTimer(createNpc({ type: "TITAN" }), roles)).toBe(false);
+  });
+
+  it("allows titan timer access when permission and level match", () => {
+    const roles = [
+      createRole([Permission.LOOTLOG_TIMERS_TITANS_READ], 250, 350),
+    ];
+
+    expect(canViewNpcTimer(createNpc({ lvl: 300, type: "TITAN" }), roles)).toBe(
+      true,
+    );
+  });
+
+  it("uses hero timer permission for hero and event hero NPCs", () => {
+    const roles = [
+      createRole([Permission.LOOTLOG_TIMERS_HEROES_READ], 100, 200),
+    ];
+
+    expect(canViewNpcTimer(createNpc({ lvl: 150, type: "HERO" }), roles)).toBe(
+      true,
+    );
+    expect(
+      canViewNpcTimer(createNpc({ lvl: 150, type: "EVENT_HERO" }), roles),
+    ).toBe(true);
+  });
+
+  it("does not combine timer permission from one role with level range from another", () => {
+    const roles = [
+      createRole([Permission.LOOTLOG_TIMERS_TITANS_READ], 1, 299),
+      createRole([], 300, 400),
+    ];
+
+    expect(canViewNpcTimer(createNpc({ lvl: 300, type: "TITAN" }), roles)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
+++ b/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
@@ -16,23 +16,31 @@ const PERMISSION = {
 } as const;
 
 type TimerPermission = (typeof PERMISSION)[keyof typeof PERMISSION];
+type TimerPermissionTier = "base" | "titans" | "heroes";
+
+const TIMER_PERMISSION_BY_TIER: Record<TimerPermissionTier, TimerPermission> = {
+  base: PERMISSION.LOOTLOG_TIMERS_READ,
+  titans: PERMISSION.LOOTLOG_TIMERS_TITANS_READ,
+  heroes: PERMISSION.LOOTLOG_TIMERS_HEROES_READ,
+};
+
+const TIMER_PERMISSION_TIER_BY_NPC_TYPE: Partial<
+  Record<string, TimerPermissionTier>
+> = {
+  TITAN: "titans",
+  HERO: "heroes",
+  EVENT_HERO: "heroes",
+};
 
 const isNpcLevelWithinRoleRange = (
   role: RolePermissionData,
   npcLevel: number,
 ): boolean => role.lvlRangeFrom <= npcLevel && role.lvlRangeTo >= npcLevel;
 
-const getRequiredTimerPermission = (npcType: string): TimerPermission => {
-  if (npcType === "TITAN") {
-    return PERMISSION.LOOTLOG_TIMERS_TITANS_READ;
-  }
-
-  if (npcType === "HERO" || npcType === "EVENT_HERO") {
-    return PERMISSION.LOOTLOG_TIMERS_HEROES_READ;
-  }
-
-  return PERMISSION.LOOTLOG_TIMERS_READ;
-};
+const getRequiredTimerPermission = (npcType: string): TimerPermission =>
+  TIMER_PERMISSION_BY_TIER[
+    TIMER_PERMISSION_TIER_BY_NPC_TYPE[npcType] ?? "base"
+  ];
 
 export const canViewNpcTimer = (
   npc: NpcPermissionData | null,


### PR DESCRIPTION
## Summary

- Refactor `canViewNpcTimer` to use an explicit timer permission tier map instead of branching on NPC type strings.
- Add focused unit coverage for base, titan, hero, event hero, missing NPC, level range, and split-role permission behavior.
- Widen `canViewChatMessage` input typing to match its existing runtime guard for missing message data.

## Validation

- `pnpm exec oxfmt --check apps/api/src/shared/utils/can-view-chat-message.ts apps/api/src/shared/utils/can-view-chat-message.spec.ts apps/api/src/shared/utils/can-view-npc-timer.spec.ts packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts`
- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/shared/utils/can-view-npc-timer.spec.ts src/shared/utils/can-view-chat-message.spec.ts`
- `pnpm --filter @lootlog/api test`
- `pnpm --filter @lootlog/api lint`
- `pnpm --filter @lootlog/api-helpers build`
- `pnpm --filter @lootlog/api build`
- `pnpm lint-staged`
- `pnpm turbo run lint '--filter=[HEAD]'`
- `pnpm turbo run format:check '--filter=[HEAD]'`
- `pnpm turbo run test '--filter=[HEAD]'`
- `pnpm turbo run build '--filter=[HEAD]'`

Notes: API lint currently reports existing warnings but exits with 0 errors. `format:check --filter=[HEAD]` has no package task to execute for these changed packages, matching the repository hook behavior.