### PR TITLE
[codex] Align permissions update payload type

### DIFF
--- a/apps/game-client/src/contexts/socket-context.tsx
+++ b/apps/game-client/src/contexts/socket-context.tsx
@@ -4,7 +4,11 @@ import {
   DEV_PERMISSION_OVERRIDE_EVENT,
   getSerializedDevPermissionOverride,
 } from "@/lib/dev-permission-override";
-import { type AppSocket, getSocket } from "@/lib/socket";
+import {
+  type AppSocket,
+  getSocket,
+  type PermissionsUpdatedPayload,
+} from "@/lib/socket";
 import { useGlobalStore } from "@/store/global.store";
 import {
   createContext,
@@ -104,9 +108,7 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
         isAfk: false,
       });
     };
-    const handlePermissionsUpdated = (data: {
-      guilds: { guild: { id: string } }[];
-    }) => {
+    const handlePermissionsUpdated = (data: PermissionsUpdatedPayload) => {
       if (import.meta.env.DEV) {
         console.log("[Gateway] Rooms rebalanced:", data);
       }
@@ -120,7 +122,7 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
         return;
       }
 
-      setJoinedGuilds(data.guilds.map((g) => g.guild.id) || []);
+      setJoinedGuilds(data.guilds.map((g) => g.guild.id));
     };
 
     socket.on(GatewayEvent.CONNECT, handleConnect);

--- a/apps/game-client/src/lib/socket.ts
+++ b/apps/game-client/src/lib/socket.ts
@@ -15,6 +15,11 @@ import type {
   PartyGatheringSession,
 } from "@/store/party-finder.store";
 
+export type PermissionsUpdatedPayload = {
+  guilds?: { guild: { id: string } }[];
+  featureRooms?: string[];
+};
+
 type ServerToClientEvents = {
   [GatewayEvent.DISCONNECT]: () => void;
   [GatewayEvent.DISCONNECTING]: () => void;
@@ -26,9 +31,7 @@ type ServerToClientEvents = {
     guildIds: string[];
   }) => void;
 
-  [GatewayEvent.PERMISSIONS_UPDATED]: (data: {
-    guilds: { guild: { id: string } }[];
-  }) => void;
+  [GatewayEvent.PERMISSIONS_UPDATED]: (data: PermissionsUpdatedPayload) => void;
 
   [GatewayEvent.TIMERS_CREATE]: (data: Timer) => void;
   [GatewayEvent.TIMERS_DELETE]: (data: Timer) => void;


### PR DESCRIPTION
## Summary

- Extracted a shared `PermissionsUpdatedPayload` type for the game-client socket event map.
- Included the gateway-emitted `featureRooms` field in the client payload shape.
- Reused that payload type in `SocketProvider` and removed an unreachable `|| []` fallback after mapping guarded guild data.

## Verification

- `pnpm exec oxfmt --check apps/game-client/src/lib/socket.ts apps/game-client/src/contexts/socket-context.tsx`
- `pnpm exec oxlint apps/game-client/src/lib/socket.ts apps/game-client/src/contexts/socket-context.tsx` (warnings only for existing dev console calls)
- `pnpm -r --filter @lootlog/types --filter @lootlog/margonem --filter @lootlog/socket-parser build`
- `pnpm --filter @lootlog/game-client test`
- `pnpm --filter @lootlog/game-client build`
- `pnpm format:check`
- `pnpm lint` (warnings only in existing unrelated packages)
- Pre-commit hook passed: lint-staged, changed-package lint/format tasks, and changed-package tests