### PR TITLE
[codex] use nullish defaults in battle filters

### DIFF
--- a/apps/battlelog-service/src/battles/services/battle-list-filter.service.ts
+++ b/apps/battlelog-service/src/battles/services/battle-list-filter.service.ts
@@ -29,7 +29,7 @@ export class BattleListFilterService {
     query: QueryBattlesDto,
     userId?: string,
   ): Promise<BattleListWhereBuilder> {
-    let characterIds = query.characterId || [];
+    let characterIds = query.characterId ?? [];
     if (query.result?.length && !characterIds.length && userId) {
       const userChars = await this.drizzle.db.query.userCharacters.findMany({
         where: { userId },

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters.tsx
@@ -42,7 +42,7 @@ export const BattlesListFilters = ({
   const worlds = worldsResponse?.worlds ?? [];
 
   const handleCharacterChange = (value: string) => {
-    const currentCharacters = filters.characterId || [];
+    const currentCharacters = filters.characterId ?? [];
     const newCharacters = currentCharacters.includes(value)
       ? currentCharacters.filter((id) => id !== value)
       : [...currentCharacters, value];
@@ -54,7 +54,7 @@ export const BattlesListFilters = ({
   };
 
   const handleTypeChange = (value: "solo" | "group") => {
-    const currentTypes = filters.type || [];
+    const currentTypes = filters.type ?? [];
     const newTypes = currentTypes.includes(value)
       ? currentTypes.filter((t) => t !== value)
       : [...currentTypes, value];
@@ -66,7 +66,7 @@ export const BattlesListFilters = ({
   };
 
   const handleResultChange = (value: "won" | "lost" | "flee") => {
-    const currentResults = filters.result || [];
+    const currentResults = filters.result ?? [];
     const newResults = currentResults.includes(value)
       ? currentResults.filter((r) => r !== value)
       : [...currentResults, value];
@@ -135,9 +135,9 @@ export const BattlesListFilters = ({
   };
 
   const activeFiltersCount =
-    (filters.characterId?.length || 0) +
-    (filters.type?.length || 0) +
-    (filters.result?.length || 0) +
+    (filters.characterId?.length ?? 0) +
+    (filters.type?.length ?? 0) +
+    (filters.result?.length ?? 0) +
     (filters.world ? 1 : 0) +
     (filters.ph ? 1 : 0) +
     (filters.matchmaking ? 1 : 0) +
@@ -149,7 +149,7 @@ export const BattlesListFilters = ({
   ) => {
     return (open: boolean) => {
       const now = Date.now();
-      const lastChange = lastStateChangeRef.current[key] || 0;
+      const lastChange = lastStateChangeRef.current[key] ?? 0;
       const timeSinceLastChange = now - lastChange;
 
       if (timeSinceLastChange < 100) {


### PR DESCRIPTION
## Summary

- Replace `|| []` defaults with `?? []` for battle filter arrays in the web filter component and battlelog service.
- Replace `|| 0` with `?? 0` for optional battle filter counts and debounce timestamps.

## Impact

This keeps optional/default handling aligned with the repo style guide and avoids collapsing valid falsy values while preserving the existing behavior for undefined filters.

## Verification

- `pnpm --filter @lootlog/nest-shared build`
- `pnpm turbo run lint build --filter=@lootlog/web --filter=@lootlog/battlelog-service`
- `pnpm --filter @lootlog/battlelog-service test`
- `.husky/pre-commit`

Notes: the first dependency install populated missing `node_modules` but exited at pnpm's build-script approval gate; the checks passed after dependencies were available. `@lootlog/ui` still reports an existing cached `no-img-element` warning during changed-package lint, and the web production build still reports existing third-party `lottie-web` direct-eval/plugin-timing warnings.