### PR TITLE
[codex] use strict null checks in battle panel

### DIFF
--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle.tsx
@@ -141,7 +141,7 @@ export const BattlePanelSingleBattle = () => {
   }, [selectedTurn]);
 
   useLayoutEffect(() => {
-    if (scrollAnimationFrameRef.current != null) {
+    if (scrollAnimationFrameRef.current !== null) {
       cancelAnimationFrame(scrollAnimationFrameRef.current);
       scrollAnimationFrameRef.current = null;
     }
@@ -200,7 +200,7 @@ export const BattlePanelSingleBattle = () => {
 
   useEffect(
     () => () => {
-      if (scrollAnimationFrameRef.current == null) {
+      if (scrollAnimationFrameRef.current === null) {
         return;
       }
 
@@ -210,7 +210,7 @@ export const BattlePanelSingleBattle = () => {
   );
 
   const handleTurnSelect = (turn: number) => {
-    if (scrollAnimationFrameRef.current != null) {
+    if (scrollAnimationFrameRef.current !== null) {
       cancelAnimationFrame(scrollAnimationFrameRef.current);
       scrollAnimationFrameRef.current = null;
     }
@@ -291,7 +291,7 @@ export const BattlePanelSingleBattle = () => {
       occlusionBottom,
     });
 
-    if (activeTurn == null || activeTurn === selectedTurnRef.current) {
+    if (activeTurn === null || activeTurn === selectedTurnRef.current) {
       return;
     }
 
@@ -301,7 +301,7 @@ export const BattlePanelSingleBattle = () => {
   };
 
   const handleBattleScroll = () => {
-    if (scrollAnimationFrameRef.current != null) {
+    if (scrollAnimationFrameRef.current !== null) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Replace loose `== null` / `!= null` checks in the battle panel single-battle component with strict `null` comparisons.
- Keep the existing scroll animation-frame and active-turn behavior while aligning with the repository style guide.

## Validation

- `corepack pnpm exec oxfmt --check apps/web/src/features/user/battle-panel/battle-panel-single-battle/battle-panel-single-battle.tsx`
- `corepack pnpm --filter @lootlog/web lint`
- `corepack pnpm turbo run build --filter=@lootlog/web...`
- `corepack pnpm turbo run test --filter=@lootlog/web...` (no web test task executed; dependency builds were cache hits)
- Commit pre-commit hook passed (`lint-staged`, changed-package lint, format check, test target).

## Notes

- The web build still emits an existing third-party `lottie-web` direct-eval warning.
- The pre-commit lint output replayed an existing cached `@lootlog/ui` warning about `<img>` in `npc-tile.tsx`; no lint errors were reported.