### PR TITLE
[codex] simplify api client json content checks

### DIFF
--- a/apps/game-client/src/lib/api-client.test.ts
+++ b/apps/game-client/src/lib/api-client.test.ts
@@ -64,6 +64,24 @@ describe("api-client", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  it("parses JSON response subtypes", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Validation failed" }), {
+        status: 200,
+        headers: {
+          "content-type": "application/problem+json",
+        },
+      }),
+    );
+
+    await expect(
+      executeApiRequest<{ detail: string }>({
+        url: new URL("https://api.example.com/fail"),
+        method: "GET",
+      }),
+    ).resolves.toEqual({ detail: "Validation failed" });
+  });
+
   it("returns raw text for non-json responses", async () => {
     mockFetch.mockResolvedValue(
       new Response("plain-text-response", {

--- a/apps/game-client/src/lib/api-client.ts
+++ b/apps/game-client/src/lib/api-client.ts
@@ -137,6 +137,16 @@ const getApiMessageFromData = (data: unknown): string | undefined => {
   return normalizedMessage.trim().length > 0 ? normalizedMessage : undefined;
 };
 
+const isJsonContentType = (contentType: string | null) => {
+  if (!contentType) {
+    return false;
+  }
+
+  return (
+    contentType.includes("application/json") || contentType.includes("+json")
+  );
+};
+
 const parseResponseBody = (
   responseText: string,
   contentType: string | null,
@@ -145,11 +155,7 @@ const parseResponseBody = (
     return undefined;
   }
 
-  const isJsonResponse =
-    contentType?.includes("application/json") === true ||
-    contentType?.includes("+json") === true;
-
-  if (!isJsonResponse) {
+  if (!isJsonContentType(contentType)) {
     return responseText;
   }
 

--- a/apps/web/src/lib/api-client/api-client.spec.ts
+++ b/apps/web/src/lib/api-client/api-client.spec.ts
@@ -1,7 +1,22 @@
-import { describe, expect, it } from "vitest";
-import { buildRequestUrl } from "./api-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildRequestUrl, executeApiRequest } from "./api-client";
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: {
+      social: vi.fn(),
+    },
+  },
+}));
+
+const mockFetch = vi.fn<typeof fetch>();
 
 describe("buildRequestUrl", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
   it("keeps the API base path for paths starting with a slash", () => {
     const url = buildRequestUrl({
       baseURL: "http://localhost/api/lootlog",
@@ -47,5 +62,23 @@ describe("buildRequestUrl", () => {
     expect(url.toString()).toBe(
       "http://localhost/api/lootlog/users/@me/preferences?include=theme&include=colorMode&page=2",
     );
+  });
+
+  it("parses JSON response subtypes", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "Reauthentication required" }), {
+        status: 200,
+        headers: {
+          "content-type": "application/problem+json",
+        },
+      }),
+    );
+
+    await expect(
+      executeApiRequest<{ detail: string }>({
+        url: new URL("https://api.example.com/session"),
+        method: "GET",
+      }),
+    ).resolves.toEqual({ detail: "Reauthentication required" });
   });
 });

--- a/apps/web/src/lib/api-client/api-client.ts
+++ b/apps/web/src/lib/api-client/api-client.ts
@@ -121,6 +121,16 @@ const getApiMessageFromData = (data: unknown): string | undefined => {
   return normalizedMessage.trim().length > 0 ? normalizedMessage : undefined;
 };
 
+const isJsonContentType = (contentType: string | null) => {
+  if (!contentType) {
+    return false;
+  }
+
+  return (
+    contentType.includes("application/json") || contentType.includes("+json")
+  );
+};
+
 const parseResponseBody = (
   responseText: string,
   contentType: string | null,
@@ -129,11 +139,7 @@ const parseResponseBody = (
     return undefined;
   }
 
-  const isJsonResponse =
-    contentType?.includes("application/json") === true ||
-    contentType?.includes("+json") === true;
-
-  if (!isJsonResponse) {
+  if (!isJsonContentType(contentType)) {
     return responseText;
   }
 


### PR DESCRIPTION
## Summary

- Extracted an `isJsonContentType` helper in the web and game-client API clients.
- Replaced the inline optional-chaining boolean comparisons in response parsing with an intent-named guard.
- Added coverage for `application/problem+json` response parsing in both API client specs.
- Mocked the web auth client in the API client spec so the test can import the module without runtime auth env.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt apps/web/src/lib/api-client/api-client.ts apps/web/src/lib/api-client/api-client.spec.ts apps/game-client/src/lib/api-client.ts apps/game-client/src/lib/api-client.test.ts`
- `corepack pnpm --filter @lootlog/types build`
- `corepack pnpm --filter @lootlog/game-client exec vitest run src/lib/api-client.test.ts`
- `corepack pnpm --filter @lootlog/web exec vitest run src/lib/api-client/api-client.spec.ts`
- `corepack pnpm --filter @lootlog/web lint`
- `corepack pnpm exec turbo run build --filter=@lootlog/web --filter=@lootlog/game-client`
- `corepack pnpm format:check`
- `corepack pnpm lint`
- `corepack pnpm --filter @lootlog/game-client test`
- `sh .husky/pre-commit`