### PR TITLE
[codex] simplify event create navigation

### DIFF
--- a/apps/web/src/features/guild/events/components/dialogs/event-create-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/event-create-dialog.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { Button } from "@lootlog/ui/components/button";
@@ -95,10 +95,6 @@ export const EventCreateDialog = ({
     }
     onOpenChange(isOpen);
   };
-
-  const canGoNext = useMemo(() => {
-    return scoringMode === "SIMPLE" || scoringMode === "ADVANCED";
-  }, [scoringMode]);
 
   const onSubmit = (data: FormData) => {
     if (data.endsAt && data.startsAt && data.endsAt <= data.startsAt) {
@@ -380,7 +376,6 @@ export const EventCreateDialog = ({
               type="button"
               size="sm"
               className="flex-1"
-              disabled={!canGoNext}
               onClick={() => setStep(2)}
             >
               {t("events.createDialog.next", "Dalej")}


### PR DESCRIPTION
## Summary

Removes a dead `canGoNext` branch from the event create dialog. `normalizeScoringMode` already narrows the value to the supported scoring modes, so the check was always true and only kept an unnecessary `useMemo` import in the component.

## Impact

No behavior change intended. The next-step button remains enabled, matching the previous normalized-mode behavior, with less component state noise.

## Verification

- `corepack pnpm install`
- `corepack pnpm --filter @lootlog/web lint`
- `corepack pnpm turbo run build --filter=@lootlog/web...`
- `corepack pnpm format:check`
- `corepack pnpm turbo run lint --filter=@lootlog/web...`
- `corepack pnpm turbo run test --filter=@lootlog/web...` (web has no test script; dependency build tasks ran)
- `VITE_AUTH_SERVICE_URL=http://localhost/api/auth corepack pnpm --filter @lootlog/web exec vitest run src/features/guild/events`
- `.husky/pre-commit`

Notes: the build reports an existing direct-eval warning from `lottie-web`; lint also replays an existing cached `@lootlog/ui` `<img>` warning. Neither is introduced by this PR.