### PR TITLE
[codex] refactor wiki basic search route helpers

### DIFF
--- a/apps/wiki/src/routes/-search-route.utils.ts
+++ b/apps/wiki/src/routes/-search-route.utils.ts
@@ -1,0 +1,61 @@
+export type BasicRouteSearch = {
+  query: string;
+  world: string;
+};
+
+export type SearchStatus = "error" | "idle" | "loading" | "ready";
+
+export const emptyBasicRouteSearch: BasicRouteSearch = {
+  query: "",
+  world: "",
+};
+
+export function validateBasicRouteSearch(
+  search: Record<string, unknown>,
+): BasicRouteSearch {
+  return {
+    query: typeof search.query === "string" ? search.query : "",
+    world: typeof search.world === "string" ? search.world : "",
+  };
+}
+
+export function getBasicRouteSearchState({
+  queryValue,
+  worldValue,
+}: {
+  queryValue: string;
+  worldValue: string;
+}): BasicRouteSearch {
+  return {
+    query: queryValue.trim(),
+    world: worldValue.trim(),
+  };
+}
+
+export function isBasicRouteSearchActive(search: BasicRouteSearch): boolean {
+  return search.query.trim() !== "" || search.world.trim() !== "";
+}
+
+export function areBasicRouteSearchStatesEqual(
+  firstSearch: BasicRouteSearch,
+  secondSearch: BasicRouteSearch,
+): boolean {
+  return (
+    firstSearch.query === secondSearch.query &&
+    firstSearch.world === secondSearch.world
+  );
+}
+
+export function getBasicRouteSearchQueryParams(
+  search: BasicRouteSearch,
+  limit: number,
+) {
+  const query = search.query.trim();
+  const world = search.world.trim();
+
+  return {
+    limit,
+    search: query === "" ? undefined : query,
+    world: world === "" ? undefined : world,
+  };
+}

--- a/apps/wiki/src/routes/npcs.tsx
+++ b/apps/wiki/src/routes/npcs.tsx
@@ -12,22 +12,18 @@ import {
   getNpcsControllerGetNpcsQueryKey,
   useNpcsControllerGetNpcs,
 } from "@/lib/api/generated/search/npcs/npcs";
+import {
+  areBasicRouteSearchStatesEqual,
+  emptyBasicRouteSearch,
+  getBasicRouteSearchQueryParams,
+  getBasicRouteSearchState,
+  isBasicRouteSearchActive,
+  type SearchStatus,
+  validateBasicRouteSearch,
+} from "./-search-route.utils";
 
 const SEARCH_DEBOUNCE_MS = 300;
 const SEARCH_LIMIT = 72;
