### PR TITLE
[codex] remove delete timer memoization

### DIFF
--- a/apps/game-client/src/components/delete-timer-popover.tsx
+++ b/apps/game-client/src/components/delete-timer-popover.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, type FC } from "react";
+import { useState, type FC } from "react";
 import { useQueries } from "@tanstack/react-query";
 import {
   Popover,
@@ -39,14 +39,9 @@ export const DeleteTimerPopover: FC<DeleteTimerPopoverProps> = ({
     },
   });
 
-  const guildEntries = useMemo(
-    () => timer.mergedGuildIds ?? [],
-    [timer.mergedGuildIds],
-  );
-
-  const uniqueGuildIds = useMemo(
-    () => Array.from(new Set(guildEntries.map((entry) => entry.guildId))),
-    [guildEntries],
+  const guildEntries = timer.mergedGuildIds ?? [];
+  const uniqueGuildIds = Array.from(
+    new Set(guildEntries.map((entry) => entry.guildId)),
   );
 
   const permissionsQueries = useQueries({
@@ -57,23 +52,21 @@ export const DeleteTimerPopover: FC<DeleteTimerPopoverProps> = ({
     })),
   });
 
-  const guildsWithPermissions = useMemo(() => {
-    return uniqueGuildIds
-      .map((guildId, index) => {
-        const permissions = permissionsQueries[index]?.data ?? [];
-        const canDelete = REQUIRED_DELETE_PERMISSIONS.some((perm) =>
-          permissions.includes(perm),
-        );
-        const entry = guildEntries.find((e) => e.guildId === guildId);
-        return {
-          guildId,
-          timerKey: entry?.timerKey ?? "",
-          permissions,
-          canDelete,
-        };
-      })
-      .filter((g) => g.canDelete && g.timerKey !== "");
-  }, [uniqueGuildIds, permissionsQueries, guildEntries]);
+  const guildsWithPermissions = uniqueGuildIds
+    .map((guildId, index) => {
+      const permissions = permissionsQueries[index]?.data ?? [];
+      const canDelete = REQUIRED_DELETE_PERMISSIONS.some((perm) =>
+        permissions.includes(perm),
+      );
+      const entry = guildEntries.find((e) => e.guildId === guildId);
+      return {
+        guildId,
+        timerKey: entry?.timerKey ?? "",
+        permissions,
+        canDelete,
+      };
+    })
+    .filter((g) => g.canDelete && g.timerKey !== "");
 
   if (guildsWithPermissions.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

- Removes manual `useMemo` usage from `DeleteTimerPopover`.
- Keeps the same derived guild and permission filtering logic as plain local constants so React Compiler can handle memoization.

## Verification

- `pnpm exec oxfmt --check apps/game-client/src/components/delete-timer-popover.tsx`
- `pnpm turbo run build --filter=@lootlog/game-client`
- `pnpm --filter @lootlog/game-client exec vitest run src/components/delete-timer-popover.test.tsx`
- `pnpm turbo run lint --filter=@lootlog/game-client` (no package lint task)
- `pnpm turbo run test --filter=@lootlog/game-client`
- `pnpm turbo run format:check --filter=@lootlog/game-client` (no package format task)
- `pnpm turbo run check-types --filter=@lootlog/game-client` (no package check-types task)
- `.husky/pre-commit`

Notes: the game-client build still emits existing warnings for the `all:b` CSS pseudo-class and unresolved runtime cursor assets; tests still print existing React `act(...)` warnings in unrelated test files.