### PR TITLE
[codex] extract ui overlay seeded random helper

### DIFF
--- a/packages/ui/src/components/cat-paw-overlay.tsx
+++ b/packages/ui/src/components/cat-paw-overlay.tsx
@@ -1,20 +1,6 @@
 import * as React from "react";
 
-function seededRandom(seed: number) {
-  let s = seed;
-  return () => {
-    s = (s * 16807 + 11) % 2147483647;
-    return (s - 1) / 2147483646;
-  };
-}
-
-function hashString(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 31 + str.charCodeAt(i)) | 0;
-  }
-  return Math.abs(hash);
-}
+import { createSeededRandom, hashString } from "@lootlog/ui/lib/seeded-random";
 
 export const PAW_SVG =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cellipse cx='16' cy='21' rx='6.5' ry='5' fill='white'/%3E%3Ccircle cx='7' cy='11' r='3' fill='white'/%3E%3Ccircle cx='13' cy='7' r='2.8' fill='white'/%3E%3Ccircle cx='19' cy='7' r='2.8' fill='white'/%3E%3Ccircle cx='25' cy='11' r='3' fill='white'/%3E%3C/svg%3E";
@@ -41,69 +27,76 @@ export function useCatTheme() {
   return isCat;
 }
 
+function createCatPaws(id: string) {
+  const random = createSeededRandom(hashString(id));
+
+  for (let i = 0; i < 20; i++) random();
+
+  const result: Array<{
+    id: string;
+    left: string;
+    top: string;
+    size: number;
+    rotation: number;
+    opacity: number;
+  }> = [];
+
+  const startX = random() * 100;
+  const startY = random() * 100;
+
+  let walkAngle = random() * Math.PI * 2;
+
+  const curveBias = (random() - 0.5) * 0.6;
+
+  const baseSize = 35 + random() * 15;
+  const baseOpacity = 0.03 + random() * 0.03;
+  const steps = 12 + Math.floor(random() * 8);
+
+  const strideForwardPx = baseSize * 0.75;
+  const strideLateralPx = baseSize * 0.6;
+  const pawRotationOutward = 12;
+
+  let bodyAccumulatedX = 0;
+  let bodyAccumulatedY = 0;
+
+  for (let i = 0; i < steps; i++) {
+    const isRightPaw = i % 2 === 0;
+
+    walkAngle += curveBias + (random() - 0.5) * 0.15;
+
+    bodyAccumulatedX += Math.cos(walkAngle) * strideForwardPx;
+    bodyAccumulatedY += Math.sin(walkAngle) * strideForwardPx;
+
+    const perpendicularAngle = walkAngle + Math.PI / 2;
+    const sideOffset = isRightPaw ? strideLateralPx : -strideLateralPx;
+
+    const pawX = bodyAccumulatedX + Math.cos(perpendicularAngle) * sideOffset;
+    const pawY = bodyAccumulatedY + Math.sin(perpendicularAngle) * sideOffset;
+
+    const angleInDegrees = walkAngle * (180 / Math.PI) + 90;
+    const pawRotation =
+      angleInDegrees + (isRightPaw ? pawRotationOutward : -pawRotationOutward);
+
+    const signX = pawX >= 0 ? "+" : "-";
+    const signY = pawY >= 0 ? "+" : "-";
+
+    result.push({
+      id: `paw-${i}`,
+      left: `calc(${startX}% ${signX} ${Math.abs(pawX)}px)`,
+      top: `calc(${startY}% ${signY} ${Math.abs(pawY)}px)`,
+      size: baseSize + (random() * 4 - 2),
+      rotation: pawRotation,
+      opacity: baseOpacity,
+    });
+  }
+
+  return result;
+}
+
 export function CatPawOverlay() {
   const isCatTheme = useCatTheme();
   const id = React.useId();
-
-  const paws = React.useMemo(() => {
-    const rand = seededRandom(hashString(id));
-
-    for (let i = 0; i < 20; i++) rand();
-
-    const result = [];
-
-    const startX = rand() * 100;
-    const startY = rand() * 100;
-
-    let walkAngle = rand() * Math.PI * 2;
-
-    const curveBias = (rand() - 0.5) * 0.6;
-
-    const baseSize = 35 + rand() * 15;
-    const baseOpacity = 0.03 + rand() * 0.03;
-    const steps = 12 + Math.floor(rand() * 8);
-
-    const strideForwardPx = baseSize * 0.75;
-    const strideLateralPx = baseSize * 0.6;
-    const pawRotationOutward = 12;
-
-    let bodyAccumulatedX = 0;
-    let bodyAccumulatedY = 0;
-
-    for (let i = 0; i < steps; i++) {
-      const isRightPaw = i % 2 === 0;
-
-      walkAngle += curveBias + (rand() - 0.5) * 0.15;
-
-      bodyAccumulatedX += Math.cos(walkAngle) * strideForwardPx;
-      bodyAccumulatedY += Math.sin(walkAngle) * strideForwardPx;
-
-      const perpendicularAngle = walkAngle + Math.PI / 2;
-      const sideOffset = isRightPaw ? strideLateralPx : -strideLateralPx;
-
-      const pawX = bodyAccumulatedX + Math.cos(perpendicularAngle) * sideOffset;
-      const pawY = bodyAccumulatedY + Math.sin(perpendicularAngle) * sideOffset;
-
-      const angleInDegrees = walkAngle * (180 / Math.PI) + 90;
-      const pawRotation =
-        angleInDegrees +
-        (isRightPaw ? pawRotationOutward : -pawRotationOutward);
-
-      const signX = pawX >= 0 ? "+" : "-";
-      const signY = pawY >= 0 ? "+" : "-";
-
-      result.push({
-        id: `paw-${i}`,
-        left: `calc(${startX}% ${signX} ${Math.abs(pawX)}px)`,
-        top: `calc(${startY}% ${signY} ${Math.abs(pawY)}px)`,
-        size: baseSize + (rand() * 4 - 2),
-        rotation: pawRotation,
-        opacity: baseOpacity,
-      });
-    }
-
-    return result;
-  }, [id]);
+  const paws = createCatPaws(id);
 
   if (!isCatTheme) return null;
 

--- a/packages/ui/src/components/rias-magic-card-overlay.tsx
+++ b/packages/ui/src/components/rias-magic-card-overlay.tsx
@@ -1,20 +1,6 @@
 import * as React from "react";
 
-function seededRandom(seed: number) {
-  let s = seed;
-  return () => {
-    s = (s * 16807 + 11) % 2147483647;
-    return (s - 1) / 2147483646;
-  };
-}
-
-function hashString(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 31 + str.charCodeAt(i)) | 0;
-  }
-  return Math.abs(hash);
-}
+import { createSeededRandom, hashString } from "@lootlog/ui/lib/seeded-random";
 
 const RIAS_CLASS = "rias";
 
