### PR TITLE
[codex] refactor auth request origin handling

### DIFF
--- a/apps/auth/src/app.factory.helpers.ts
+++ b/apps/auth/src/app.factory.helpers.ts
@@ -98,7 +98,13 @@ const getRequestProtocol = (request: BetterAuthFastifyRequest) => {
   );
 
   if (typeof forwardedProtocol === "string" && forwardedProtocol.length > 0) {
-    return forwardedProtocol.split(",")[0]?.trim() || "http";
+    const firstForwardedProtocol = forwardedProtocol.split(",")[0]?.trim();
+
+    if (firstForwardedProtocol) {
+      return firstForwardedProtocol;
+    }
+
+    return "http";
   }
 
   return (request.raw.socket as { encrypted?: boolean }).encrypted
@@ -109,7 +115,9 @@ const getRequestProtocol = (request: BetterAuthFastifyRequest) => {
 export const buildBetterAuthRequest = async (
   request: BetterAuthFastifyRequest,
 ) => {
-  const origin = `${getRequestProtocol(request)}://${getHeaderValue(request.headers.host) ?? "localhost"}`;
+  const requestProtocol = getRequestProtocol(request);
+  const requestHost = getHeaderValue(request.headers.host) ?? "localhost";
+  const origin = `${requestProtocol}://${requestHost}`;
   const parsedBody = serializeParsedBody(request.body, request.headers);
   const body =
     parsedBody ??

--- a/apps/auth/src/app.factory.spec.ts
+++ b/apps/auth/src/app.factory.spec.ts
@@ -13,19 +13,21 @@ const createRequest = ({
   headers,
   method,
   rawBody,
+  socketEncrypted = false,
   url,
 }: {
   body?: unknown;
   headers: Record<string, string>;
   method: string;
   rawBody?: string;
+  socketEncrypted?: boolean;
   url: string;
 }) => {
   const rawRequest = Readable.from(rawBody ? [rawBody] : []) as MockRawRequest;
   rawRequest.headers = headers;
   rawRequest.method = method;
   rawRequest.url = url;
-  rawRequest.socket = { encrypted: false };
+  rawRequest.socket = { encrypted: socketEncrypted };
 
   return {
     body,
@@ -96,5 +98,35 @@ describe("buildBetterAuthRequest", () => {
       "http://localhost/idp/callback/discord?code=test-code&state=test-state",
     );
     expect(authRequest.method).toBe("GET");
+  });
+
+  it("uses the first forwarded protocol when building the request origin", async () => {
+    const request = createRequest({
+      headers: {
+        host: "lootlog.pl",
+        "x-forwarded-proto": "https, http",
+      },
+      method: "GET",
+      url: "/idp/callback/discord",
+    });
+
+    const authRequest = await buildBetterAuthRequest(request);
+
+    expect(authRequest.url).toBe("https://lootlog.pl/idp/callback/discord");
+  });
+
+  it("uses the socket protocol when forwarded protocol is absent", async () => {
+    const request = createRequest({
+      headers: {
+        host: "lootlog.pl",
+      },
+      method: "GET",
+      socketEncrypted: true,
+      url: "/idp/callback/discord",
+    });
+
+    const authRequest = await buildBetterAuthRequest(request);
+
+    expect(authRequest.url).toBe("https://lootlog.pl/idp/callback/discord");
   });
 });


### PR DESCRIPTION
## Summary

- split auth request origin construction into named protocol and host values
- make forwarded-protocol fallback explicit instead of relying on a compact truthy fallback
- add tests for forwarded proxy protocol handling and encrypted socket fallback

## Verification

- `corepack pnpm --filter @lootlog/auth test -- app.factory.spec.ts`
- `corepack pnpm --filter @lootlog/auth lint`
- `corepack pnpm format:check`
- `corepack pnpm --filter @lootlog/nest-shared run build` to refresh injected workspace dependency outputs
- `corepack pnpm turbo run build --filter=@lootlog/auth...`
- `corepack pnpm turbo run test --filter=@lootlog/auth`
- pre-commit hook: lint-staged, changed-package lint, changed-package tests

Note: dependency installation with pnpm 10.32.1 completed; pnpm reported that `necord@6.14.0` build scripts remain skipped by the repo approval policy, which was not needed for this auth change.