### PR TITLE
[codex] Remove unused roles error enum

### DIFF
--- a/apps/api/src/roles/enum/error-key.enum.ts
+++ b/apps/api/src/roles/enum/error-key.enum.ts
@@ -1,1 +1,0 @@
-export enum ErrorKey {}


### PR DESCRIPTION
## Summary

- Remove the unused empty `ErrorKey` enum from `apps/api/src/roles/enum/error-key.enum.ts`.
- Keep the refactor scoped to dead code only; no runtime imports or behavior depended on this file.

## Verification

- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/roles/roles.controller.spec.ts src/roles/roles.service.spec.ts`
- `pnpm turbo run build --filter=@lootlog/api`
- `pnpm format:check`
- `pnpm turbo run test '--filter=[HEAD]'`
- `pnpm turbo run lint '--filter=[HEAD]'` (passes with existing warnings)
- `pnpm turbo run format:check '--filter=[HEAD]'` (no package task configured)
- Pre-commit hook ran successfully during commit, including changed-package lint, format check, and tests.