### PR TITLE
[codex] refactor expandable data table rendering

### DIFF
--- a/apps/web/src/components/battle/expandable-data-table.tsx
+++ b/apps/web/src/components/battle/expandable-data-table.tsx
@@ -16,7 +16,7 @@ import {
   type SortingState,
 } from "@tanstack/react-table";
 import { cn } from "@lootlog/ui/lib/utils";
-import React, { useState } from "react";
+import { Fragment, type ReactNode, useState } from "react";
 import { ArrowUpDown, ArrowUp, ArrowDown } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { DamageBreakdown } from "./damage-breakdown";
@@ -28,16 +28,53 @@ import { DamageDealtBreakdown } from "./damage-dealt-breakdown";
 import type { BattleWarrior as Warrior } from "@/lib/api/battlelog-types";
 import { useTranslation } from "react-i18next";
 
+type ExpandedRowType =
+  | "damage"
+  | "legendary"
+  | "turns"
+  | "blocks"
+  | "details"
+  | "damageDealt";
+
 interface ExpandableDataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
   getRowClassName?: (row: Row<TData>) => string;
   forceHorizontalScroll?: boolean;
-  expandedRows: Map<
-    string,
-    "damage" | "legendary" | "turns" | "blocks" | "details" | "damageDealt"
-  >;
+  expandedRows: Map<string, ExpandedRowType>;
 }
+
+const renderSortIcon = (sortDirection: false | "asc" | "desc"): ReactNode => {
+  if (sortDirection === "asc") {
+    return <ArrowUp className="h-4 w-4" />;
+  }
+
+  if (sortDirection === "desc") {
+    return <ArrowDown className="h-4 w-4" />;
+  }
+
+  return <ArrowUpDown className="h-4 w-4 opacity-50" />;
+};
+
+const renderExpandedContent = (
+  expansionType: ExpandedRowType,
+  warrior: Warrior,
+): ReactNode => {
+  switch (expansionType) {
+    case "damage":
+      return <DamageBreakdown warrior={warrior} />;
+    case "legendary":
+      return <LegendaryBonusesBreakdown warrior={warrior} />;
+    case "turns":
+      return <TurnsBreakdown warrior={warrior} />;
+    case "blocks":
+      return <BlocksBreakdown warrior={warrior} />;
+    case "details":
+      return <WarriorDetailsBreakdown warrior={warrior} />;
+    case "damageDealt":
+      return <DamageDealtBreakdown warrior={warrior} />;
+  }
+};
 
 export function ExpandableDataTable<TData, TValue>({
   columns,
@@ -70,39 +107,36 @@ export function ExpandableDataTable<TData, TValue>({
                 {headerGroup.headers.map((header) => {
                   const canSort = header.column.getCanSort();
                   const sortDirection = header.column.getIsSorted();
+                  let headerContent: ReactNode = null;
 
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder ? null : canSort ? (
-                        <button
-                          type="button"
-                          className="flex w-full items-center gap-2 cursor-pointer select-none hover:bg-gray-400/10 p-2 -m-2 rounded text-left"
-                          onClick={header.column.getToggleSortingHandler()}
-                        >
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                          <span className="ml-auto">
-                            {sortDirection === "asc" ? (
-                              <ArrowUp className="h-4 w-4" />
-                            ) : sortDirection === "desc" ? (
-                              <ArrowDown className="h-4 w-4" />
-                            ) : (
-                              <ArrowUpDown className="h-4 w-4 opacity-50" />
-                            )}
-                          </span>
-                        </button>
-                      ) : (
-                        <div className={cn("flex items-center gap-2")}>
-                          {flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                        </div>
-                      )}
-                    </TableHead>
-                  );
+                  if (!header.isPlaceholder && canSort) {
+                    headerContent = (
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 cursor-pointer select-none hover:bg-gray-400/10 p-2 -m-2 rounded text-left"
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                        <span className="ml-auto">
+                          {renderSortIcon(sortDirection)}
+                        </span>
+                      </button>
+                    );
+                  } else if (!header.isPlaceholder) {
+                    headerContent = (
+                      <div className={cn("flex items-center gap-2")}>
+                        {flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                      </div>
+                    );
+                  }
+
+                  return <TableHead key={header.id}>{headerContent}</TableHead>;
                 })}
               </TableRow>
             ))}
@@ -114,7 +148,7 @@ export function ExpandableDataTable<TData, TValue>({
                 const expansionType = expandedRows.get(warrior.id);
 
                 return (
-                  <React.Fragment key={row.id}>
+                  <Fragment key={row.id}>
                     <TableRow
                       className={cn(
                         "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
@@ -132,7 +166,7 @@ export function ExpandableDataTable<TData, TValue>({
                       ))}
                     </TableRow>
                     <AnimatePresence>
-                      {expansionType && (
+                      {expansionType ? (
                         <motion.tr
                           key={`${row.id}-expanded`}
                           layout
@@ -170,36 +204,18 @@ export function ExpandableDataTable<TData, TValue>({
                                     ease: "easeInOut",
                                   }}
                                 >
-                                  {expansionType === "damage" && (
-                                    <DamageBreakdown warrior={warrior} />
-                                  )}
-                                  {expansionType === "legendary" && (
-                                    <LegendaryBonusesBreakdown
-                                      warrior={warrior}
-                                    />
-                                  )}
-                                  {expansionType === "turns" && (
-                                    <TurnsBreakdown warrior={warrior} />
-                                  )}
-                                  {expansionType === "blocks" && (
-                                    <BlocksBreakdown warrior={warrior} />
-                                  )}
-                                  {expansionType === "details" && (
-                                    <WarriorDetailsBreakdown
-                                      warrior={warrior}
-                                    />
-                                  )}
-                                  {expansionType === "damageDealt" && (
-                                    <DamageDealtBreakdown warrior={warrior} />
+                                  {renderExpandedContent(
+                                    expansionType,
+                                    warrior,
                                   )}
                                 </motion.div>
                               </AnimatePresence>
                             </motion.div>
                           </TableCell>
                         </motion.tr>
-                      )}
+                      ) : null}
                     </AnimatePresence>
-                  </React.Fragment>
+                  </Fragment>
                 );
               })
             ) : (


### PR DESCRIPTION
## Summary
- Name the expandable battle table row variant type.
- Move sort icon selection into a small helper.
- Centralize expanded warrior detail rendering behind a switch instead of repeated inline conditionals.

## Verification
- `pnpm exec oxfmt --check apps/web/src/components/battle/expandable-data-table.tsx`
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web...`
- `VITE_AUTH_SERVICE_URL=http://localhost/api/auth pnpm --filter @lootlog/web exec vitest run`
- `sh .husky/pre-commit`
- Commit hook ran successfully during `git commit`