### PR TITLE
[codex] remove window title callback memo

### DIFF
--- a/apps/game-client/src/components/window-title-bar.tsx
+++ b/apps/game-client/src/components/window-title-bar.tsx
@@ -1,4 +1,4 @@
-import { type FC, useCallback } from "react";
+import type { FC } from "react";
 import { Blend, Lock, Unlock, XIcon } from "lucide-react";
 import {
   Tooltip,
@@ -34,11 +34,11 @@ export const WindowTitleBar: FC<WindowTitleBarProps> = ({
   onTouchStart,
 }) => {
   const { t } = useTranslation("common");
-  const handleOpacityChange = useCallback(() => {
+  const handleOpacityChange = () => {
     const currentIndex = OPACITY_LEVELS.indexOf(opacity);
     const nextIndex = (currentIndex + 1) % OPACITY_LEVELS.length;
     onOpacityChange(OPACITY_LEVELS[nextIndex]);
-  }, [opacity, onOpacityChange]);
+  };
 
   return (
     <div


### PR DESCRIPTION
## Summary

- Removed the unnecessary `useCallback` wrapper from the game client `WindowTitleBar` opacity handler.
- Switched the React import to a type-only `FC` import, matching the repo's React Compiler guidance to avoid manual memoization.

## Verification

- `corepack pnpm turbo run build --filter=@lootlog/game-client...`
- `corepack pnpm --filter @lootlog/game-client test`
- `corepack pnpm format:check`
- `corepack pnpm lint` (passed with existing warnings)
- Pre-commit hook passed during `git commit`, including lint-staged and changed-package tests.