### PR TITLE
[codex] simplify chat message permission checks

### DIFF
--- a/apps/api/src/shared/utils/can-view-chat-message.ts
+++ b/apps/api/src/shared/utils/can-view-chat-message.ts
@@ -11,14 +11,27 @@ const NPC_TIER_PERMISSIONS: Record<NpcRoutingTier, Permission> = {
   heroes: Permission.LOOTLOG_CHAT_HEROES_READ,
 };
 
-const hasNpcPermission = (npc: NpcData, roles: Role[]) => {
+const hasPermission = (roles: Role[], permission: Permission) => {
+  return roles.some((role) => role.permissions.includes(permission));
+};
+
+const isNpcScopedMessage = (data: ChatStoredMessage) => {
+  return (
+    data.type === MessageType.NPC ||
+    (data.type === MessageType.PARTY_GATHERING && data.npc !== undefined)
+  );
+};
+
+const isNpcLevelInRoleRange = (npc: NpcData, role: Role) => {
+  return role.lvlRangeFrom <= npc.lvl && role.lvlRangeTo >= npc.lvl;
+};
+
+const hasNpcTierPermission = (npc: NpcData, roles: Role[]) => {
   const permission = NPC_TIER_PERMISSIONS[getNpcRoutingTier(npc)];
 
   return roles.some(
     (role) =>
-      role.permissions.includes(permission) &&
-      role.lvlRangeFrom <= npc.lvl &&
-      role.lvlRangeTo >= npc.lvl,
+      role.permissions.includes(permission) && isNpcLevelInRoleRange(npc, role),
   );
 };
 
@@ -27,19 +40,14 @@ export const canViewChatMessage = (
   roles: Role[],
 ) => {
   if (!data) return false;
-  const canReadChatMessages = roles.some((role) =>
-    role.permissions.includes(Permission.LOOTLOG_CHAT_READ),
-  );
-  if (!canReadChatMessages) return false;
 
-  if (
-    data.type === MessageType.NPC ||
-    (data.type === MessageType.PARTY_GATHERING && data.npc)
-  ) {
+  if (!hasPermission(roles, Permission.LOOTLOG_CHAT_READ)) return false;
+
+  if (isNpcScopedMessage(data)) {
     const npc = data.npc;
     if (!npc) return false;
 
-    return hasNpcPermission(npc, roles);
+    return hasNpcTierPermission(npc, roles);
   }
 
   return true;


### PR DESCRIPTION
## Summary

- Split chat message permission checks into named helpers for base chat access, NPC-scoped messages, and NPC level range matching.
- Renamed the NPC permission helper to make tier-specific access explicit while preserving current behavior.

## Verification

- `corepack pnpm exec oxfmt --check apps/api/src/shared/utils/can-view-chat-message.ts apps/api/src/shared/utils/can-view-chat-message.spec.ts`
- `corepack pnpm exec oxlint apps/api/src/shared/utils/can-view-chat-message.ts apps/api/src/shared/utils/can-view-chat-message.spec.ts`
- `corepack pnpm --dir apps/api exec vitest run src/shared/utils/can-view-chat-message.spec.ts --config ./vitest.config.ts`
- `corepack pnpm --filter @lootlog/api test`
- `corepack pnpm turbo run build --filter=@lootlog/api... --force`
- `corepack pnpm format:check`
- `corepack pnpm lint` (passes with existing warnings)
- Commit pre-commit hook passed changed-package lint/test checks.