### PR TITLE
[codex] simplify world switcher options

### DIFF
--- a/apps/web/src/components/common/world-switcher.tsx
+++ b/apps/web/src/components/common/world-switcher.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocalStorage } from "usehooks-ts";
 import { FilterPopover } from "@lootlog/ui/components/filter-popover";
@@ -44,32 +44,25 @@ export const WorldSwitcher: React.FC<WorldSwitcherProps> = ({
   const isControlled = value !== undefined;
   const currentWorld = isControlled ? value : contextWorld;
 
-  const orderedWorlds = useMemo(() => {
-    if (!worlds) return [];
-    const sanitizedOrder = worldOrder.filter((w) => worlds.includes(w));
-    const remaining = worlds.filter((w) => !sanitizedOrder.includes(w));
-    return [...sanitizedOrder, ...remaining];
-  }, [worldOrder, worlds]);
-
-  const options = useMemo(() => {
-    const worldOptions =
-      orderedWorlds?.map((w) => ({
-        value: w,
-        label: w.charAt(0).toUpperCase() + w.slice(1),
-      })) ?? [];
-
-    if (showAllOption) {
-      return [
+  const orderedWorlds = worlds
+    ? [
+        ...worldOrder.filter((world) => worlds.includes(world)),
+        ...worlds.filter((world) => !worldOrder.includes(world)),
+      ]
+    : [];
+  const worldOptions = orderedWorlds.map((world) => ({
+    value: world,
+    label: world.charAt(0).toUpperCase() + world.slice(1),
+  }));
+  const options = showAllOption
+    ? [
         {
           value: ALL_WORLDS_SENTINEL,
           label: t("kills.home.filters.allWorlds"),
         },
         ...worldOptions,
-      ];
-    }
-
-    return worldOptions;
-  }, [orderedWorlds, showAllOption, t]);
+      ]
+    : worldOptions;
 
   const handleSelect = (selectedValue: string) => {
     const actualWorld =


### PR DESCRIPTION
## Summary
- Remove manual `useMemo` usage from `WorldSwitcher` option derivation.
- Keep world ordering and the optional all-worlds sentinel behavior as render-time derived constants.

## Impact
This aligns the component with the React Compiler guidance in the repo instructions and reduces local hook boilerplate without changing the displayed options or selection behavior.

## Verification
- `pnpm exec oxfmt apps/web/src/components/common/world-switcher.tsx`
- `pnpm exec oxfmt --check apps/web/src/components/common/world-switcher.tsx`
- `pnpm turbo run lint --filter=@lootlog/web`
- `pnpm turbo run build --filter=@lootlog/web`
- `pnpm turbo run test --filter=@lootlog/web`
- `VITE_AUTH_SERVICE_URL=http://localhost:4000 pnpm --filter @lootlog/web exec vitest run`
- `.husky/pre-commit` (also ran during commit)