### PR TITLE
[codex] consolidate notification model imports

### DIFF
--- a/apps/web/src/features/guild/notifications/components/notification-rule-card.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-rule-card.tsx
@@ -24,6 +24,7 @@ import { useGuildId } from "@/hooks/context/use-guild-id";
 import {
   CreateNotificationRuleDtoScheduleIntervalType as NotificationScheduleIntervalType,
   CreateNotificationRuleDtoTriggerType as NotificationTriggerType,
+  type GuildNotificationRulesResponseDto,
 } from "@/lib/api/generated/main/model";
 import {
   getGuildNotificationRuleNpcCount,
@@ -45,7 +46,6 @@ import {
   useNotificationsGuildControllerRebuildGuildRuleJobs,
   useNotificationsGuildControllerTriggerGuildRuleTest,
 } from "@/lib/api/generated/main/notifications/notifications";
-import type { GuildNotificationRulesResponseDto } from "@/lib/api/generated/main/model";
 
 type NotificationRuleCardProps = {
   rule: GuildNotificationRulesResponseDto["items"][number];

--- a/apps/web/src/features/guild/notifications/components/notification-template-editor.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-template-editor.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import {
   CreateNotificationRuleDtoTriggerType as NotificationTriggerType,
   type CreateNotificationRuleDtoTriggerType,
+  type RoleResponseDtoOutput as GuildRole,
 } from "@/lib/api/generated/main/model";
 import {
   TIMER_PRESET_SIMPLE,
@@ -64,7 +65,6 @@ import {
   removeTemplateTokenNode,
   SCHEDULED_MESSAGE_VARIABLE_KEYS,
 } from "./notification-template-editor.utils";
-import type { RoleResponseDtoOutput as GuildRole } from "@/lib/api/generated/main/model";
 
 type NotificationTemplateEditorProps = {
   value: string;

--- a/apps/web/src/features/guild/notifications/utils/notification-settings.utils.ts
+++ b/apps/web/src/features/guild/notifications/utils/notification-settings.utils.ts
@@ -1,14 +1,12 @@
 import type { BadgeProps } from "@lootlog/ui/components/badge";
-import type {
-  CreateNotificationRuleDtoScheduleAnchor,
-  CreateNotificationRuleDtoTriggerType,
-  GuildNotificationRulesResponseDto,
-  NotificationJobsResponseDto,
-  NotificationTargetResponseDto,
-} from "@/lib/api/generated/main/model";
 import {
   CreateNotificationRuleDtoScheduleAnchor as NotificationScheduleAnchor,
   CreateNotificationRuleDtoTriggerType as NotificationTriggerType,
+  type CreateNotificationRuleDtoScheduleAnchor,
+  type CreateNotificationRuleDtoTriggerType,
+  type GuildNotificationRulesResponseDto,
+  type NotificationJobsResponseDto,
+  type NotificationTargetResponseDto,
 } from "@/lib/api/generated/main/model";
 
 type GuildNotificationTarget = NotificationTargetResponseDto;


### PR DESCRIPTION
## Summary
- Consolidates duplicate imports from `@/lib/api/generated/main/model` in three guild notification files.
- Uses inline `type` specifiers so value and type imports stay in a single import block per repository style.

## Impact
- No runtime behavior changes; this is an import-only refactor.
- Keeps generated-model import sections easier to scan and avoids split imports from the same module.

## Verification
- `pnpm exec oxfmt --check apps/web/src/features/guild/notifications/components/notification-template-editor.tsx apps/web/src/features/guild/notifications/components/notification-rule-card.tsx apps/web/src/features/guild/notifications/utils/notification-settings.utils.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web exec vitest run src/features/guild/notifications/utils/notification-rule-form-npc.utils.spec.ts src/features/guild/notifications/utils/notification-rule-form.schema.spec.ts src/features/guild/notifications/utils/notification-schedule-time.utils.spec.ts`
- `pnpm turbo run build --filter=@lootlog/web...`
- `git commit` pre-commit hook passed (`lint-staged`, changed-package lint, format check, tests).