### PR TITLE
[codex] expose api helpers as concrete subpaths

### DIFF
--- a/apps/auth/src/auth/auth.service.spec.ts
+++ b/apps/auth/src/auth/auth.service.spec.ts
@@ -4,13 +4,13 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
-import { validateToken } from "@lootlog/api-helpers";
+import { validateToken } from "@lootlog/api-helpers/auth/verify-jwt";
 import { APIError } from "better-auth/api";
 import { AuthService } from "./auth.service";
 import { idpTokenRequestSchema } from "./dto/idp-token-request.dto";
 import { auth } from "./better-auth";
 
-vi.mock("@lootlog/api-helpers", () => ({
+vi.mock("@lootlog/api-helpers/auth/verify-jwt", () => ({
   validateToken:
     vi.fn<(input: unknown) => Promise<{ userId: string; discordId: string }>>(),
 }));

--- a/apps/auth/src/auth/auth.service.ts
+++ b/apps/auth/src/auth/auth.service.ts
@@ -5,8 +5,11 @@ import {
   InternalServerErrorException,
   UnauthorizedException,
 } from "@nestjs/common";
+import {
+  type JwksKeys,
+  validateToken,
+} from "@lootlog/api-helpers/auth/verify-jwt";
 import { APIError } from "better-auth/api";
-import { type JwksKeys, validateToken } from "@lootlog/api-helpers";
 import { fromNodeHeaders } from "better-auth/node";
 import type { IncomingHttpHeaders } from "node:http";
 import { env } from "src/config/env";

--- a/packages/api-helpers/README.md
+++ b/packages/api-helpers/README.md
@@ -10,9 +10,8 @@ Shared auth and request-context helpers for backend services.
 
 ## Exports
 
-- `userMetadataFromHeaders`
-- `validateToken`
-- JWT verification types from `verify-jwt.types`
+- `@lootlog/api-helpers/auth/user-metadata`
+- `@lootlog/api-helpers/auth/verify-jwt`
 - `@lootlog/api-helpers/permissions`
 
 ## Development
@@ -25,5 +24,5 @@ pnpm --filter @lootlog/api-helpers build
 
 ## Notes
 
-- Main exports are defined in `src/index.ts`.
+- Public exports are built directly from their implementation files.
 - Token verification is implemented with `jose` and expects either a JWKS object or a remote JWKS URL.

--- a/packages/api-helpers/package.json
+++ b/packages/api-helpers/package.json
@@ -3,21 +3,29 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {
+      "auth/user-metadata": [
+        "./dist/auth/user-metadata.d.ts"
+      ],
+      "auth/verify-jwt": [
+        "./dist/auth/verify-jwt.d.ts"
+      ],
       "permissions": [
         "./dist/permissions.d.ts"
       ]
     }
   },
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+    "./auth/user-metadata": {
+      "types": "./dist/auth/user-metadata.d.ts",
+      "import": "./dist/auth/user-metadata.mjs",
+      "require": "./dist/auth/user-metadata.js"
+    },
+    "./auth/verify-jwt": {
+      "types": "./dist/auth/verify-jwt.d.ts",
+      "import": "./dist/auth/verify-jwt.mjs",
+      "require": "./dist/auth/verify-jwt.js"
     },
     "./permissions": {
       "types": "./dist/permissions.d.ts",

--- a/packages/api-helpers/src/index.ts
+++ b/packages/api-helpers/src/index.ts
@@ -1,4 +1,0 @@
-export * from "./lib/auth/middleware/user-metadata.middleware.js";
-export * from "./lib/auth/utils/verify-jwt.js";
-export * from "./lib/auth/utils/verify-jwt.types.js";
-export * from "./lib/permissions/can-view-npc-timer";

--- a/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
+++ b/packages/api-helpers/src/lib/auth/utils/verify-jwt.ts
@@ -38,3 +38,10 @@ export async function validateToken({
     discordId: payload.discordId as string,
   };
 }
+
+export type {
+  Jwks,
+  JwksKeys,
+  VerifyTokenOptions,
+  VerifyTokenResponse,
+} from "./verify-jwt.types.js";

--- a/packages/api-helpers/tsdown.config.ts
+++ b/packages/api-helpers/tsdown.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: {
-    index: "src/index.ts",
+    "auth/user-metadata": "src/lib/auth/middleware/user-metadata.middleware.ts",
+    "auth/verify-jwt": "src/lib/auth/utils/verify-jwt.ts",
     permissions: "src/lib/permissions/can-view-npc-timer.ts",
   },
   format: ["esm", "cjs"],


### PR DESCRIPTION
## Summary

- Replace the re-export-only `@lootlog/api-helpers` root barrel with concrete `auth/user-metadata`, `auth/verify-jwt`, and `permissions` package entries.
- Export JWT helper types from the implementation module so consumers can import from the concrete auth subpath.
- Update `@lootlog/auth` imports and mocks to use `@lootlog/api-helpers/auth/verify-jwt`.

## Verification

- `pnpm --filter @lootlog/api-helpers build`
- `pnpm --filter @lootlog/auth test`
- `pnpm --filter @lootlog/auth lint`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/auth build`
- `pnpm exec oxfmt --check apps/auth/src/auth/auth.service.ts apps/auth/src/auth/auth.service.spec.ts packages/api-helpers/package.json packages/api-helpers/tsdown.config.ts packages/api-helpers/src/lib/auth/utils/verify-jwt.ts packages/api-helpers/README.md`
- `pnpm turbo run build '--filter=[HEAD]'`
- Pre-commit hook during commit: `lint-staged`, changed-package lint, changed-package format check, changed-package tests

Note: the first direct auth build in this fresh worktree failed until `@lootlog/nest-shared` was built once through pnpm so its injected workspace dependency copy synced. The rerun passed.