### PR TITLE
[codex] refactor(web): simplify world switcher options

### DIFF
--- a/apps/web/src/components/common/world-switcher.tsx
+++ b/apps/web/src/components/common/world-switcher.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocalStorage } from "usehooks-ts";
 import { FilterPopover } from "@lootlog/ui/components/filter-popover";
@@ -34,7 +34,7 @@ export const WorldSwitcher: React.FC<WorldSwitcherProps> = ({
   const { data: fetchedWorlds } = useGuildsControllerGetWorldsByGuildId({
     guildId: guildId ?? "",
   });
-  const worlds = externalWorlds ?? fetchedWorlds;
+  const worlds = externalWorlds ?? fetchedWorlds ?? [];
   const guildContext = useContext(GuildContext);
   const contextWorld = guildContext?.world ?? "";
   const setContextWorld = guildContext?.setWorld;
@@ -44,32 +44,28 @@ export const WorldSwitcher: React.FC<WorldSwitcherProps> = ({
   const isControlled = value !== undefined;
   const currentWorld = isControlled ? value : contextWorld;
 
-  const orderedWorlds = useMemo(() => {
-    if (!worlds) return [];
-    const sanitizedOrder = worldOrder.filter((w) => worlds.includes(w));
-    const remaining = worlds.filter((w) => !sanitizedOrder.includes(w));
-    return [...sanitizedOrder, ...remaining];
-  }, [worldOrder, worlds]);
+  const sanitizedWorldOrder = worldOrder.filter((world) =>
+    worlds.includes(world),
+  );
+  const orderedWorlds = [
+    ...sanitizedWorldOrder,
+    ...worlds.filter((world) => !sanitizedWorldOrder.includes(world)),
+  ];
 
-  const options = useMemo(() => {
-    const worldOptions =
-      orderedWorlds?.map((w) => ({
-        value: w,
-        label: w.charAt(0).toUpperCase() + w.slice(1),
-      })) ?? [];
+  const worldOptions = orderedWorlds.map((world) => ({
+    value: world,
+    label: world.charAt(0).toUpperCase() + world.slice(1),
+  }));
 
-    if (showAllOption) {
-      return [
+  const options = showAllOption
+    ? [
         {
           value: ALL_WORLDS_SENTINEL,
           label: t("kills.home.filters.allWorlds"),
         },
         ...worldOptions,
-      ];
-    }
-
-    return worldOptions;
-  }, [orderedWorlds, showAllOption, t]);
+      ]
+    : worldOptions;
 
   const handleSelect = (selectedValue: string) => {
     const actualWorld =
@@ -84,7 +80,7 @@ export const WorldSwitcher: React.FC<WorldSwitcherProps> = ({
     if (actualWorld) {
       setWorldOrder((prev) => [
         actualWorld,
-        ...prev.filter((w) => w !== actualWorld),
+        ...prev.filter((world) => world !== actualWorld),
       ]);
     }
   };


### PR DESCRIPTION
## Summary
- Remove manual `useMemo` usage from `WorldSwitcher` in line with the React Compiler memoization rule.
- Default fetched/external worlds to an empty array and name the derived world-order arrays more clearly.
- Keep the component API and i18n behavior unchanged.

## Verification
- `pnpm install --frozen-lockfile` after approving pending dependency builds locally with `pnpm approve-builds --all`
- `pnpm exec oxfmt --check apps/web/src/components/common/world-switcher.tsx`
- `pnpm turbo run lint --filter=@lootlog/web`
- `pnpm turbo run test --filter=@lootlog/web`
- `pnpm turbo run build --filter=@lootlog/web`
- `.husky/pre-commit`

Notes: web build completed with an existing third-party `lottie-web` direct eval warning. The changed-package `format:check` hook reported no package task to execute for `@lootlog/web`, while lint-staged formatting passed for the staged file.