### PR TITLE
[codex] Hoist timer duration parser constants

### DIFF
--- a/apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts
+++ b/apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts
@@ -1,5 +1,9 @@
 import { MAX_DURATION_SECONDS } from "@/features/timers/constants/max-duration-seconds";
 
+const DURATION_PATTERN = /^(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?$/i;
+const SECONDS_IN_HOUR = 3600;
+const SECONDS_IN_MINUTE = 60;
+
 export const parseDurationToSeconds = (input: string): number => {
   const normalizedInput = input.trim();
 
@@ -7,13 +11,14 @@ export const parseDurationToSeconds = (input: string): number => {
     return 0;
   }
 
-  const regex = /^(?:(\d+)\s*h)?\s*(?:(\d+)\s*m)?\s*(?:(\d+)\s*s)?$/i;
-  const match = normalizedInput.match(regex);
+  const match = normalizedInput.match(DURATION_PATTERN);
   if (!match) return 0;
 
   const [, hours = "0", minutes = "0", seconds = "0"] = match;
   const totalSeconds =
-    Number(hours) * 3600 + Number(minutes) * 60 + Number(seconds);
+    Number(hours) * SECONDS_IN_HOUR +
+    Number(minutes) * SECONDS_IN_MINUTE +
+    Number(seconds);
 
   return Math.min(totalSeconds, MAX_DURATION_SECONDS);
 };


### PR DESCRIPTION
## Summary
- Hoists the manual timer duration regex to module scope so it is reused instead of recreated for every parse.
- Replaces hardcoded hour/minute multipliers with named constants in the duration parser.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @lootlog/types build`
- `corepack pnpm --filter @lootlog/game-client exec vitest run src/features/timers/helpers/add-timer-form-helpers.test.ts`
- `corepack pnpm oxfmt --check apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts`
- `corepack pnpm oxlint apps/game-client/src/features/timers/helpers/add-timer-form-helpers.ts`
- `corepack pnpm turbo run build --filter=@lootlog/game-client`
- `.husky/pre-commit` (also rerun by `git commit`)

Notes: the game-client build still emits existing CSS/asset warnings unrelated to this helper. The pre-commit package lint/format Turbo steps report no tasks for `@lootlog/game-client`, while lint-staged runs `oxlint` and `oxfmt` on the staged file.