### PR TITLE
[codex] refactor reservation schedule date helpers

### DIFF
--- a/apps/web/src/features/guild/reservations/schedule/utils.spec.ts
+++ b/apps/web/src/features/guild/reservations/schedule/utils.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReservationSegment } from "./types";
+import {
+  formatDateWithTime,
+  formatSegmentTime,
+  getDateOfISOWeek,
+  getISOWeek,
+  getISOWeekYear,
+  getLastISOWeek,
+  shouldShowEndDateOnFirstSegment,
+} from "./utils";
+
+const createSegment = ({
+  isReservationStart,
+  reservationEnd,
+  segmentStart,
+}: {
+  isReservationStart: boolean;
+  reservationEnd: Date;
+  segmentStart: Date;
+}): ReservationSegment => ({
+  reservation: {
+    toDate: reservationEnd,
+  } as ReservationSegment["reservation"],
+  id: "segment",
+  dayIdx: 0,
+  startHour: 0,
+  durationHours: 1,
+  segmentStart,
+  segmentEnd: reservationEnd,
+  isReservationStart,
+});
+
+describe("reservation schedule utils", () => {
+  it("formats same-day segment times without a date prefix", () => {
+    expect(
+      formatSegmentTime(new Date(2026, 0, 5, 9, 5), new Date(2026, 0, 5, 0, 0)),
+    ).toBe("09:05");
+  });
+
+  it("formats cross-day segment times with a date prefix", () => {
+    expect(
+      formatSegmentTime(
+        new Date(2026, 0, 6, 1, 30),
+        new Date(2026, 0, 5, 0, 0),
+      ),
+    ).toBe("06.01 01:30");
+  });
+
+  it("formats dates with their time", () => {
+    expect(formatDateWithTime(new Date(2026, 10, 9, 7, 45))).toBe(
+      "09.11 07:45",
+    );
+  });
+
+  it("shows an end date on first segments that end on a later calendar day", () => {
+    const segment = createSegment({
+      isReservationStart: true,
+      segmentStart: new Date(2026, 0, 5, 22, 0),
+      reservationEnd: new Date(2026, 0, 6, 1, 0),
+    });
+
+    expect(shouldShowEndDateOnFirstSegment(segment)).toBe(true);
+  });
+
+  it("does not show an end date for same-day or continuation segments", () => {
+    const sameDaySegment = createSegment({
+      isReservationStart: true,
+      segmentStart: new Date(2026, 0, 5, 9, 0),
+      reservationEnd: new Date(2026, 0, 5, 10, 0),
+    });
+    const continuationSegment = createSegment({
+      isReservationStart: false,
+      segmentStart: new Date(2026, 0, 6, 0, 0),
+      reservationEnd: new Date(2026, 0, 6, 1, 0),
+    });
+
+    expect(shouldShowEndDateOnFirstSegment(sameDaySegment)).toBe(false);
+    expect(shouldShowEndDateOnFirstSegment(continuationSegment)).toBe(false);
+  });
+
+  it("calculates ISO week and year around year boundaries", () => {
+    expect(getISOWeek(new Date(2026, 0, 1))).toBe(1);
+    expect(getISOWeekYear(new Date(2026, 0, 1))).toBe(2026);
+    expect(getISOWeek(new Date(2027, 0, 1))).toBe(53);
+    expect(getISOWeekYear(new Date(2027, 0, 1))).toBe(2026);
+  });
+
+  it("returns ISO week start dates", () => {
+    expect(getDateOfISOWeek(1, 2026)).toEqual(new Date(2025, 11, 29));
+    expect(getDateOfISOWeek(53, 2026)).toEqual(new Date(2026, 11, 28));
+    expect(getLastISOWeek(2026)).toBe(53);
+  });
+});

--- a/apps/web/src/features/guild/reservations/schedule/utils.ts
+++ b/apps/web/src/features/guild/reservations/schedule/utils.ts
@@ -1,18 +1,20 @@
 import type { ReservationSegment } from "./types";
 
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
 const formatTime = (date: Date) =>
   `${date.getHours().toString().padStart(2, "0")}:${date
     .getMinutes()
     .toString()
     .padStart(2, "0")}`;
 
-export const formatSegmentTime = (date: Date, reference: Date) => {
-  const isSameDay =
-    date.getFullYear() === reference.getFullYear() &&
-    date.getMonth() === reference.getMonth() &&
-    date.getDate() === reference.getDate();
+const isSameCalendarDay = (date: Date, reference: Date) =>
+  date.getFullYear() === reference.getFullYear() &&
+  date.getMonth() === reference.getMonth() &&
+  date.getDate() === reference.getDate();
 
-  if (isSameDay) {
+export const formatSegmentTime = (date: Date, reference: Date) => {
+  if (isSameCalendarDay(date, reference)) {
     return formatTime(date);
   }
 
@@ -37,11 +39,7 @@ export const shouldShowEndDateOnFirstSegment = (
   const reservationEnd = segment.reservation.toDate;
   const segmentStart = segment.segmentStart;
 
-  return !(
-    reservationEnd.getFullYear() === segmentStart.getFullYear() &&
-    reservationEnd.getMonth() === segmentStart.getMonth() &&
-    reservationEnd.getDate() === segmentStart.getDate()
-  );
+  return !isSameCalendarDay(reservationEnd, segmentStart);
 };
 
 export function getISOWeek(date = new Date()) {
@@ -55,7 +53,7 @@ export function getISOWeek(date = new Date()) {
   }
   const weekNumber =
     1 +
-    Math.ceil((Number(firstThursday) - Number(target.valueOf())) / 604800000);
+    Math.ceil((Number(firstThursday) - Number(target.valueOf())) / MS_PER_WEEK);
   return weekNumber;
 }
 
@@ -74,7 +72,10 @@ export function getDateOfISOWeek(week: number, year: number) {
   const simple = new Date(year, 0, 1 + (week - 1) * 7);
   const dow = simple.getDay();
   const ISOweekStart = simple;
-  if (dow <= 4) ISOweekStart.setDate(simple.getDate() - simple.getDay() + 1);
-  else ISOweekStart.setDate(simple.getDate() + 8 - simple.getDay());
+  if (dow <= 4) {
+    ISOweekStart.setDate(simple.getDate() - simple.getDay() + 1);
+  } else {
+    ISOweekStart.setDate(simple.getDate() + 8 - simple.getDay());
+  }
   return ISOweekStart;
 }


### PR DESCRIPTION
## Summary
- Extract the repeated same-calendar-day comparison used by reservation schedule formatting helpers.
- Replace the ISO week millisecond literal with a named `MS_PER_WEEK` constant.
- Add focused Vitest coverage for reservation schedule time formatting, end-date visibility, and ISO week helpers.

## Verification
- `pnpm --filter @lootlog/web exec vitest run src/features/guild/reservations/schedule/utils.spec.ts`
- `pnpm exec oxfmt --check apps/web/src/features/guild/reservations/schedule/utils.ts apps/web/src/features/guild/reservations/schedule/utils.spec.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web`
- `.husky/pre-commit`

Notes: `pnpm install --frozen-lockfile` linked dependencies in this fresh worktree but exited after pnpm generated build-script approval prompts; no package metadata changes were kept. The repo pre-commit hook's `test` step does not run the new web spec because `@lootlog/web` has no package-level `test` script, so the spec was run directly.