### PR TITLE
[codex] Type battlelog test fixtures

### DIFF
--- a/apps/battlelog-service/src/battles/battle-processor.spec.ts
+++ b/apps/battlelog-service/src/battles/battle-processor.spec.ts
@@ -1,4 +1,4 @@
-import { BattleProcessor } from "@lootlog/battle-processor";
+import { BattleProcessor, type BattlePayload } from "@lootlog/battle-processor";
 import type { CreateBattleDto } from "./dto/create-battle.dto";
 
 describe("BattleProcessor", () => {
@@ -67,7 +67,7 @@ describe("BattleProcessor", () => {
 
   describe("extractAndParseMoves", () => {
     it("should parse moves correctly", () => {
-      const events = [
+      const events: BattlePayload["events"] = [
         {
           ev: 1000,
           f: {
@@ -76,7 +76,7 @@ describe("BattleProcessor", () => {
         },
       ];
 
-      const moves = processor.extractAndParseMoves(events as any);
+      const moves = processor.extractAndParseMoves(events);
 
       expect(moves).toHaveLength(2);
       expect(moves[0]).toEqual({
@@ -96,7 +96,7 @@ describe("BattleProcessor", () => {
     });
 
     it("should handle moves with zero IDs as null", () => {
-      const events = [
+      const events: BattlePayload["events"] = [
         {
           ev: 1000,
           f: {
@@ -105,7 +105,7 @@ describe("BattleProcessor", () => {
         },
       ];
 
-      const moves = processor.extractAndParseMoves(events as any);
+      const moves = processor.extractAndParseMoves(events);
 
       expect(moves[0]).toEqual({
         attackerId: null,
@@ -117,7 +117,7 @@ describe("BattleProcessor", () => {
     });
 
     it("should handle moves without params", () => {
-      const events = [
+      const events: BattlePayload["events"] = [
         {
           ev: 1000,
           f: {
@@ -126,7 +126,7 @@ describe("BattleProcessor", () => {
         },
       ];
 
-      const moves = processor.extractAndParseMoves(events as any);
+      const moves = processor.extractAndParseMoves(events);
 
       expect(moves[0].actions).toEqual([
         { actionType: "step", param: "" },

--- a/apps/battlelog-service/src/battles/battles.controller.spec.ts
+++ b/apps/battlelog-service/src/battles/battles.controller.spec.ts
@@ -5,6 +5,7 @@ import { BattleAnalyticsService } from "./services/battle-analytics.service";
 import { AuthGuard } from "src/shared/guards/auth.guard";
 import { BattleAccessGuard } from "src/shared/guards/battle-access.guard";
 import { BattleOwnerGuard } from "src/shared/guards/battle-owner.guard";
+import type { QueryBattleStatisticsDto } from "./dto/query-battle-statistics.dto";
 
 describe("BattlesController", () => {
   let controller: BattlesController;
@@ -109,12 +110,13 @@ describe("BattlesController", () => {
       highlights: [],
     };
     mockBattleAnalyticsService.getCombatProfile.mockResolvedValue(profile);
+    const query: QueryBattleStatisticsDto = { characterId: "char-1" };
 
-    await expect(
-      controller.getCombatProfile({ characterId: "char-1" } as any, "user-1"),
-    ).resolves.toBe(profile);
+    await expect(controller.getCombatProfile(query, "user-1")).resolves.toBe(
+      profile,
+    );
     expect(mockBattleAnalyticsService.getCombatProfile).toHaveBeenCalledWith(
-      { characterId: "char-1" },
+      query,
       "user-1",
     );
   });


### PR DESCRIPTION
## Summary

- Replaced `as any` casts in battle processor move fixture tests with `BattlePayload["events"]` typing.
- Typed the combat profile controller query fixture as `QueryBattleStatisticsDto` and reused the fixture in the expectation.

## Verification

- `pnpm --filter @lootlog/battlelog-service test -- src/battles/battle-processor.spec.ts src/battles/battles.controller.spec.ts`
- `pnpm exec oxfmt --check apps/battlelog-service/src/battles/battle-processor.spec.ts apps/battlelog-service/src/battles/battles.controller.spec.ts`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm turbo run build --filter=@lootlog/battlelog-service... --force`
- `pnpm turbo run lint --filter=@lootlog/battlelog-service...`
- `pnpm turbo run test --filter=@lootlog/battlelog-service`
- `pnpm --filter @lootlog/battlelog-service build`
- `pnpm format:check`
- `git diff --check`
- Husky pre-commit hook