### PR TITLE
[codex] tighten activity controller spec

### DIFF
--- a/apps/activity/src/activities/activities.controller.spec.ts
+++ b/apps/activity/src/activities/activities.controller.spec.ts
@@ -220,7 +220,7 @@ describe("ActivitiesController", () => {
 
   describe("endpoint restrictions", () => {
     it("should not have a findAll method that allows fetching all activities", () => {
-      expect((controller as any).findAll).toBeUndefined();
+      expect("findAll" in controller).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replaced the `as any` lookup in `ActivitiesController` tests with a type-safe `"findAll" in controller` assertion.
- Kept the endpoint restriction coverage intact while removing the only handwritten unsafe cast in the activity controller spec.

## Verification

- `CI=true corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt --check apps/activity/src/activities/activities.controller.spec.ts`
- `git diff --check`
- `corepack pnpm turbo run build --filter=@lootlog/types --filter=@lootlog/nest-shared --force`
- `corepack pnpm --dir apps/activity exec vitest run --config ./vitest.config.ts src/activities/activities.controller.spec.ts`
- `corepack pnpm turbo run lint --filter=@lootlog/activity`
- `corepack pnpm turbo run build --filter=@lootlog/activity`
- `corepack pnpm turbo run test --filter=@lootlog/activity`
- `corepack pnpm turbo run check-types --filter=@lootlog/activity` (no package task configured; Nest build type checker reported 0 issues)
- `.husky/pre-commit` with staged file, rerun by `git commit`

Note: pnpm 10 emitted the existing unapproved build-script warning for `necord@6.14.0` during install, but install completed successfully.