### PR TITLE
[codex] Simplify guild nav item export

### DIFF
--- a/apps/web/src/components/layout/guild-nav-item.tsx
+++ b/apps/web/src/components/layout/guild-nav-item.tsx
@@ -11,8 +11,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@lootlog/ui/components/tooltip";
-import type { FC } from "react";
-import type React from "react";
+import type { FC, MouseEvent } from "react";
 import { Link } from "@tanstack/react-router";
 import { ThemeCircularFrame, useThemeMeta } from "@/themes";
 import { useTranslation } from "react-i18next";
@@ -24,7 +23,7 @@ export type GuildNavItemProps = {
   unreadLootsCount?: number;
 };
 
-const GuildNavItemComponent: FC<GuildNavItemProps> = ({
+export const GuildNavItem: FC<GuildNavItemProps> = ({
   guild,
   isDragging = false,
   currentGuildId,
@@ -35,7 +34,7 @@ const GuildNavItemComponent: FC<GuildNavItemProps> = ({
   const isActive =
     currentGuildId === guild.id || currentGuildId === guild.vanityUrl;
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: MouseEvent) => {
     if (isDragging) {
       e.preventDefault();
       e.stopPropagation();
@@ -93,5 +92,3 @@ const GuildNavItemComponent: FC<GuildNavItemProps> = ({
     </Tooltip>
   );
 };
-
-export const GuildNavItem = GuildNavItemComponent;


### PR DESCRIPTION
## Summary

- Export `GuildNavItem` directly instead of via an intermediate `GuildNavItemComponent` alias.
- Collapse duplicate React type imports into a single type import and use `MouseEvent` directly.

## Impact

This is a source-only clarity refactor in the web layout component. It does not change routing, rendering, styling, translations, or runtime behavior.

## Verification

- `pnpm --filter @lootlog/web lint`
- `pnpm exec oxfmt --check apps/web/src/components/layout/guild-nav-item.tsx`
- `pnpm turbo run build --filter=@lootlog/web...`
- `git commit` pre-commit hook passed, including lint-staged and changed-package Turbo checks.