### PR TITLE
[codex] fix injected package build artifacts

### DIFF
--- a/apps/api/src/notifications/notification-rule.service.ts
+++ b/apps/api/src/notifications/notification-rule.service.ts
@@ -26,6 +26,7 @@ import type { CreateNotificationRuleDto } from "src/notifications/dto/create-not
 import type { UpdateNotificationRuleDto } from "src/notifications/dto/update-notification-rule.dto";
 import {
   calculateFirstOccurrenceInTimeZone,
+  isRecurringScheduleInterval,
   isValidTimeZone,
 } from "src/notifications/utils/notification-schedule-time.util";
 import { ensureLimitNotExceeded } from "src/notifications/utils/ensure-limit-not-exceeded.util";
@@ -783,8 +784,7 @@ export class NotificationRuleService {
 
     if (
       ownerType === DbNotificationOwnerType.USER &&
-      (intervalType === DbNotificationScheduleIntervalType.DAILY ||
-        intervalType === DbNotificationScheduleIntervalType.WEEKLY) &&
+      isRecurringScheduleInterval(intervalType) &&
       !scheduleTimezone
     ) {
       throw new BadRequestException(
@@ -802,8 +802,7 @@ export class NotificationRuleService {
 
     if (
       !scheduledAt &&
-      (intervalType === DbNotificationScheduleIntervalType.DAILY ||
-        intervalType === DbNotificationScheduleIntervalType.WEEKLY) &&
+      isRecurringScheduleInterval(intervalType) &&
       timeOfDay &&
       scheduleTimezone
     ) {

--- a/apps/api/src/notifications/utils/notification-schedule-time.util.ts
+++ b/apps/api/src/notifications/utils/notification-schedule-time.util.ts
@@ -15,6 +15,15 @@ export function isValidTimeZone(timeZone: string): boolean {
   }
 }
 
+export function isRecurringScheduleInterval(
+  intervalType: NotificationScheduleIntervalType,
+): boolean {
+  return (
+    intervalType === NotificationScheduleIntervalType.DAILY ||
+    intervalType === NotificationScheduleIntervalType.WEEKLY
+  );
+}
+
 export function calculateFirstOccurrenceInTimeZone(params: {
   intervalType: NotificationScheduleIntervalType;
   timeOfDay: string;

--- a/packages/api-helpers/package.json
+++ b/packages/api-helpers/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "license": "MIT",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "typesVersions": {
     "*": {
       "auth/user-metadata": [

--- a/packages/api-helpers/tsdown.config.ts
+++ b/packages/api-helpers/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "auth/verify-jwt": "src/lib/auth/utils/verify-jwt.ts",
     permissions: "src/lib/permissions/can-view-npc-timer.ts",
   },
+  dts: true,
   format: ["esm", "cjs"],
   outExtensions: ({ format }) => ({
     js: format === "cjs" ? ".js" : ".mjs",

--- a/packages/nest-shared/package.json
+++ b/packages/nest-shared/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "Shared NestJS modules, services, and utilities for backend microservices",
   "license": "MIT",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Allow `@lootlog/api-helpers` and `@lootlog/nest-shared` package tarballs to include their built `dist` output for pnpm injected workspace installs.
- Enable declaration output for `@lootlog/api-helpers` so its exported `types` paths resolve.
- Extract a shared `isRecurringScheduleInterval` helper for notification schedule checks.

## Root cause
`inject-workspace-packages` installs some workspace dependencies from packed package contents. `@lootlog/nest-shared` and `@lootlog/api-helpers` did not explicitly include `dist`, so injected copies could miss the files referenced by their `exports` maps.

## Verification
- `corepack pnpm turbo run build --filter=@lootlog/api...`
- `corepack pnpm turbo run test --filter=@lootlog/api`
- `corepack pnpm turbo run lint --filter=@lootlog/api`
- `corepack pnpm exec oxfmt --check apps/api/src/notifications/notification-rule.service.ts apps/api/src/notifications/utils/notification-schedule-time.util.ts packages/api-helpers/package.json packages/api-helpers/tsdown.config.ts packages/nest-shared/package.json`
- `.husky/pre-commit`

Note: API lint currently reports existing warnings but exits with 0 errors.