### PR TITLE
[codex] Fix zero battle total reporting

### DIFF
--- a/apps/battlelog-service/src/battles/services/pagination.service.spec.ts
+++ b/apps/battlelog-service/src/battles/services/pagination.service.spec.ts
@@ -192,6 +192,24 @@ describe("PaginationService", () => {
       expect(result.performance.countTime).toBeDefined();
       expect(typeof result.performance.countTime).toBe("number");
       expect(result.pagination.total).toBe(100);
+      expect(result.performance.estimatedTotal).toBe(true);
+    });
+
+    it("should mark zero totals as estimated when includeTotal is true", async () => {
+      drizzleService.db.query.battles.findMany.mockResolvedValue([]);
+      drizzleService.db.execute.mockResolvedValue({
+        rows: [{ estimated_count: "0" }],
+      });
+
+      const result = await service.paginateBattles(() => undefined, {
+        size: 10,
+        sortOrder: "desc",
+        includeTotal: true,
+      });
+
+      expect(result.pagination.total).toBe(0);
+      expect(result.performance.totalItems).toBe(0);
+      expect(result.performance.estimatedTotal).toBe(true);
     });
   });
 });

--- a/apps/battlelog-service/src/battles/services/pagination.service.ts
+++ b/apps/battlelog-service/src/battles/services/pagination.service.ts
@@ -106,7 +106,7 @@ export class PaginationService {
         queryTime,
         countTime: includeTotal ? countTime : undefined,
         totalItems: total,
-        estimatedTotal: !!total,
+        estimatedTotal: total !== undefined,
       },
     };
   }
@@ -203,7 +203,7 @@ export class PaginationService {
           WHERE relname = 'battles'
         `);
         const row = result.rows[0] as { estimated_count: string } | undefined;
-        return Number(row?.estimated_count || 0);
+        return Number(row?.estimated_count ?? 0);
       }
 
       const result = await this.drizzle.db


### PR DESCRIPTION
## Summary

- Report `estimatedTotal` whenever battle pagination total metadata is present, including valid zero totals.
- Use a nullish fallback when parsing the PostgreSQL estimated count row.
- Add regression coverage for `includeTotal` returning an estimated count of `0`.

## Verification

- `pnpm --filter @lootlog/battlelog-service test`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/battlelog-service build`
- `pnpm format:check apps/battlelog-service/src/battles/services/pagination.service.ts apps/battlelog-service/src/battles/services/pagination.service.spec.ts`
- `pnpm lint-staged --diff=HEAD --diff-filter=ACMR`
- `git diff --check`
- Commit pre-commit hooks passed

Note: `pnpm install --frozen-lockfile` populated dependencies but exited after pnpm requested build-script approval for native/tooling dependencies. The targeted tests, lint, format, and builds passed after local dependency setup.