### PR TITLE
[codex] Preserve equals in item stat values

### DIFF
--- a/apps/web/src/utils/item-tips/parse-item-stats.spec.ts
+++ b/apps/web/src/utils/item-tips/parse-item-stats.spec.ts
@@ -45,4 +45,15 @@ describe("parseItemStats", () => {
       { key: "ttl", value: "180" },
     ]);
   });
+
+  it("should preserve equals signs inside stat values", () => {
+    const stats = "custom=a=b=c;flag;empty=";
+    const result = parseItemStats(stats);
+
+    expect(result).toEqual([
+      { key: "custom", value: "a=b=c" },
+      { key: "flag", value: true },
+      { key: "empty", value: "" },
+    ]);
+  });
 });

--- a/packages/ui/src/components/item-stat-utils.ts
+++ b/packages/ui/src/components/item-stat-utils.ts
@@ -25,11 +25,11 @@ function isString(value: unknown): value is string {
 }
 
 const parseItemStat = (stat: string): ItemStat => {
-  const [rawKey, rawValue] = stat.split("=");
+  const [key = "undefined", ...rawValueParts] = stat.split("=");
 
   return {
-    key: rawKey ?? "undefined",
-    value: rawValue ?? true,
+    key,
+    value: rawValueParts.length === 0 ? true : rawValueParts.join("="),
   };
 };
 


### PR DESCRIPTION
## Summary
- Preserve additional `=` characters when parsing item stat values in `parseItemStats`.
- Add a regression test covering values with repeated equals, boolean flag stats, and empty values.

## Impact
This keeps existing flag and empty-value behavior while avoiding value truncation for item stats whose value itself contains `=`.

## Verification
- `corepack pnpm --filter @lootlog/web exec vitest run src/utils/item-tips/parse-item-stats.spec.ts`
- `corepack pnpm --filter @lootlog/ui lint`
- `corepack pnpm --filter @lootlog/web lint`
- `corepack pnpm format:check`
- `corepack pnpm turbo run build --filter=@lootlog/web`
- `.husky/pre-commit`

Note: direct `corepack pnpm --filter @lootlog/web build` was not used as final validation because a fresh install had not built workspace dependency outputs yet; the Turbo-filtered build built dependencies in order and passed.