### PR TITLE
[codex] simplify gateway room feature filtering

### DIFF
--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -11,10 +11,6 @@ import { Platform } from "src/gateway/enums/platform.enum";
 export type FeatureName = "chat" | "timers" | "notifications" | "loots";
 export type TierName = NpcRoutingTier;
 
-// Features excluded for web app (they don't need chat/notifications)
-const WEB_EXCLUDED_FEATURES: FeatureName[] = ["chat", "notifications"];
-const GAME_EXCLUDED_FEATURES: FeatureName[] = ["loots"];
-
 const FEATURE_ROOMS = {
   chat: {
     base: Permission.LOOTLOG_CHAT_READ,
@@ -38,11 +34,26 @@ const FEATURE_ROOMS = {
   },
 } as const;
 
+type FeatureRoom = { feature: FeatureName; tier: TierName };
+
 const FEATURE_NAMES = Object.keys(FEATURE_ROOMS) as FeatureName[];
 const TIER_NAMES = Object.keys(FEATURE_ROOMS.chat) as TierName[];
-const ALL_FEATURE_ROOMS = FEATURE_NAMES.flatMap((feature) =>
+const ALL_FEATURE_ROOMS: FeatureRoom[] = FEATURE_NAMES.flatMap((feature) =>
   TIER_NAMES.map((tier) => ({ feature, tier })),
 );
+const PLATFORM_EXCLUDED_FEATURES: Record<Platform, readonly FeatureName[]> = {
+  [Platform.GAME]: ["loots"],
+  [Platform.WEB_APP]: ["chat", "notifications"],
+  [Platform.UNKNOWN]: ["loots"],
+};
+
+function getApplicableFeatureRooms(platform: Platform): FeatureRoom[] {
+  const excludedFeatures = PLATFORM_EXCLUDED_FEATURES[platform];
+
+  return ALL_FEATURE_ROOMS.filter(
+    ({ feature }) => !excludedFeatures.includes(feature),
+  );
+}
 
 export function buildRoomName(
   guildId: string,
@@ -79,15 +90,7 @@ export function calculateUserRooms(
     roomsByGuild: new Map(),
   };
 
-  // Filter features based on platform (web doesn't need chat/notifications)
-  const applicableFeatures =
-    platform === Platform.WEB_APP
-      ? ALL_FEATURE_ROOMS.filter(
-          ({ feature }) => !WEB_EXCLUDED_FEATURES.includes(feature),
-        )
-      : ALL_FEATURE_ROOMS.filter(
-          ({ feature }) => !GAME_EXCLUDED_FEATURES.includes(feature),
-        );
+  const applicableFeatures = getApplicableFeatureRooms(platform);
 
   for (const { guild, roles } of guilds) {
     const guildRooms: string[] = [];


### PR DESCRIPTION
## Summary

- Replaces duplicated platform-specific room feature filtering in `room-utils` with a typed exclusion map.
- Keeps `Platform.UNKNOWN` aligned with the previous non-web behavior by excluding loot rooms like game clients.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt --check apps/gateway/src/gateway/utils/room-utils.ts`
- `corepack pnpm --filter @lootlog/gateway lint`
- `corepack pnpm turbo run build --filter=@lootlog/gateway...`
- `corepack pnpm exec vitest run --config ./vitest.config.ts src/gateway/utils/room-utils.spec.ts` from `apps/gateway`
- `corepack pnpm turbo run test --filter=@lootlog/gateway`
- `corepack pnpm format:check`
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm --filter @lootlog/developer typecheck`
- `corepack pnpm --filter @lootlog/docs typecheck`
- `corepack pnpm --filter @lootlog/landing typecheck`
- `corepack pnpm build`
- Commit hook: lint-staged, changed-package lint, changed-package format task check, changed-package tests

Note: the first full `pnpm build` exposed missing `dist` files in injected workspace package copies after cache replay (`@lootlog/nest-shared`, then `@lootlog/api-helpers`). I forced those package builds to sync injected artifacts and reran the root build successfully.