### PR TITLE
[codex] Remove api-helpers root auth barrel

### DIFF
--- a/apps/auth/src/auth/auth.service.spec.ts
+++ b/apps/auth/src/auth/auth.service.spec.ts
@@ -4,13 +4,13 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { validateToken } from "@lootlog/api-helpers";
+import { validateToken } from "@lootlog/api-helpers/auth/verify-jwt";
 import { APIError } from "better-auth/api";
 import { AuthService } from "./auth.service";
 import { idpTokenRequestSchema } from "./dto/idp-token-request.dto";
 import { auth } from "./better-auth";
 
-vi.mock("@lootlog/api-helpers", () => ({
+vi.mock("@lootlog/api-helpers/auth/verify-jwt", () => ({
   validateToken:
     vi.fn<(input: unknown) => Promise<{ userId: string; discordId: string }>>(),
 }));

--- a/apps/auth/src/auth/auth.service.ts
+++ b/apps/auth/src/auth/auth.service.ts
@@ -5,8 +5,11 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
+import {
+  type JwksKeys,
+  validateToken,
+} from "@lootlog/api-helpers/auth/verify-jwt";
 import { APIError } from "better-auth/api";
-import { type JwksKeys, validateToken } from "@lootlog/api-helpers";
 import { fromNodeHeaders } from "better-auth/node";
 import type { IncomingHttpHeaders } from "node:http";
 import { env } from "src/config/env";

--- a/packages/api-helpers/README.md
+++ b/packages/api-helpers/README.md
@@ -1,18 +1,17 @@
 # @lootlog/api-helpers
 
-Shared auth and request-context helpers for backend services.
+Shared auth and permission helpers for backend services.
 
 ## Overview
 
-- Provides reusable helpers for validating Auth-issued JWTs and extracting user metadata from trusted headers.
-- Supports the Hono services used in this monorepo and keeps auth-adjacent logic out of individual apps.
+- Provides reusable helpers for validating Auth-issued JWTs.
+- Keeps auth-adjacent logic out of individual apps.
 - Ships an additional `permissions` subpath export for permission-related helpers.
 
 ## Exports
 
-- `userMetadataFromHeaders`
-- `validateToken`
-- JWT verification types from `verify-jwt.types`
+- `validateToken` from `@lootlog/api-helpers/auth/verify-jwt`
+- JWT verification types from `@lootlog/api-helpers/auth/verify-jwt`
 - `@lootlog/api-helpers/permissions`
 
 ## Development
@@ -25,5 +24,4 @@ pnpm --filter @lootlog/api-helpers build
 
 ## Notes
 
-- Main exports are defined in `src/index.ts`.
 - Token verification is implemented with `jose` and expects either a JWKS object or a remote JWKS URL.

--- a/packages/api-helpers/package.json
+++ b/packages/api-helpers/package.json
@@ -3,21 +3,21 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "auth/verify-jwt": [
+        "./dist/auth/verify-jwt.d.ts"
+      ],
       "permissions": [
         "./dist/permissions.d.ts"
       ]
     }
   },
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+    "./auth/verify-jwt": {
+      "types": "./dist/auth/verify-jwt.d.ts",
+      "import": "./dist/auth/verify-jwt.mjs",
+      "require": "./dist/auth/verify-jwt.js"
     },
     "./permissions": {
       "types": "./dist/permissions.d.ts",
@@ -29,7 +29,6 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "hono": "^4.12.25",
     "jose": "^6.2.2"
   },
   "devDependencies": {

--- a/packages/api-helpers/src/index.ts
+++ b/packages/api-helpers/src/index.ts
@@ -1,4 +1,0 @@
-export * from "./lib/auth/middleware/user-metadata.middleware.js";
-export * from "./lib/auth/utils/verify-jwt.js";
-export * from "./lib/auth/utils/verify-jwt.types.js";
-export * from "./lib/permissions/can-view-npc-timer";

--- a/packages/api-helpers/src/lib/auth/middleware/user-metadata.middleware.ts
+++ b/packages/api-helpers/src/lib/auth/middleware/user-metadata.middleware.ts
@@ -1,8 +1,0 @@
-import { createMiddleware } from "hono/factory";
-
-export const userMetadataFromHeaders = createMiddleware(async (c, next) => {
-  c.set("userId", c.req.raw.headers.get("X-Auth-User-Id"));
-  c.set("discordId", c.req.raw.headers.get("X-Auth-Discord-Id"));
-
-  await next();
-});

--- a/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
+++ b/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
@@ -1,5 +1,14 @@
-import { VerifyTokenOptions, VerifyTokenResponse } from "./verify-jwt.types.js";
 import { jwtVerify, createRemoteJWKSet, createLocalJWKSet } from "jose";
+import type {
+  VerifyTokenOptions,
+  VerifyTokenResponse,
+} from "./verify-jwt.types.js";
+
+export type {
+  JwksKeys,
+  VerifyTokenOptions,
+  VerifyTokenResponse,
+} from "./verify-jwt.types.js";
 
 export async function validateToken({
   token,

--- a/packages/api-helpers/tsdown.config.ts
+++ b/packages/api-helpers/tsdown.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: {
-    index: "src/index.ts",
+    "auth/verify-jwt": "src/lib/auth/utils/verify-jwt.ts",
     permissions: "src/lib/permissions/can-view-npc-timer.ts",
   },
   format: ["esm", "cjs"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1374,9 +1374,6 @@ importers:
 
   packages/api-helpers:
     dependencies:
-      hono:
-        specifier: ^4.12.25
-        version: 4.12.25
       jose:
         specifier: ^6.2.2
         version: 6.2.2
@@ -15307,7 +15304,6 @@ snapshots:
 
   '@lootlog/api-helpers@file:packages/api-helpers':
     dependencies:
-      hono: 4.12.25
       jose: 6.2.3
 
   '@lootlog/nest-shared@file:packages/nest-shared(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(ioredis@5.10.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)':


### PR DESCRIPTION
## Summary

- Removed the re-export-only `@lootlog/api-helpers` root entry and its `src/index.ts` barrel.
- Published the JWT verifier through the concrete `@lootlog/api-helpers/auth/verify-jwt` subpath and updated the auth service/test imports.
- Deleted the unused Hono user metadata middleware and removed the now-unused `hono` dependency.

## Validation

- `corepack pnpm install --frozen-lockfile --lockfile-only --ignore-scripts`
- `corepack pnpm format:check`
- `corepack pnpm --filter @lootlog/api-helpers exec tsc --noEmit`
- `corepack pnpm --filter @lootlog/api-helpers build`
- `corepack pnpm --filter @lootlog/auth lint`
- `corepack pnpm --filter @lootlog/auth test`
- `corepack pnpm lint-staged --diff=HEAD~1`
- `corepack pnpm turbo run lint '--filter=[HEAD^]'`
- `corepack pnpm turbo run test '--filter=[HEAD^]'`

## Note

- `corepack pnpm --filter @lootlog/auth build` and `corepack pnpm turbo run build --filter=@lootlog/auth` still fail in this fresh injected-workspace install because the virtual `@lootlog/nest-shared` package copy does not include its `dist` declarations. That failure occurs before resolving this PR's `api-helpers` import path.