-type SearchStatus = "error" | "idle" | "loading" | "ready";
-
-type NpcsRouteSearch = {
-  query: string;
-  world: string;
-};
-
-function validateSearch(search: Record<string, unknown>): NpcsRouteSearch {
-  return {
-    query: typeof search.query === "string" ? search.query : "",
-    world: typeof search.world === "string" ? search.world : "",
-  };
-}
 
 export const Route = createFileRoute("/npcs")({
   component: NpcsRoute,
@@ -39,7 +35,7 @@ export const Route = createFileRoute("/npcs")({
     ],
   }),
   loader: () => getRuntimeConfig(),
-  validateSearch,
+  validateSearch: validateBasicRouteSearch,
 });
 
 function NpcsRoute() {
@@ -48,13 +44,8 @@ function NpcsRoute() {
   const search = Route.useSearch();
   const [queryValue, setQueryValue] = useState(search.query);
   const [worldValue, setWorldValue] = useState(search.world);
-  const hasActiveSearch =
-    search.query.trim() !== "" || search.world.trim() !== "";
-  const queryParams = {
-    limit: SEARCH_LIMIT,
-    search: search.query.trim() || undefined,
-    world: search.world.trim() || undefined,
-  };
+  const hasActiveSearch = isBasicRouteSearchActive(search);
+  const queryParams = getBasicRouteSearchQueryParams(search, SEARCH_LIMIT);
   const npcsQuery = useNpcsControllerGetNpcs(queryParams, {
     query: {
       enabled: hasActiveSearch,
@@ -82,14 +73,13 @@ function NpcsRoute() {
   }, [search.query, search.world]);
 
   useEffect(() => {
-    const nextSearch = {
-      query: queryValue.trim(),
-      world: worldValue.trim(),
-    };
+    const nextSearch = getBasicRouteSearchState({ queryValue, worldValue });
 
     if (
-      nextSearch.query === search.query &&
-      nextSearch.world === search.world
+      areBasicRouteSearchStatesEqual(nextSearch, {
+        query: search.query,
+        world: search.world,
+      })
     ) {
       return;
     }
@@ -113,10 +103,7 @@ function NpcsRoute() {
 
     startTransition(() => {
       void navigate({
-        search: {
-          query: queryValue.trim(),
-          world: worldValue.trim(),
-        },
+        search: getBasicRouteSearchState({ queryValue, worldValue }),
       });
     });
   }
@@ -127,10 +114,7 @@ function NpcsRoute() {
 
     startTransition(() => {
       void navigate({
-        search: {
-          query: "",
-          world: "",
-        },
+        search: emptyBasicRouteSearch,
       });
     });
   }

--- a/apps/wiki/src/routes/players.tsx
+++ b/apps/wiki/src/routes/players.tsx
@@ -11,22 +11,18 @@ import {
   getPlayersControllerGetPlayersQueryKey,
   usePlayersControllerGetPlayers,
 } from "@/lib/api/generated/search/players/players";
+import {
+  areBasicRouteSearchStatesEqual,
+  emptyBasicRouteSearch,
+  getBasicRouteSearchQueryParams,
+  getBasicRouteSearchState,
+  isBasicRouteSearchActive,
+  type SearchStatus,
+  validateBasicRouteSearch,
+} from "./-search-route.utils";
 
 const SEARCH_DEBOUNCE_MS = 300;
 const SEARCH_LIMIT = 72;
-type SearchStatus = "error" | "idle" | "loading" | "ready";
-
-type PlayersRouteSearch = {
-  query: string;
-  world: string;
-};
-
-function validateSearch(search: Record<string, unknown>): PlayersRouteSearch {
-  return {
-    query: typeof search.query === "string" ? search.query : "",
-    world: typeof search.world === "string" ? search.world : "",
-  };
-}
 
 export const Route = createFileRoute("/players")({
   component: PlayersRoute,
@@ -38,7 +34,7 @@ export const Route = createFileRoute("/players")({
     ],
   }),
   loader: () => getRuntimeConfig(),
-  validateSearch,
+  validateSearch: validateBasicRouteSearch,
 });
 
 function PlayersRoute() {
@@ -47,13 +43,8 @@ function PlayersRoute() {
   const search = Route.useSearch();
   const [queryValue, setQueryValue] = useState(search.query);
   const [worldValue, setWorldValue] = useState(search.world);
-  const hasActiveSearch =
-    search.query.trim() !== "" || search.world.trim() !== "";
-  const queryParams = {
-    limit: SEARCH_LIMIT,
-    search: search.query.trim() || undefined,
-    world: search.world.trim() || undefined,
-  };
+  const hasActiveSearch = isBasicRouteSearchActive(search);
+  const queryParams = getBasicRouteSearchQueryParams(search, SEARCH_LIMIT);
   const playersQuery = usePlayersControllerGetPlayers(queryParams, {
     query: {
       enabled: hasActiveSearch,
@@ -81,14 +72,13 @@ function PlayersRoute() {
   }, [search.query, search.world]);
 
   useEffect(() => {
-    const nextSearch = {
-      query: queryValue.trim(),
-      world: worldValue.trim(),
-    };
+    const nextSearch = getBasicRouteSearchState({ queryValue, worldValue });
 
     if (
-      nextSearch.query === search.query &&
-      nextSearch.world === search.world
+      areBasicRouteSearchStatesEqual(nextSearch, {
+        query: search.query,
+        world: search.world,
+      })
     ) {
       return;
     }
@@ -112,10 +102,7 @@ function PlayersRoute() {
 
     startTransition(() => {
       void navigate({
-        search: {
-          query: queryValue.trim(),
-          world: worldValue.trim(),
-        },
+        search: getBasicRouteSearchState({ queryValue, worldValue }),
       });
     });
   }
@@ -126,10 +113,7 @@ function PlayersRoute() {
 
     startTransition(() => {
       void navigate({
-        search: {
-          query: "",
-          world: "",
-        },
+        search: emptyBasicRouteSearch,
       });
     });
   }


### PR DESCRIPTION
## Summary

- Extract shared query/world search route helpers for the wiki NPC and player routes.
- Reuse the shared helpers for search validation, activity checks, query params, submit/reset state, and debounce comparisons.
- Prefix the helper file with `-` so TanStack Router ignores it as a route file.

## Verification

- `pnpm exec oxfmt --check apps/wiki/src/routes/-search-route.utils.ts apps/wiki/src/routes/npcs.tsx apps/wiki/src/routes/players.tsx`
- `pnpm --filter @lootlog/wiki lint` (passes with one pre-existing warning in `apps/wiki/src/routes/__root.tsx` about `<head>`)
- `pnpm --filter @lootlog/wiki test`
- `pnpm --filter @lootlog/wiki exec tsc --noEmit`
- `pnpm --filter @lootlog/wiki build` (passes with an existing `/themes/rias-bg.png` runtime-resolution warning)
- Commit hook ran lint-staged plus changed-package lint/test successfully