### PR TITLE
[codex] refactor game slider value initialization

### DIFF
--- a/apps/game-client/src/components/ui/slider.tsx
+++ b/apps/game-client/src/components/ui/slider.tsx
@@ -8,8 +8,23 @@ interface SliderProps extends React.ComponentPropsWithoutRef<
 > {
   showValue?: boolean;
   formatValue?: (value: number) => React.ReactNode;
-  showEndpoints?: boolean; // show min & max labels
+  showEndpoints?: boolean;
   formatEndpoint?: (value: number, type: "min" | "max") => React.ReactNode;
+}
+
+function getInitialSliderValue(
+  value: SliderProps["value"],
+  defaultValue: SliderProps["defaultValue"],
+) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (Array.isArray(defaultValue)) {
+    return defaultValue;
+  }
+
+  return [0];
 }
 
 const Slider = React.forwardRef<
@@ -30,17 +45,17 @@ const Slider = React.forwardRef<
     },
     ref,
   ) => {
-    const [internalValue, setInternalValue] = React.useState<number[]>(
-      (value as number[]) || (defaultValue as number[]) || [0],
+    const [internalValue, setInternalValue] = React.useState<number[]>(() =>
+      getInitialSliderValue(value, defaultValue),
     );
 
     React.useEffect(() => {
       if (Array.isArray(value)) setInternalValue(value);
     }, [value]);
 
-    const handleValueChange = (vals: number[]) => {
-      if (value === undefined) setInternalValue(vals); // uncontrolled
-      onValueChange?.(vals);
+    const handleValueChange = (nextValue: number[]) => {
+      if (value === undefined) setInternalValue(nextValue);
+      onValueChange?.(nextValue);
     };
 
     const currentVal = (Array.isArray(value) ? value : internalValue)[0];


### PR DESCRIPTION
## Summary

- Add a typed helper for the game-client slider's initial value selection.
- Remove the cast-heavy `||` fallback chain in favor of explicit array checks.
- Rename the value-change argument for clearer controlled/uncontrolled state handling.

## Verification

- `pnpm exec oxfmt --check apps/game-client/src/components/ui/slider.tsx`
- `pnpm --filter @lootlog/game-client exec oxlint src/components/ui/slider.tsx`
- `pnpm --filter @lootlog/game-client test`
- `pnpm turbo run build --filter=@lootlog/game-client...`
- `pnpm format:check`
- `pnpm lint` (passes with existing unrelated warnings)
- Pre-commit hook passed

## Notes

- A previous draft PR opened during this run overlapped with existing PR #1015 and was closed to avoid duplicate automation work.