### PR TITLE
[codex] share API own-field helper

### DIFF
--- a/apps/api/src/guilds/guilds.service.ts
+++ b/apps/api/src/guilds/guilds.service.ts
@@ -29,6 +29,7 @@ import { ErrorKey } from "src/guilds/enum/error-key.enum";
 import { MembersService } from "src/members/members.service";
 import { RolesService } from "src/roles/roles.service";
 import { generateSlug } from "src/shared/utils/generate-slug";
+import { hasOwnField } from "src/shared/utils/has-own-field";
 import { RESTRICTED_VANITY_URLS } from "src/guilds/constants/restricted-vanity-urls";
 import { DiscordService } from "src/discord/discord.service";
 import { RedisService } from "@lootlog/nest-shared/redis";
@@ -1235,7 +1236,7 @@ export class GuildsService {
     const guild = await this.prisma.guild.update({
       where: { id: guildId },
       data: {
-        ...(Object.prototype.hasOwnProperty.call(data, "vanityUrl")
+        ...(hasOwnField(data, "vanityUrl")
           ? { vanityUrl: generateSlug(data.vanityUrl ?? undefined) }
           : {}),
         ...(data.publicStatsCardEnabled !== undefined

--- a/apps/api/src/notifications/notification-rule.service.ts
+++ b/apps/api/src/notifications/notification-rule.service.ts
@@ -29,7 +29,7 @@ import {
   isValidTimeZone,
 } from "src/notifications/utils/notification-schedule-time.util";
 import { ensureLimitNotExceeded } from "src/notifications/utils/ensure-limit-not-exceeded.util";
-import { hasOwnUpdateField } from "src/notifications/utils/has-own-update-field.util";
+import { hasOwnField } from "src/shared/utils/has-own-field";
 import {
   type TestTriggerUsage,
   computeTestTriggerUsage,
@@ -373,9 +373,9 @@ export class NotificationRuleService {
     ruleId: number,
     data: UpdateNotificationRuleDto,
   ) {
-    const hasName = hasOwnUpdateField(data, "name");
-    const hasWorld = hasOwnUpdateField(data, "world");
-    const hasContentTemplate = hasOwnUpdateField(data, "contentTemplate");
+    const hasName = hasOwnField(data, "name");
+    const hasWorld = hasOwnField(data, "world");
+    const hasContentTemplate = hasOwnField(data, "contentTemplate");
     const existingRule = await this.ensureRule({ ownerType, ownerId, ruleId });
     const nextTriggerType =
       (data.triggerType as DbNotificationTriggerType | undefined) ??
@@ -766,7 +766,7 @@ export class NotificationRuleService {
       data.scheduleWeekday ?? existingRule?.scheduleWeekday ?? null;
     const timeOfDay =
       data.scheduleTimeOfDay ?? existingRule?.scheduleTimeOfDay ?? null;
-    const hasScheduledUntil = hasOwnUpdateField(data, "scheduledUntil");
+    const hasScheduledUntil = hasOwnField(data, "scheduledUntil");
     let scheduledUntil = existingRule?.scheduledUntil ?? null;
 
     if (hasScheduledUntil) {

--- a/apps/api/src/notifications/notification-target.service.ts
+++ b/apps/api/src/notifications/notification-target.service.ts
@@ -31,7 +31,7 @@ import {
   computeTestTriggerUsage,
   getDefaultTestTriggerUsage,
 } from "src/notifications/utils/test-trigger-usage.util";
-import { hasOwnUpdateField } from "src/notifications/utils/has-own-update-field.util";
+import { hasOwnField } from "src/shared/utils/has-own-field";
 
 const USER_DM_TEST_TRIGGER_LIMIT = 5;
 const USER_DM_TEST_TRIGGER_WINDOW_MS = 15 * 60_000;
@@ -421,7 +421,7 @@ export class NotificationTargetService {
   private getDisplayNameUpdate(
     data: Pick<UpdateNotificationTargetDto, "displayName">,
   ): Pick<Prisma.NotificationTargetUpdateInput, "displayName"> {
-    if (!hasOwnUpdateField(data, "displayName")) {
+    if (!hasOwnField(data, "displayName")) {
       return {};
     }
 

--- a/apps/api/src/shared/utils/has-own-field.spec.ts
+++ b/apps/api/src/shared/utils/has-own-field.spec.ts
@@ -1,14 +1,14 @@
-import { hasOwnUpdateField } from "./has-own-update-field.util";
+import { hasOwnField } from "./has-own-field";
 
-describe("hasOwnUpdateField", () => {
+describe("hasOwnField", () => {
   it("detects nullable fields explicitly present in partial update data", () => {
-    expect(hasOwnUpdateField({ displayName: null }, "displayName")).toBe(true);
+    expect(hasOwnField({ displayName: null }, "displayName")).toBe(true);
   });
 
   it("returns false when the partial update field is omitted", () => {
     const updateData: { displayName?: string | null } = {};
 
-    expect(hasOwnUpdateField(updateData, "displayName")).toBe(false);
+    expect(hasOwnField(updateData, "displayName")).toBe(false);
   });
 
   it("ignores fields inherited from the prototype chain", () => {
@@ -16,6 +16,6 @@ describe("hasOwnUpdateField", () => {
       displayName: "inherited",
     }) as { displayName?: string };
 
-    expect(hasOwnUpdateField(updateData, "displayName")).toBe(false);
+    expect(hasOwnField(updateData, "displayName")).toBe(false);
   });
 });

--- a/apps/api/src/shared/utils/has-own-field.ts
+++ b/apps/api/src/shared/utils/has-own-field.ts
@@ -1,4 +1,4 @@
-export function hasOwnUpdateField<TData extends object>(
+export function hasOwnField<TData extends object>(
   data: TData,
   field: keyof TData,
 ) {


### PR DESCRIPTION
## Summary
- Move the generic own-field check from notifications into `src/shared/utils/has-own-field`.
- Update notification rule/target updates and guild config vanity URL handling to use the shared helper.
- Keep the inherited-property regression coverage with the moved helper spec.

## Verification
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --filter @lootlog/api-helpers build`
- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/shared/utils/has-own-field.spec.ts src/guilds/guilds.service.spec.ts src/notifications/notifications.service.spec.ts`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm exec oxfmt --check apps/api/src/shared/utils/has-own-field.ts apps/api/src/shared/utils/has-own-field.spec.ts apps/api/src/guilds/guilds.service.ts apps/api/src/notifications/notification-rule.service.ts apps/api/src/notifications/notification-target.service.ts`
- `pnpm --filter @lootlog/api build`
- `pnpm --filter @lootlog/api test`
- `sh .husky/pre-commit`
- commit hooks ran successfully during `git commit`