### PR TITLE
[codex] Simplify presence level normalization

### DIFF
--- a/apps/gateway/src/gateway/utils/normalize-presence-level.ts
+++ b/apps/gateway/src/gateway/utils/normalize-presence-level.ts
@@ -1,10 +1,12 @@
-export const normalizePresenceLevel = (level: unknown) => {
+export const normalizePresenceLevel = (level: unknown): number => {
   if (typeof level === "number" && Number.isFinite(level)) {
     return level;
   }
 
-  const normalizedLevel =
-    typeof level === "string" ? Number.parseInt(level, 10) : Number.NaN;
+  if (typeof level !== "string") {
+    return 0;
+  }
 
+  const normalizedLevel = Number.parseInt(level, 10);
   return Number.isFinite(normalizedLevel) ? normalizedLevel : 0;
 };


### PR DESCRIPTION
## Summary

- Make `normalizePresenceLevel` return `number` explicitly.
- Replace the `Number.NaN` sentinel path with a direct non-string guard before parsing string levels.

## Impact

Runtime behavior is unchanged; numeric levels still pass through, string levels still use `Number.parseInt`, and invalid values still normalize to `0`. The control flow is easier to read and the helper contract is clearer.

## Verification

- `pnpm --filter @lootlog/gateway exec vitest run --config ./vitest.config.ts src/gateway/utils/normalize-presence-level.spec.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm exec oxfmt --check apps/gateway/src/gateway/utils/normalize-presence-level.ts`
- `pnpm exec oxlint apps/gateway/src/gateway/utils/normalize-presence-level.ts`
- `pnpm turbo run build --filter=@lootlog/gateway`
- `pnpm lint-staged`
- `pnpm turbo run lint --filter='[HEAD]'`
- `pnpm turbo run format:check --filter='[HEAD]'` (no `format:check` task for `@lootlog/gateway`; file-level `oxfmt` passed)
- `pnpm turbo run test --filter='[HEAD]'`
- Git pre-commit hook passed during commit.