@@ -43,43 +29,44 @@ const MAGIC_CIRCLE_SVG =
 const ENERGY_PARTICLE_SVG =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Ccircle cx='4' cy='4' r='3' fill='white' opacity='0.6'/%3E%3Ccircle cx='4' cy='4' r='1.5' fill='white' opacity='0.9'/%3E%3C/svg%3E";
 
+function createRiasOverlayElements(id: string) {
+  const random = createSeededRandom(hashString(id));
+
+  for (let i = 0; i < 20; i++) random();
+
+  const result: Array<{
+    id: string;
+    left: string;
+    top: string;
+    size: number;
+    rotation: number;
+    opacity: number;
+    type: "circle" | "particle";
+  }> = [];
+
+  const count = 5 + Math.floor(random() * 4);
+
+  for (let i = 0; i < count; i++) {
+    const type = random() > 0.5 ? "circle" : "particle";
+
+    result.push({
+      id: `rias-${i}`,
+      left: `${random() * 100}%`,
+      top: `${random() * 100}%`,
+      size: type === "circle" ? 20 + random() * 16 : 8 + random() * 6,
+      rotation: random() * 360,
+      opacity: 0.02 + random() * 0.02,
+      type,
+    });
+  }
+
+  return result;
+}
+
 export function RiasMagicCardOverlay() {
   const isRiasTheme = useRiasTheme();
   const id = React.useId();
-
-  const elements = React.useMemo(() => {
-    const rand = seededRandom(hashString(id));
-
-    for (let i = 0; i < 20; i++) rand();
-
-    const result: Array<{
-      id: string;
-      left: string;
-      top: string;
-      size: number;
-      rotation: number;
-      opacity: number;
-      type: "circle" | "particle";
-    }> = [];
-
-    const count = 5 + Math.floor(rand() * 4);
-
-    for (let i = 0; i < count; i++) {
-      const type = rand() > 0.5 ? "circle" : "particle";
-
-      result.push({
-        id: `rias-${i}`,
-        left: `${rand() * 100}%`,
-        top: `${rand() * 100}%`,
-        size: type === "circle" ? 20 + rand() * 16 : 8 + rand() * 6,
-        rotation: rand() * 360,
-        opacity: 0.02 + rand() * 0.02,
-        type,
-      });
-    }
-
-    return result;
-  }, [id]);
+  const elements = createRiasOverlayElements(id);
 
   if (!isRiasTheme) return null;
 

--- a/packages/ui/src/components/rukia-frost-card-overlay.tsx
+++ b/packages/ui/src/components/rukia-frost-card-overlay.tsx
@@ -1,20 +1,6 @@
 import * as React from "react";
 
-function seededRandom(seed: number) {
-  let s = seed;
-  return () => {
-    s = (s * 16807 + 11) % 2147483647;
-    return (s - 1) / 2147483646;
-  };
-}
-
-function hashString(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 31 + str.charCodeAt(i)) | 0;
-  }
-  return Math.abs(hash);
-}
+import { createSeededRandom, hashString } from "@lootlog/ui/lib/seeded-random";
 
 const RUKIA_CLASS = "rukia";
 
