### PR TITLE
[codex] refactor: consolidate web imports

### DIFF
--- a/apps/web/src/features/guild/notifications/components/notification-rule-card.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-rule-card.tsx
@@ -24,6 +24,7 @@ import { useGuildId } from "@/hooks/context/use-guild-id";
 import {
   CreateNotificationRuleDtoScheduleIntervalType as NotificationScheduleIntervalType,
   CreateNotificationRuleDtoTriggerType as NotificationTriggerType,
+  type GuildNotificationRulesResponseDto,
 } from "@/lib/api/generated/main/model";
 import {
   getGuildNotificationRuleNpcCount,
@@ -45,7 +46,6 @@ import {
   useNotificationsGuildControllerRebuildGuildRuleJobs,
   useNotificationsGuildControllerTriggerGuildRuleTest,
 } from "@/lib/api/generated/main/notifications/notifications";
-import type { GuildNotificationRulesResponseDto } from "@/lib/api/generated/main/model";
 
 type NotificationRuleCardProps = {
   rule: GuildNotificationRulesResponseDto["items"][number];

--- a/apps/web/src/features/guild/notifications/components/notification-template-editor.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-template-editor.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 import {
   CreateNotificationRuleDtoTriggerType as NotificationTriggerType,
   type CreateNotificationRuleDtoTriggerType,
+  type RoleResponseDtoOutput as GuildRole,
 } from "@/lib/api/generated/main/model";
 import {
   TIMER_PRESET_SIMPLE,
@@ -64,7 +65,6 @@ import {
   removeTemplateTokenNode,
   SCHEDULED_MESSAGE_VARIABLE_KEYS,
 } from "./notification-template-editor.utils";
-import type { RoleResponseDtoOutput as GuildRole } from "@/lib/api/generated/main/model";
 
 type NotificationTemplateEditorProps = {
   value: string;

--- a/apps/web/src/features/guild/notifications/utils/notification-settings.utils.ts
+++ b/apps/web/src/features/guild/notifications/utils/notification-settings.utils.ts
@@ -1,14 +1,12 @@
 import type { BadgeProps } from "@lootlog/ui/components/badge";
-import type {
-  CreateNotificationRuleDtoScheduleAnchor,
-  CreateNotificationRuleDtoTriggerType,
-  GuildNotificationRulesResponseDto,
-  NotificationJobsResponseDto,
-  NotificationTargetResponseDto,
-} from "@/lib/api/generated/main/model";
 import {
   CreateNotificationRuleDtoScheduleAnchor as NotificationScheduleAnchor,
+  type CreateNotificationRuleDtoScheduleAnchor,
   CreateNotificationRuleDtoTriggerType as NotificationTriggerType,
+  type CreateNotificationRuleDtoTriggerType,
+  type GuildNotificationRulesResponseDto,
+  type NotificationJobsResponseDto,
+  type NotificationTargetResponseDto,
 } from "@/lib/api/generated/main/model";
 
 type GuildNotificationTarget = NotificationTargetResponseDto;

--- a/apps/web/src/lib/router/document-title.ts
+++ b/apps/web/src/lib/router/document-title.ts
@@ -1,7 +1,9 @@
 import i18n from "@/i18n/config";
-import { getNavigationInfo } from "@/components/layout/get-navigation-info";
+import {
+  getNavigationInfo,
+  type Breadcrumb,
+} from "@/components/layout/get-navigation-info";
 import { getUserNavigationInfo } from "@/components/layout/get-user-navigation-info";
-import type { Breadcrumb } from "@/components/layout/get-navigation-info";
 import type { Battle } from "@/lib/api/battlelog-types";
 import { getBattleRouteLabel } from "@/lib/battle/battle-route-label";
 


### PR DESCRIPTION
## Summary

- Consolidates split value/type imports in hand-written `apps/web` files.
- Keeps generated API imports type-only where possible with inline `type` specifiers.
- Removes duplicate imports from the same module without changing runtime behavior.

## Verification

- `pnpm exec oxfmt --check apps/web/src/features/guild/notifications/components/notification-rule-card.tsx apps/web/src/features/guild/notifications/components/notification-template-editor.tsx apps/web/src/features/guild/notifications/utils/notification-settings.utils.ts apps/web/src/lib/router/document-title.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web...`
- `sh .husky/pre-commit`

Notes:
- `pnpm --filter @lootlog/web build` fails when run directly because workspace dependency packages such as `@lootlog/types` and `@lootlog/socket-parser` have not been built first; the filtered Turbo build succeeds and includes those dependency builds.
- The pre-commit `format:check` and `test` Turbo steps find no `@lootlog/web` package tasks to execute, matching the current package scripts.