### PR TITLE
[codex] simplify sidebar badge variant

### DIFF
--- a/apps/web/src/components/layout/sidebar-nav/sidebar-nav-item.tsx
+++ b/apps/web/src/components/layout/sidebar-nav/sidebar-nav-item.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@lootlog/ui/components/badge";
 import { Button } from "@lootlog/ui/components/button";
 import { cn } from "@lootlog/ui/lib/utils";
-import { useState } from "react";
+import { type MouseEvent, type ReactNode, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import type { MenuItem } from "./types";
 import { ThemeInteractiveFrame } from "@/themes";
@@ -23,15 +23,16 @@ export const SidebarNavItem = ({
   path: string;
   available: boolean;
   isActive: boolean;
-  icon: React.ReactNode;
+  icon: ReactNode;
   label: string;
   badge?: MenuItem["badge"];
   highlight?: boolean;
   isRukiaTheme: boolean;
   isCatTheme: boolean;
-  onItemClick: (e: React.MouseEvent) => void;
+  onItemClick: (e: MouseEvent) => void;
 }) => {
   const [isHovered, setIsHovered] = useState(false);
+  const badgeVariant = isActive ? "white" : (badge?.variant ?? "default");
 
   const buttonContent = (
     <Button
@@ -59,10 +60,7 @@ export const SidebarNavItem = ({
         {label}
       </div>
       {badge && (
-        <Badge
-          variant={isActive ? "white" : (badge.variant ?? "default")}
-          className="ml-auto"
-        >
+        <Badge variant={badgeVariant} className="ml-auto">
           {badge.content}
         </Badge>
       )}


### PR DESCRIPTION
## Summary
- Replace the sidebar badge nested conditional with a named `badgeVariant` value.
- Import React event/node types inline with `useState` and use those local type names in props.

## Verification
- `pnpm --filter @lootlog/web lint`
- `pnpm exec oxfmt --check apps/web/src/components/layout/sidebar-nav/sidebar-nav-item.tsx`
- `pnpm turbo run build --filter=@lootlog/web`
- `.husky/pre-commit` (also reran during commit)

Notes: the direct `pnpm --filter @lootlog/web build` path fails in a fresh checkout until workspace dependency packages are built; the Turbo-filtered build includes those dependencies and passed. The production build still reports an existing third-party `lottie-web` direct-eval warning.