### PR TITLE
[codex] remove battlelog type suppressions

### DIFF
--- a/apps/battlelog-service/scripts/migrate-init.ts
+++ b/apps/battlelog-service/scripts/migrate-init.ts
@@ -7,7 +7,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import pg from "pg";
 
 const databaseUrl = process.env.POSTGRESQL_CONNECTION_URI;
@@ -15,8 +14,6 @@ if (!databaseUrl) {
   throw new Error("POSTGRESQL_CONNECTION_URI is required");
 }
 
-// @ts-ignore
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const migrationsFolder = path.resolve(__dirname, "../drizzle");
 const migrationsSchema = "drizzle";
 const migrationsTable = "__drizzle_migrations";

--- a/packages/battle-processor/src/index.ts
+++ b/packages/battle-processor/src/index.ts
@@ -2113,7 +2113,9 @@ export class BattleProcessor {
           losingTeam = t2;
         }
       } else if (winningTeam === null) {
-        winningTeam = getDefaultOpposingTeam(losingTeam);
+        if (losingTeam !== null) {
+          winningTeam = getDefaultOpposingTeam(losingTeam);
+        }
       } else if (losingTeam === null) {
         losingTeam = getDefaultOpposingTeam(winningTeam);
       }


### PR DESCRIPTION
## Summary
- Remove the `@ts-ignore` in the battlelog migration init script by using Node `__dirname` directly.
- Make the battle outcome fallback narrowing explicit before deriving a missing winning team.

## Verification
- `pnpm exec oxfmt --check apps/battlelog-service/scripts/migrate-init.ts packages/battle-processor/src/index.ts`
- `pnpm exec oxlint apps/battlelog-service/scripts/migrate-init.ts packages/battle-processor/src/index.ts`
- `pnpm --dir apps/battlelog-service exec tsc --noEmit --ignoreConfig --module NodeNext --moduleResolution NodeNext --target ES2023 --types node --skipLibCheck --esModuleInterop --allowSyntheticDefaultImports scripts/migrate-init.ts`
- `pnpm --filter @lootlog/battle-processor build`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm --filter @lootlog/battlelog-service build`
- `pnpm --filter @lootlog/battlelog-service test`
- `.husky/pre-commit`
