### PR TITLE
[codex] Extract notification update field helper

### DIFF
--- a/apps/api/src/notifications/notification-rule.service.ts
+++ b/apps/api/src/notifications/notification-rule.service.ts
@@ -29,6 +29,7 @@ import {
   isValidTimeZone,
 } from "src/notifications/utils/notification-schedule-time.util";
 import { ensureLimitNotExceeded } from "src/notifications/utils/ensure-limit-not-exceeded.util";
+import { hasOwnUpdateField } from "src/notifications/utils/has-own-update-field.util";
 import {
   type TestTriggerUsage,
   computeTestTriggerUsage,
@@ -40,13 +41,6 @@ const GUILD_NOTIFICATION_TEST_TRIGGER_LIMIT = 10;
 const GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_MS = 15 * 60_000;
 const GUILD_NOTIFICATION_MAX_NPCS_PER_RULE = 5;
 const USER_NOTIFICATION_RULE_LIMIT = 50;
-
-function hasUpdateRuleField(
-  data: UpdateNotificationRuleDto,
-  field: keyof UpdateNotificationRuleDto,
-) {
-  return Object.prototype.hasOwnProperty.call(data, field);
-}
 
 @Injectable()
 export class NotificationRuleService {
@@ -379,9 +373,9 @@ export class NotificationRuleService {
     ruleId: number,
     data: UpdateNotificationRuleDto,
   ) {
-    const hasName = hasUpdateRuleField(data, "name");
-    const hasWorld = hasUpdateRuleField(data, "world");
-    const hasContentTemplate = hasUpdateRuleField(data, "contentTemplate");
+    const hasName = hasOwnUpdateField(data, "name");
+    const hasWorld = hasOwnUpdateField(data, "world");
+    const hasContentTemplate = hasOwnUpdateField(data, "contentTemplate");
     const existingRule = await this.ensureRule({ ownerType, ownerId, ruleId });
     const nextTriggerType =
       (data.triggerType as DbNotificationTriggerType | undefined) ??
@@ -772,7 +766,7 @@ export class NotificationRuleService {
       data.scheduleWeekday ?? existingRule?.scheduleWeekday ?? null;
     const timeOfDay =
       data.scheduleTimeOfDay ?? existingRule?.scheduleTimeOfDay ?? null;
-    const hasScheduledUntil = hasUpdateRuleField(data, "scheduledUntil");
+    const hasScheduledUntil = hasOwnUpdateField(data, "scheduledUntil");
     let scheduledUntil = existingRule?.scheduledUntil ?? null;
 
     if (hasScheduledUntil) {

--- a/apps/api/src/notifications/notification-target.service.ts
+++ b/apps/api/src/notifications/notification-target.service.ts
@@ -31,6 +31,7 @@ import {
   computeTestTriggerUsage,
   getDefaultTestTriggerUsage,
 } from "src/notifications/utils/test-trigger-usage.util";
+import { hasOwnUpdateField } from "src/notifications/utils/has-own-update-field.util";
 
 const USER_DM_TEST_TRIGGER_LIMIT = 5;
 const USER_DM_TEST_TRIGGER_WINDOW_MS = 15 * 60_000;
@@ -420,7 +421,7 @@ export class NotificationTargetService {
   private getDisplayNameUpdate(
     data: Pick<UpdateNotificationTargetDto, "displayName">,
   ): Pick<Prisma.NotificationTargetUpdateInput, "displayName"> {
-    if (!Object.prototype.hasOwnProperty.call(data, "displayName")) {
+    if (!hasOwnUpdateField(data, "displayName")) {
       return {};
     }
 

--- a/apps/api/src/notifications/utils/has-own-update-field.util.spec.ts
+++ b/apps/api/src/notifications/utils/has-own-update-field.util.spec.ts
@@ -1,0 +1,21 @@
+import { hasOwnUpdateField } from "./has-own-update-field.util";
+
+describe("hasOwnUpdateField", () => {
+  it("detects nullable fields explicitly present in partial update data", () => {
+    expect(hasOwnUpdateField({ displayName: null }, "displayName")).toBe(true);
+  });
+
+  it("returns false when the partial update field is omitted", () => {
+    const updateData: { displayName?: string | null } = {};
+
+    expect(hasOwnUpdateField(updateData, "displayName")).toBe(false);
+  });
+
+  it("ignores fields inherited from the prototype chain", () => {
+    const updateData = Object.create({
+      displayName: "inherited",
+    }) as { displayName?: string };
+
+    expect(hasOwnUpdateField(updateData, "displayName")).toBe(false);
+  });
+});

--- a/apps/api/src/notifications/utils/has-own-update-field.util.ts
+++ b/apps/api/src/notifications/utils/has-own-update-field.util.ts
@@ -1,0 +1,6 @@
+export function hasOwnUpdateField<TData extends object>(
+  data: TData,
+  field: keyof TData,
+) {
+  return Object.prototype.hasOwnProperty.call(data, field);
+}


### PR DESCRIPTION
## Summary
- Added a shared notification helper for own-field checks in partial update DTOs.
- Replaced duplicated raw `Object.prototype.hasOwnProperty.call` checks in notification rule and target services.
- Added focused coverage for nullable, omitted, and inherited update fields.

## Verification
- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/notifications/utils/has-own-update-field.util.spec.ts`
- `pnpm --filter @lootlog/api format`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm turbo run build --filter=@lootlog/api... --ui=stream`
- `pnpm turbo run lint --filter=@lootlog/api... --ui=stream` (passes with existing warnings)
- `pnpm turbo run format:check --filter=@lootlog/api... --ui=stream` (no package scripts in scope)
- `pnpm turbo run check-types --filter=@lootlog/api... --ui=stream` (no package scripts in scope; API build ran Nest/TSC and found 0 issues)
- `pnpm --filter @lootlog/api test`
- `pnpm turbo run test --filter=@lootlog/api... --ui=stream`
- Pre-commit hook: `lint-staged`, `turbo run lint --filter=[HEAD]`, `turbo run format:check --filter=[HEAD]`, `turbo run test --filter=[HEAD]`