### PR TITLE
[codex] simplify gateway room calculation

### DIFF
--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -91,31 +91,25 @@ export function calculateUserRooms(
 
   for (const { guild, roles } of guilds) {
     const guildRooms: string[] = [];
-    const isOwner = guild.ownerId === discordId;
+    const hasFullGuildAccess =
+      guild.ownerId === discordId || isOwnerOrAdminFromRoles(roles);
 
     // Everyone gets presence and events rooms
     guildRooms.push(buildRoomName(guild.id, "presence"));
     guildRooms.push(buildRoomName(guild.id, "events"));
 
-    // Owner/Admin get all feature rooms + admin room
-    if (isOwner || isOwnerOrAdminFromRoles(roles)) {
+    if (hasFullGuildAccess) {
       guildRooms.push(buildRoomName(guild.id, "admin"));
+    }
+
+    if (hasFullGuildAccess || hasOnlinePlayersAccess(roles)) {
       guildRooms.push(buildRoomName(guild.id, "online-players"));
+    }
 
-      for (const { feature, tier } of applicableFeatures) {
+    for (const { feature, tier } of applicableFeatures) {
+      const requiredPermission = FEATURE_ROOMS[feature][tier];
+      if (hasFullGuildAccess || hasPermission(roles, requiredPermission)) {
         guildRooms.push(buildRoomName(guild.id, feature, tier));
-      }
-    } else {
-      if (hasPermission(roles, Permission.LOOTLOG_ONLINE_PLAYERS_READ)) {
-        guildRooms.push(buildRoomName(guild.id, "online-players"));
-      }
-
-      // Calculate based on specific permissions
-      for (const { feature, tier } of applicableFeatures) {
-        const requiredPermission = FEATURE_ROOMS[feature][tier];
-        if (hasPermission(roles, requiredPermission)) {
-          guildRooms.push(buildRoomName(guild.id, feature, tier));
-        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Simplifies gateway room calculation by using one full-access flag for owner/admin users.
- Reuses the same online-player and feature-room addition paths for full-access and permission-scoped users.
- Keeps room membership behavior unchanged while removing nested branching and duplicated loops.

## Verification

- `pnpm -C apps/gateway exec vitest run --config ./vitest.config.ts src/gateway/utils/room-utils.spec.ts --fileParallelism=false`
- `pnpm --filter @lootlog/gateway exec oxfmt --check src/gateway/utils/room-utils.ts`
- `pnpm turbo run build --filter=@lootlog/gateway`
- `pnpm turbo run lint --filter=@lootlog/gateway`
- `pnpm turbo run test --filter=@lootlog/gateway`
- `.husky/pre-commit`

Notes: gateway has no package-level `format:check` or `check-types` Turbo task, so formatting was checked directly with `oxfmt` and type checking was covered by the Nest gateway build.