@@ -41,43 +27,44 @@ const SNOWFLAKE_SVG =
 const CRYSTAL_SVG =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 0 L9 6 L15 6 L10 9 L12 16 L8 11 L4 16 L6 9 L1 6 L7 6 Z' fill='white'/%3E%3C/svg%3E";
 
+function createRukiaOverlayElements(id: string) {
+  const random = createSeededRandom(hashString(id));
+
+  for (let i = 0; i < 20; i++) random();
+
+  const result: Array<{
+    id: string;
+    left: string;
+    top: string;
+    size: number;
+    rotation: number;
+    opacity: number;
+    type: "snowflake" | "crystal";
+  }> = [];
+
+  const count = 6 + Math.floor(random() * 4);
+
+  for (let i = 0; i < count; i++) {
+    const type = random() > 0.4 ? "snowflake" : "crystal";
+
+    result.push({
+      id: `frost-${i}`,
+      left: `${random() * 100}%`,
+      top: `${random() * 100}%`,
+      size: type === "snowflake" ? 18 + random() * 14 : 10 + random() * 8,
+      rotation: random() * 360,
+      opacity: 0.025 + random() * 0.025,
+      type,
+    });
+  }
+
+  return result;
+}
+
 export function RukiaFrostCardOverlay() {
   const isRukiaTheme = useRukiaTheme();
   const id = React.useId();
-
-  const elements = React.useMemo(() => {
-    const rand = seededRandom(hashString(id));
-
-    for (let i = 0; i < 20; i++) rand();
-
-    const result: Array<{
-      id: string;
-      left: string;
-      top: string;
-      size: number;
-      rotation: number;
-      opacity: number;
-      type: "snowflake" | "crystal";
-    }> = [];
-
-    const count = 6 + Math.floor(rand() * 4);
-
-    for (let i = 0; i < count; i++) {
-      const type = rand() > 0.4 ? "snowflake" : "crystal";
-
-      result.push({
-        id: `frost-${i}`,
-        left: `${rand() * 100}%`,
-        top: `${rand() * 100}%`,
-        size: type === "snowflake" ? 18 + rand() * 14 : 10 + rand() * 8,
-        rotation: rand() * 360,
-        opacity: 0.025 + rand() * 0.025,
-        type,
-      });
-    }
-
-    return result;
-  }, [id]);
+  const elements = createRukiaOverlayElements(id);
 
   if (!isRukiaTheme) return null;
 

--- a/packages/ui/src/lib/seeded-random.ts
+++ b/packages/ui/src/lib/seeded-random.ts
@@ -1,0 +1,18 @@
+export function createSeededRandom(seed: number) {
+  let state = seed;
+
+  return () => {
+    state = (state * 16807 + 11) % 2147483647;
+    return (state - 1) / 2147483646;
+  };
+}
+
+export function hashString(value: string): number {
+  let hash = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) | 0;
+  }
+
+  return Math.abs(hash);
+}


### PR DESCRIPTION
## Summary

- Extracted the duplicated seeded random/hash helpers from the themed UI overlay components into `@lootlog/ui/lib/seeded-random`.
- Moved each overlay's deterministic element generation into a plain local factory, removing `React.useMemo` from the cat, Rias, and Rukia card overlays while preserving the `useId`-seeded output.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt --check packages/ui/src/lib/seeded-random.ts packages/ui/src/components/rias-magic-card-overlay.tsx packages/ui/src/components/cat-paw-overlay.tsx packages/ui/src/components/rukia-frost-card-overlay.tsx`
- `corepack pnpm --filter @lootlog/ui lint` (passes with pre-existing `npc-tile.tsx` warning)
- `corepack pnpm exec tsc -p packages/ui/tsconfig.json --noEmit`
- `corepack pnpm turbo run lint --filter=...@lootlog/ui` (passes with pre-existing UI/wiki warnings)
- `corepack pnpm turbo run build --filter=...@lootlog/ui --force`
- `corepack pnpm --filter @lootlog/wiki test`
- `corepack pnpm format:check`
- `corepack pnpm --filter @lootlog/landing typecheck`
- `corepack pnpm --filter @lootlog/developer typecheck`
- `corepack pnpm lint` (passes with existing warnings in unrelated packages)
- Pre-commit hook passed during `git commit`