### PR TITLE
[codex] simplify env value generation

### DIFF
--- a/packages/cli/src/commands/env/generate.ts
+++ b/packages/cli/src/commands/env/generate.ts
@@ -80,7 +80,7 @@ const processEnvFile = async (
   let variables = parseEnvFile(sampleContent);
 
   if (options.auto) {
-    variables = generateEnvValues(variables, sharedValues, true);
+    variables = generateEnvValues(variables, sharedValues);
     let derivedSharedValues = sharedValues;
     if (processOptions.useGeneratedSharedValues) {
       derivedSharedValues = extractSharedValues(variables);

--- a/packages/cli/src/utils/env-generator.test.ts
+++ b/packages/cli/src/utils/env-generator.test.ts
@@ -161,7 +161,6 @@ const assertGeneratedRootValuesCanBeReused = (): void => {
       envVariable("REDIS_PASSWORD", "redis_password"),
     ],
     new Map(),
-    true,
   );
 
   const extractedSharedValues = extractSharedValues(generatedRootVariables);

--- a/packages/cli/src/utils/env-generator.ts
+++ b/packages/cli/src/utils/env-generator.ts
@@ -189,14 +189,9 @@ const generateSmartDefault = (
 export const generateEnvValues = (
   variables: EnvVariable[],
   sharedValues: Map<string, string> = new Map(),
-  autoMode: boolean = true,
 ): EnvVariable[] => {
   return variables.map((variable) => {
     if (variable.isEmpty || variable.isComment || !variable.key) {
-      return variable;
-    }
-
-    if (!autoMode) {
       return variable;
     }
 


### PR DESCRIPTION
## Summary
- Remove the unused `autoMode` branch from `generateEnvValues`.
- Update the env generation caller and test to use the simplified signature.

## Verification
- `pnpm --filter @lootlog/cli test`
- `pnpm exec oxfmt --check packages/cli/src/utils/env-generator.ts packages/cli/src/commands/env/generate.ts packages/cli/src/utils/env-generator.test.ts`
- `pnpm turbo run build --filter=@lootlog/cli`
- `pnpm turbo run check-types --filter=@lootlog/cli` (no `check-types` task exists for `@lootlog/cli`)
- `.husky/pre-commit`
- `git commit` hook reran `.husky/pre-commit` successfully