### PR TITLE
[codex] Share NPC timer permission routing

### DIFF
--- a/packages/api-helpers/package.json
+++ b/packages/api-helpers/package.json
@@ -29,6 +29,7 @@
     "build": "tsdown"
   },
   "dependencies": {
+    "@lootlog/types": "workspace:*",
     "hono": "^4.12.25",
     "jose": "^6.2.2"
   },

--- a/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
+++ b/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
@@ -1,3 +1,5 @@
+import { getNpcRoutingTier, type NpcRoutingTier } from "@lootlog/types";
+
 export type NpcPermissionData = {
   lvl: number;
   type: string;
@@ -16,20 +18,11 @@ const PERMISSION = {
 } as const;
 
 type TimerPermission = (typeof PERMISSION)[keyof typeof PERMISSION];
-type TimerPermissionTier = "base" | "titans" | "heroes";
 
-const TIMER_PERMISSION_BY_TIER: Record<TimerPermissionTier, TimerPermission> = {
+const TIMER_PERMISSION_BY_TIER: Record<NpcRoutingTier, TimerPermission> = {
   base: PERMISSION.LOOTLOG_TIMERS_READ,
   titans: PERMISSION.LOOTLOG_TIMERS_TITANS_READ,
   heroes: PERMISSION.LOOTLOG_TIMERS_HEROES_READ,
-};
-
-const TIMER_PERMISSION_TIER_BY_NPC_TYPE: Partial<
-  Record<string, TimerPermissionTier>
-> = {
-  TITAN: "titans",
-  HERO: "heroes",
-  EVENT_HERO: "heroes",
 };
 
 const isNpcLevelWithinRoleRange = (
@@ -37,18 +30,14 @@ const isNpcLevelWithinRoleRange = (
   npcLevel: number,
 ): boolean => role.lvlRangeFrom <= npcLevel && role.lvlRangeTo >= npcLevel;
 
-const getRequiredTimerPermission = (npcType: string): TimerPermission =>
-  TIMER_PERMISSION_BY_TIER[
-    TIMER_PERMISSION_TIER_BY_NPC_TYPE[npcType] ?? "base"
-  ];
-
 export const canViewNpcTimer = (
   npc: NpcPermissionData | null,
   roles: RolePermissionData[],
 ): boolean => {
   if (!npc) return false;
 
-  const requiredTimerPermission = getRequiredTimerPermission(npc.type);
+  const requiredTimerPermission =
+    TIMER_PERMISSION_BY_TIER[getNpcRoutingTier(npc)];
 
   return roles.some(
     (role) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1374,6 +1374,9 @@ importers:
 
   packages/api-helpers:
     dependencies:
+      '@lootlog/types':
+        specifier: workspace:*
+        version: link:../types
       hono:
         specifier: ^4.12.25
         version: 4.12.25
@@ -15307,6 +15310,7 @@ snapshots:
 
   '@lootlog/api-helpers@file:packages/api-helpers':
     dependencies:
+      '@lootlog/types': file:packages/types
       hono: 4.12.25
       jose: 6.2.3
 


### PR DESCRIPTION
## Summary

- Reused the shared `getNpcRoutingTier` helper inside `@lootlog/api-helpers` timer permission checks.
- Removed the duplicate local hero/titan NPC type map from `canViewNpcTimer`.
- Declared `@lootlog/types` as an explicit workspace dependency for `@lootlog/api-helpers`.

## Verification

- `corepack pnpm install`
- `corepack pnpm turbo run build --filter=@lootlog/api-helpers`
- `corepack pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/shared/utils/can-view-npc-timer.spec.ts`
- `corepack pnpm exec tsc -p packages/api-helpers/tsconfig.json --noEmit`
- `corepack pnpm exec oxlint packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts`
- `corepack pnpm exec oxfmt --check packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts packages/api-helpers/package.json pnpm-lock.yaml`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `.husky/pre-commit` (also passed during `git commit`)

Note: an initial package-script test invocation ran the full API suite and failed before the target test because workspace packages had not been built for package-export resolution. After building the affected dependency chain, the focused spec passed.