### PR TITLE
[codex] simplify theme overlay generators

### DIFF
--- a/packages/ui/src/components/cat-paw-overlay.tsx
+++ b/packages/ui/src/components/cat-paw-overlay.tsx
@@ -41,71 +41,81 @@ export function useCatTheme() {
   return isCat;
 }
 
+type CatPaw = {
+  id: string;
+  left: string;
+  top: string;
+  size: number;
+  rotation: number;
+  opacity: number;
+};
+
+function createCatPaws(id: string): CatPaw[] {
+  const rand = seededRandom(hashString(id));
+
+  for (let i = 0; i < 20; i++) rand();
+
+  const result: CatPaw[] = [];
+
+  const startX = rand() * 100;
+  const startY = rand() * 100;
+
+  let walkAngle = rand() * Math.PI * 2;
+
+  const curveBias = (rand() - 0.5) * 0.6;
+
+  const baseSize = 35 + rand() * 15;
+  const baseOpacity = 0.03 + rand() * 0.03;
+  const steps = 12 + Math.floor(rand() * 8);
+
+  const strideForwardPx = baseSize * 0.75;
+  const strideLateralPx = baseSize * 0.6;
+  const pawRotationOutward = 12;
+
+  let bodyAccumulatedX = 0;
+  let bodyAccumulatedY = 0;
+
+  for (let i = 0; i < steps; i++) {
+    const isRightPaw = i % 2 === 0;
+
+    walkAngle += curveBias + (rand() - 0.5) * 0.15;
+
+    bodyAccumulatedX += Math.cos(walkAngle) * strideForwardPx;
+    bodyAccumulatedY += Math.sin(walkAngle) * strideForwardPx;
+
+    const perpendicularAngle = walkAngle + Math.PI / 2;
+    const sideOffset = isRightPaw ? strideLateralPx : -strideLateralPx;
+
+    const pawX = bodyAccumulatedX + Math.cos(perpendicularAngle) * sideOffset;
+    const pawY = bodyAccumulatedY + Math.sin(perpendicularAngle) * sideOffset;
+
+    const angleInDegrees = walkAngle * (180 / Math.PI) + 90;
+    const pawRotation =
+      angleInDegrees + (isRightPaw ? pawRotationOutward : -pawRotationOutward);
+
+    const signX = pawX >= 0 ? "+" : "-";
+    const signY = pawY >= 0 ? "+" : "-";
+
+    result.push({
+      id: `paw-${i}`,
+      left: `calc(${startX}% ${signX} ${Math.abs(pawX)}px)`,
+      top: `calc(${startY}% ${signY} ${Math.abs(pawY)}px)`,
+      size: baseSize + (rand() * 4 - 2),
+      rotation: pawRotation,
+      opacity: baseOpacity,
+    });
+  }
+
+  return result;
+}
+
 export function CatPawOverlay() {
   const isCatTheme = useCatTheme();
   const id = React.useId();
 
-  const paws = React.useMemo(() => {
-    const rand = seededRandom(hashString(id));
-
-    for (let i = 0; i < 20; i++) rand();
-
-    const result = [];
-
-    const startX = rand() * 100;
-    const startY = rand() * 100;
-
-    let walkAngle = rand() * Math.PI * 2;
-
-    const curveBias = (rand() - 0.5) * 0.6;
-
-    const baseSize = 35 + rand() * 15;
-    const baseOpacity = 0.03 + rand() * 0.03;
-    const steps = 12 + Math.floor(rand() * 8);
-
-    const strideForwardPx = baseSize * 0.75;
-    const strideLateralPx = baseSize * 0.6;
-    const pawRotationOutward = 12;
-
-    let bodyAccumulatedX = 0;
-    let bodyAccumulatedY = 0;
-
-    for (let i = 0; i < steps; i++) {
-      const isRightPaw = i % 2 === 0;
-
-      walkAngle += curveBias + (rand() - 0.5) * 0.15;
-
-      bodyAccumulatedX += Math.cos(walkAngle) * strideForwardPx;
-      bodyAccumulatedY += Math.sin(walkAngle) * strideForwardPx;
-
-      const perpendicularAngle = walkAngle + Math.PI / 2;
-      const sideOffset = isRightPaw ? strideLateralPx : -strideLateralPx;
-
-      const pawX = bodyAccumulatedX + Math.cos(perpendicularAngle) * sideOffset;
-      const pawY = bodyAccumulatedY + Math.sin(perpendicularAngle) * sideOffset;
-
-      const angleInDegrees = walkAngle * (180 / Math.PI) + 90;
-      const pawRotation =
-        angleInDegrees +
-        (isRightPaw ? pawRotationOutward : -pawRotationOutward);
-
-      const signX = pawX >= 0 ? "+" : "-";
-      const signY = pawY >= 0 ? "+" : "-";
-
-      result.push({
-        id: `paw-${i}`,
-        left: `calc(${startX}% ${signX} ${Math.abs(pawX)}px)`,
-        top: `calc(${startY}% ${signY} ${Math.abs(pawY)}px)`,
-        size: baseSize + (rand() * 4 - 2),
-        rotation: pawRotation,
-        opacity: baseOpacity,
-      });
-    }
-
-    return result;
-  }, [id]);
-
   if (!isCatTheme) return null;
+
+  const paws = createCatPaws(id);
 
   return (
     <div

--- a/packages/ui/src/components/rias-magic-card-overlay.tsx
+++ b/packages/ui/src/components/rias-magic-card-overlay.tsx
@@ -43,45 +43,48 @@ const MAGIC_CIRCLE_SVG =
 const ENERGY_PARTICLE_SVG =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Ccircle cx='4' cy='4' r='3' fill='white' opacity='0.6'/%3E%3Ccircle cx='4' cy='4' r='1.5' fill='white' opacity='0.9'/%3E%3C/svg%3E";
 
+type RiasMagicElement = {
+  id: string;
+  left: string;
+  top: string;
+  size: number;
+  rotation: number;
+  opacity: number;
+  type: "circle" | "particle";
+};
+
+function createRiasMagicElements(id: string): RiasMagicElement[] {
+  const rand = seededRandom(hashString(id));
+
+  for (let i = 0; i < 20; i++) rand();
+
+  const result: RiasMagicElement[] = [];
+  const count = 5 + Math.floor(rand() * 4);
+
+  for (let i = 0; i < count; i++) {
+    const type = rand() > 0.5 ? "circle" : "particle";
+
+    result.push({
+      id: `rias-${i}`,
+      left: `${rand() * 100}%`,
+      top: `${rand() * 100}%`,
+      size: type === "circle" ? 20 + rand() * 16 : 8 + rand() * 6,
+      rotation: rand() * 360,
+      opacity: 0.02 + rand() * 0.02,
+      type,
+    });
+  }
+
+  return result;
+}
+
 export function RiasMagicCardOverlay() {
   const isRiasTheme = useRiasTheme();
   const id = React.useId();
 
-  const elements = React.useMemo(() => {
-    const rand = seededRandom(hashString(id));
-
-    for (let i = 0; i < 20; i++) rand();
-
-    const result: Array<{
-      id: string;
-      left: string;
-      top: string;
-      size: number;
-      rotation: number;
-      opacity: number;
-      type: "circle" | "particle";
-    }> = [];
-
-    const count = 5 + Math.floor(rand() * 4);
-
-    for (let i = 0; i < count; i++) {
-      const type = rand() > 0.5 ? "circle" : "particle";
-
-      result.push({
-        id: `rias-${i}`,
-        left: `${rand() * 100}%`,
-        top: `${rand() * 100}%`,
-        size: type === "circle" ? 20 + rand() * 16 : 8 + rand() * 6,
-        rotation: rand() * 360,
-        opacity: 0.02 + rand() * 0.02,
-        type,
-      });
-    }
-
-    return result;
-  }, [id]);
-
   if (!isRiasTheme) return null;
+
+  const elements = createRiasMagicElements(id);
 
   return (
     <div

--- a/packages/ui/src/components/rukia-frost-card-overlay.tsx
+++ b/packages/ui/src/components/rukia-frost-card-overlay.tsx
@@ -41,45 +41,48 @@ const SNOWFLAKE_SVG =
 const CRYSTAL_SVG =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 0 L9 6 L15 6 L10 9 L12 16 L8 11 L4 16 L6 9 L1 6 L7 6 Z' fill='white'/%3E%3C/svg%3E";
 
+type RukiaFrostElement = {
+  id: string;
+  left: string;
+  top: string;
+  size: number;
+  rotation: number;
+  opacity: number;
+  type: "snowflake" | "crystal";
+};
+
+function createRukiaFrostElements(id: string): RukiaFrostElement[] {
+  const rand = seededRandom(hashString(id));
+
+  for (let i = 0; i < 20; i++) rand();
+
+  const result: RukiaFrostElement[] = [];
+  const count = 6 + Math.floor(rand() * 4);
+
+  for (let i = 0; i < count; i++) {
+    const type = rand() > 0.4 ? "snowflake" : "crystal";
+
+    result.push({
+      id: `frost-${i}`,
+      left: `${rand() * 100}%`,
+      top: `${rand() * 100}%`,
+      size: type === "snowflake" ? 18 + rand() * 14 : 10 + rand() * 8,
+      rotation: rand() * 360,
+      opacity: 0.025 + rand() * 0.025,
+      type,
+    });
+  }
+
+  return result;
+}
+
 export function RukiaFrostCardOverlay() {
   const isRukiaTheme = useRukiaTheme();
   const id = React.useId();
 
-  const elements = React.useMemo(() => {
-    const rand = seededRandom(hashString(id));
-
-    for (let i = 0; i < 20; i++) rand();
-
-    const result: Array<{
-      id: string;
-      left: string;
-      top: string;
-      size: number;
-      rotation: number;
-      opacity: number;
-      type: "snowflake" | "crystal";
-    }> = [];
-
-    const count = 6 + Math.floor(rand() * 4);
-
-    for (let i = 0; i < count; i++) {
-      const type = rand() > 0.4 ? "snowflake" : "crystal";
-
-      result.push({
-        id: `frost-${i}`,
-        left: `${rand() * 100}%`,
-        top: `${rand() * 100}%`,
-        size: type === "snowflake" ? 18 + rand() * 14 : 10 + rand() * 8,
-        rotation: rand() * 360,
-        opacity: 0.025 + rand() * 0.025,
-        type,
-      });
-    }
-
-    return result;
-  }, [id]);
-
   if (!isRukiaTheme) return null;
+
+  const elements = createRukiaFrostElements(id);
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Move seeded theme overlay element generation into named pure helpers.
- Remove manual `React.useMemo` wrappers from the overlay components.
- Skip deterministic overlay element generation until the matching theme is active.

## Verification

- `pnpm exec oxfmt --check packages/ui/src/components/rias-magic-card-overlay.tsx packages/ui/src/components/rukia-frost-card-overlay.tsx packages/ui/src/components/cat-paw-overlay.tsx`
- `pnpm --filter @lootlog/ui lint`
- `pnpm --filter @lootlog/ui exec tsc --noEmit`
- `git diff --check`
- `pnpm turbo run lint --filter=@lootlog/ui`
- `pnpm turbo run build --filter=...@lootlog/ui`
- `pnpm turbo run test --filter=@lootlog/ui` (no package test task configured)
- Husky pre-commit checks during `git commit`

## Notes

- `pnpm install --frozen-lockfile` linked dependencies but exited nonzero on pending pnpm build-script approvals; the generated `allowBuilds` metadata was not kept.
- `@lootlog/ui` lint reports an existing warning in `src/components/npc-tile.tsx` but exits successfully.