### PR TITLE
[codex] refactor: simplify battle table header rendering

### DIFF
--- a/apps/web/src/components/battle/expandable-data-table.tsx
+++ b/apps/web/src/components/battle/expandable-data-table.tsx
@@ -70,39 +70,45 @@ export function ExpandableDataTable<TData, TValue>({
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort();
                   const sortDirection = header.column.getIsSorted();
+                  let headerContent: React.ReactNode = null;
 
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder ? null : canSort ? (
+                  if (!header.isPlaceholder) {
+                    const renderedHeader = flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    );
+
+                    if (canSort) {
+                      let sortIcon = (
+                        <ArrowUpDown className="h-4 w-4 opacity-50" />
+                      );
+
+                      if (sortDirection === "asc") {
+                        sortIcon = <ArrowUp className="h-4 w-4" />;
+                      } else if (sortDirection === "desc") {
+                        sortIcon = <ArrowDown className="h-4 w-4" />;
+                      }
+
+                      headerContent = (
                         <button
                           type="button"
                           className="flex w-full items-center gap-2 cursor-pointer select-none hover:bg-gray-400/10 p-2 -m-2 rounded text-left"
                           onClick={header.column.getToggleSortingHandler()}
                         >
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                          <span className="ml-auto">
-                            {sortDirection === "asc" ? (
-                              <ArrowUp className="h-4 w-4" />
-                            ) : sortDirection === "desc" ? (
-                              <ArrowDown className="h-4 w-4" />
-                            ) : (
-                              <ArrowUpDown className="h-4 w-4 opacity-50" />
-                            )}
-                          </span>
+                          {renderedHeader}
+                          <span className="ml-auto">{sortIcon}</span>
                         </button>
-                      ) : (
-                        <div className={cn("flex items-center gap-2")}>
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
+                      );
+                    } else {
+                      headerContent = (
+                        <div className="flex items-center gap-2">
+                          {renderedHeader}
                         </div>
-                      )}
-                    </TableHead>
-                  );
+                      );
+                    }
+                  }
+
+                  return <TableHead key={header.id}>{headerContent}</TableHead>;
                 })}
               </TableRow>
             ))}


### PR DESCRIPTION
## Summary

- Simplifies `ExpandableDataTable` header rendering by replacing nested JSX ternaries with explicit `headerContent` and `sortIcon` variables.
- Preserves sortable header behavior and placeholder handling while making the control flow easier to follow.

## Verification

- `pnpm exec oxfmt --check apps/web/src/components/battle/expandable-data-table.tsx`
- `pnpm turbo run build --filter=@lootlog/web`
- `pnpm turbo run lint --filter=@lootlog/web`
- Pre-commit hook: `pnpm lint-staged`, `pnpm turbo run lint --filter=[HEAD]`, `pnpm turbo run format:check --filter=[HEAD]`, `pnpm turbo run test --filter=[HEAD]`

Notes: `pnpm --filter @lootlog/web build` was not sufficient because it does not build workspace dependencies first; the Turbo build succeeded. The changed-package `format:check` hook currently reports no package task for `@lootlog/web`, so the file-level `oxfmt --check` is the meaningful formatting check for this change.