### PR TITLE
[codex] simplify bento animation helpers

### DIFF
--- a/packages/ui/src/components/bento.tsx
+++ b/packages/ui/src/components/bento.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useRef, useEffect, useState, useCallback } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { gsap } from "gsap";
 import { ImageZoom } from "@lootlog/ui/components/image-zoom";
 
@@ -107,87 +107,87 @@ const ParticleCard: React.FC<{
   const particlesInitialized = useRef(false);
   const magnetismAnimationRef = useRef<gsap.core.Tween | null>(null);
 
-  const initializeParticles = useCallback(() => {
-    if (particlesInitialized.current || !cardRef.current) return;
-
-    const { width, height } = cardRef.current.getBoundingClientRect();
-    memoizedParticles.current = Array.from({ length: particleCount }, () =>
-      createParticleElement(
-        Math.random() * width,
-        Math.random() * height,
-        glowColor,
-      ),
-    );
-    particlesInitialized.current = true;
-  }, [particleCount, glowColor]);
-
-  const clearAllParticles = useCallback(() => {
-    timeoutsRef.current.forEach(clearTimeout);
-    timeoutsRef.current = [];
-    magnetismAnimationRef.current?.kill();
-
-    particlesRef.current.forEach((particle) => {
-      gsap.to(particle, {
-        scale: 0,
-        opacity: 0,
-        duration: 0.3,
-        ease: "back.in(1.7)",
-        onComplete: () => {
-          particle.parentNode?.removeChild(particle);
-        },
-      });
-    });
-    particlesRef.current = [];
-  }, []);
-
-  const animateParticles = useCallback(() => {
-    if (!cardRef.current || !isHoveredRef.current) return;
-
-    if (!particlesInitialized.current) {
-      initializeParticles();
-    }
-
-    memoizedParticles.current.forEach((particle, index) => {
-      const timeoutId = setTimeout(() => {
-        if (!isHoveredRef.current || !cardRef.current) return;
-
-        const clone = particle.cloneNode(true) as HTMLDivElement;
-        cardRef.current.appendChild(clone);
-        particlesRef.current.push(clone);
-
-        gsap.fromTo(
-          clone,
-          { scale: 0, opacity: 0 },
-          { scale: 1, opacity: 1, duration: 0.3, ease: "back.out(1.7)" },
-        );
-
-        gsap.to(clone, {
-          x: (Math.random() - 0.5) * 100,
-          y: (Math.random() - 0.5) * 100,
-          rotation: Math.random() * 360,
-          duration: 2 + Math.random() * 2,
-          ease: "none",
-          repeat: -1,
-          yoyo: true,
-        });
-
-        gsap.to(clone, {
-          opacity: 0.3,
-          duration: 1.5,
-          ease: "power2.inOut",
-          repeat: -1,
-          yoyo: true,
-        });
-      }, index * 100);
-
-      timeoutsRef.current.push(timeoutId);
-    });
-  }, [initializeParticles]);
-
   useEffect(() => {
     if (disableAnimations || !cardRef.current) return;
 
     const element = cardRef.current;
+
+    const initializeParticles = () => {
+      if (particlesInitialized.current || !cardRef.current) return;
+
+      const { width, height } = cardRef.current.getBoundingClientRect();
+      memoizedParticles.current = Array.from({ length: particleCount }, () =>
+        createParticleElement(
+          Math.random() * width,
+          Math.random() * height,
+          glowColor,
+        ),
+      );
+      particlesInitialized.current = true;
+    };
+
+    const clearAllParticles = () => {
+      timeoutsRef.current.forEach(clearTimeout);
+      timeoutsRef.current = [];
+      magnetismAnimationRef.current?.kill();
+
+      particlesRef.current.forEach((particle) => {
+        gsap.to(particle, {
+          scale: 0,
+          opacity: 0,
+          duration: 0.3,
+          ease: "back.in(1.7)",
+          onComplete: () => {
+            particle.parentNode?.removeChild(particle);
+          },
+        });
+      });
+      particlesRef.current = [];
+    };
+
+    const animateParticles = () => {
+      if (!cardRef.current || !isHoveredRef.current) return;
+
+      if (!particlesInitialized.current) {
+        initializeParticles();
+      }
+
+      memoizedParticles.current.forEach((particle, index) => {
+        const timeoutId = setTimeout(() => {
+          if (!isHoveredRef.current || !cardRef.current) return;
+
+          const clone = particle.cloneNode(true) as HTMLDivElement;
+          cardRef.current.appendChild(clone);
+          particlesRef.current.push(clone);
+
+          gsap.fromTo(
+            clone,
+            { scale: 0, opacity: 0 },
+            { scale: 1, opacity: 1, duration: 0.3, ease: "back.out(1.7)" },
+          );
+
+          gsap.to(clone, {
+            x: (Math.random() - 0.5) * 100,
+            y: (Math.random() - 0.5) * 100,
+            rotation: Math.random() * 360,
+            duration: 2 + Math.random() * 2,
+            ease: "none",
+            repeat: -1,
+            yoyo: true,
+          });
+
+          gsap.to(clone, {
+            opacity: 0.3,
+            duration: 1.5,
+            ease: "power2.inOut",
+            repeat: -1,
+            yoyo: true,
+          });
+        }, index * 100);
+
+        timeoutsRef.current.push(timeoutId);
+      });
+    };
 
     const handleMouseEnter = () => {
       isHoveredRef.current = true;
@@ -321,13 +321,12 @@ const ParticleCard: React.FC<{
       clearAllParticles();
     };
   }, [
-    animateParticles,
-    clearAllParticles,
     disableAnimations,
     enableTilt,
     enableMagnetism,
     clickEffect,
     glowColor,
+    particleCount,
   ]);
 
   return (
@@ -396,7 +395,7 @@ const GlobalSpotlight: React.FC<{
         e.clientY >= rect.top &&
         e.clientY <= rect.bottom;
 
-      isInsideSection.current = mouseInside || false;
+      isInsideSection.current = mouseInside ?? false;
       const cards = gridRef.current.querySelectorAll(".card");
 
       if (!mouseInside) {


### PR DESCRIPTION
## Summary

- Move Bento particle animation helper functions inside the effect that owns their event listeners.
- Remove the unnecessary `useCallback` import/wrappers in line with the React Compiler guidance.
- Replace a boolean `|| false` fallback with `?? false` to match repo nullish-coalescing style.

## Verification

- `pnpm --filter @lootlog/ui lint` (passes with existing `npc-tile.tsx` no-img-element warning)
- `pnpm --filter @lootlog/ui exec tsc --noEmit`
- `pnpm exec oxfmt --check packages/ui/src/components/bento.tsx`
- `pnpm turbo run lint --filter=@lootlog/ui` (passes with same existing warning)
- `pnpm turbo run format:check --filter=@lootlog/ui` (no package task executed)
- `pnpm turbo run test --filter=@lootlog/ui` (no package task executed)
- `git diff --check`
- Husky pre-commit hook via `git commit`