### PR TITLE
[codex] Narrow API helper permission exports

### DIFF
--- a/packages/api-helpers/src/index.ts
+++ b/packages/api-helpers/src/index.ts
@@ -1,4 +1,3 @@
 export * from "./lib/auth/middleware/user-metadata.middleware.js";
 export * from "./lib/auth/utils/verify-jwt.js";
 export * from "./lib/auth/utils/verify-jwt.types.js";
-export * from "./lib/permissions/can-view-npc-timer";

--- a/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
+++ b/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
@@ -4,7 +4,7 @@ export type NpcPermissionData = {
 };
 
 export type RolePermissionData = {
-  permissions: string[];
+  permissions: readonly string[];
   lvlRangeFrom: number;
   lvlRangeTo: number;
 };
@@ -44,7 +44,7 @@ const getRequiredTimerPermission = (npcType: string): TimerPermission =>
 
 export const canViewNpcTimer = (
   npc: NpcPermissionData | null,
-  roles: RolePermissionData[],
+  roles: readonly RolePermissionData[],
 ): boolean => {
   if (!npc) return false;
 


### PR DESCRIPTION
Closed by automation: after opening this draft I found the persisted automation memory under `/Users/kamil/.codex`, which notes recent `@lootlog/api-helpers` entrypoint work. This PR is therefore duplicative of an avoided area for the hourly refactor scout.