### PR TITLE
[codex] simplify api helper keyset selection

### DIFF
--- a/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
+++ b/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
@@ -1,5 +1,23 @@
-import { VerifyTokenOptions, VerifyTokenResponse } from "./verify-jwt.types.js";
 import { jwtVerify, createRemoteJWKSet, createLocalJWKSet } from "jose";
+import type {
+  VerifyTokenOptions,
+  VerifyTokenResponse,
+} from "./verify-jwt.types.js";
+
+function createKeyset({
+  jwks,
+  jwksUri,
+}: Pick<VerifyTokenOptions, "jwks" | "jwksUri">) {
+  if (jwks) {
+    return createLocalJWKSet(jwks);
+  }
+
+  if (jwksUri) {
+    return createRemoteJWKSet(new URL(jwksUri));
+  }
+
+  throw new Error("No keyset provided");
+}
 
 export async function validateToken({
   token,
@@ -8,15 +26,7 @@ export async function validateToken({
   issuer,
   audience,
 }: VerifyTokenOptions): Promise<VerifyTokenResponse> {
-  const keyset = jwks
-    ? createLocalJWKSet(jwks)
-    : jwksUri
-      ? createRemoteJWKSet(new URL(jwksUri))
-      : undefined;
-
-  if (!keyset) {
-    throw new Error("No keyset provided");
-  }
+  const keyset = createKeyset({ jwks, jwksUri });
 
   const { payload } = await jwtVerify(token, keyset, {
     issuer,


### PR DESCRIPTION
## Summary

- Replaced the nested JWKS source ternary in `validateToken` with a small guard-clause helper.
- Switched `VerifyTokenOptions` and `VerifyTokenResponse` to a type-only import.
- Preserved existing behavior: local JWKS is preferred over JWKS URI, and missing keysets still throw `No keyset provided`.

## Verification

- `CI=true corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt --write packages/api-helpers/src/lib/auth/utils/verify-jwt.ts`
- `corepack pnpm --filter @lootlog/api-helpers build`
- `corepack pnpm --filter @lootlog/auth test -- src/auth/auth.service.spec.ts`
- `corepack pnpm exec oxlint packages/api-helpers/src/lib/auth/utils/verify-jwt.ts`
- `corepack pnpm exec tsc --noEmit -p packages/api-helpers/tsconfig.json`
- `.husky/pre-commit`