### PR TITLE
refactor: simplify package subpath exports

### DIFF
--- a/packages/api-helpers/tsdown.config.ts
+++ b/packages/api-helpers/tsdown.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
+  dts: true,
   entry: {
     "auth/user-metadata": "src/lib/auth/middleware/user-metadata.middleware.ts",
     "auth/verify-jwt": "src/lib/auth/utils/verify-jwt.ts",

--- a/packages/nest-shared/package.json
+++ b/packages/nest-shared/package.json
@@ -20,8 +20,8 @@
       "default": "./dist/decorators/index.js"
     },
     "./openapi": {
-      "types": "./dist/openapi/index.d.ts",
-      "default": "./dist/openapi/index.js"
+      "types": "./dist/openapi/openapi-document.d.ts",
+      "default": "./dist/openapi/openapi-document.js"
     },
     "./redis": {
       "types": "./dist/redis/index.d.ts",

--- a/packages/nest-shared/src/index.ts
+++ b/packages/nest-shared/src/index.ts
@@ -29,4 +29,4 @@ export {
   openApiYamlDumpOptions,
   sanitizeOpenApiDocument,
   type OpenApiYamlDumpOptions,
-} from "./openapi";
+} from "./openapi/openapi-document";

--- a/packages/nest-shared/src/openapi/index.ts
+++ b/packages/nest-shared/src/openapi/index.ts
@@ -1,6 +1,0 @@
-export {
-  openApiYamlDumpOptions,
-  sanitizeOpenApiDocument,
-  writeOpenApiDocumentToYamlFile,
-  type OpenApiYamlDumpOptions,
-} from "./openapi-document";

--- a/scripts/sanitize-openapi.ts
+++ b/scripts/sanitize-openapi.ts
@@ -5,7 +5,7 @@ import {
   openApiYamlDumpOptions,
   type OpenApiYamlDumpOptions,
   sanitizeOpenApiDocument,
-} from "../packages/nest-shared/src/openapi";
+} from "../packages/nest-shared/src/openapi/openapi-document";
 
 type YamlModule = {
   load: (content: string) => unknown;


### PR DESCRIPTION
## Summary
- remove the re-export-only OpenAPI barrel from @lootlog/nest-shared and point the ./openapi package export at the implementation module
- update the OpenAPI sanitizer script to import the implementation directly
- enable declaration output for @lootlog/api-helpers subpath exports so downstream package builds resolve types

## Verification
- pnpm format:check
- pnpm turbo run build --filter=@lootlog/nest-shared
- pnpm turbo run build --filter=@lootlog/api-helpers --concurrency=1
- pnpm turbo run build --filter=@lootlog/auth --concurrency=1
- pnpm turbo run build --filter=@lootlog/api --concurrency=1
- pnpm turbo run build --filter=@lootlog/search --concurrency=1
- pnpm turbo run build --filter=@lootlog/activity --concurrency=1
- pnpm turbo run build --filter=@lootlog/battlelog-service --concurrency=1
- pnpm turbo run test --filter=@lootlog/activity --filter=@lootlog/search --filter=@lootlog/auth --filter=@lootlog/battlelog-service --filter=@lootlog/api --concurrency=1
- pnpm turbo run lint --filter=@lootlog/api --filter=@lootlog/auth --filter=@lootlog/activity --filter=@lootlog/battlelog-service --concurrency=1
- pnpm lint
- pnpm turbo run build --concurrency=1
- sh .husky/pre-commit