### PR TITLE
[codex] Extract battle team presentation helper

### DIFF
--- a/apps/web/src/components/battle/battle-compact-overview-card.tsx
+++ b/apps/web/src/components/battle/battle-compact-overview-card.tsx
@@ -3,16 +3,14 @@ import { cn } from "@lootlog/ui/lib/utils";
 import { Flag, Trophy, type LucideIcon } from "lucide-react";
 import type { FC } from "react";
 import { useTranslation } from "react-i18next";
-import type {
-  Battle,
-  BattleWarrior as Warrior,
-} from "@/lib/api/battlelog-types";
+import type { Battle } from "@/lib/api/battlelog-types";
 import {
   BATTLE_BADGE_COLORS,
   BATTLE_SURFACE_COLORS,
 } from "./utils/battle-color-palette";
 import { BattleCompactTeam } from "./battle-compact-team";
 import { BattleMetadata } from "./battle-metadata";
+import { getBattleTeamPresentation } from "./utils/battle-team-presentation";
 
 export type BattleCompactOverviewCardProps = {
   battle: Battle;
@@ -41,20 +39,8 @@ export const BattleCompactOverviewCard: FC<BattleCompactOverviewCardProps> = ({
   currentUserCharacterId,
 }) => {
   const { t } = useTranslation();
-  const characterId = currentUserCharacterId ?? battle.characterId;
-  const attackingTeam = battle.warriors.filter(
-    (warrior: Warrior) => warrior.team === 1,
-  );
-  const defendingTeam = battle.warriors.filter(
-    (warrior: Warrior) => warrior.team === 2,
-  );
-  const userWarrior = battle.warriors.find(
-    (warrior: Warrior) => warrior.originalId === characterId,
-  );
-  const leftTeam = userWarrior?.team === 1 ? attackingTeam : defendingTeam;
-  const rightTeam = userWarrior?.team === 1 ? defendingTeam : attackingTeam;
-  const leftTeamNumber = userWarrior?.team === 1 ? 1 : 2;
-  const rightTeamNumber = userWarrior?.team === 1 ? 2 : 1;
+  const { characterId, leftTeam, rightTeam, leftTeamNumber, rightTeamNumber } =
+    getBattleTeamPresentation(battle, currentUserCharacterId);
   const winnerResult = getWinnerResult(battle);
   const isLeftTeamWinner = battle.winningTeam === leftTeamNumber;
   const isRightTeamWinner = battle.winningTeam === rightTeamNumber;

--- a/apps/web/src/components/battle/battle-overview-card.tsx
+++ b/apps/web/src/components/battle/battle-overview-card.tsx
@@ -4,13 +4,11 @@ import { BattleOverviewHeader } from "./battle-overview-header";
 import { BattleTeamSection } from "./battle-team-section";
 import { AnimatedTrophy } from "./animated-trophy";
 import { BattleMetadata } from "./battle-metadata";
-import type {
-  Battle,
-  BattleWarrior as Warrior,
-} from "@/lib/api/battlelog-types";
+import type { Battle } from "@/lib/api/battlelog-types";
 import { useTranslation } from "react-i18next";
 import { cn } from "@lootlog/ui/lib/utils";
 import { BATTLE_SURFACE_COLORS } from "./utils/battle-color-palette";
+import { getBattleTeamPresentation } from "./utils/battle-team-presentation";
 
 export type BattleOverviewCardProps = {
   battle: Battle;
@@ -38,18 +36,14 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
   showHeader = true,
 }) => {
   const { t } = useTranslation();
-  const attackingTeam = battle.warriors.filter((w: Warrior) => w.team === 1);
-  const defendingTeam = battle.warriors.filter((w: Warrior) => w.team === 2);
-
-  const userTeam = battle.warriors.find(
-    (w: Warrior) =>
-      w.originalId === (currentUserCharacterId || battle.characterId),
-  );
-
-  const leftTeam = userTeam?.team === 1 ? attackingTeam : defendingTeam;
-  const rightTeam = userTeam?.team === 1 ? defendingTeam : attackingTeam;
-  const leftTeamNumber = userTeam?.team === 1 ? 1 : 2;
-  const rightTeamNumber = userTeam?.team === 1 ? 2 : 1;
+  const {
+    characterId,
+    leftTeam,
+    rightTeam,
+    leftTeamNumber,
+    rightTeamNumber,
+    userWarrior,
+  } = getBattleTeamPresentation(battle, currentUserCharacterId);
 
   const handleShareClick = () => {
     onShare?.(battle.id);
@@ -91,8 +85,8 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
             <BattleTeamSection
               team={leftTeam}
               teamNumber={leftTeamNumber}
-              userTeam={userTeam?.team}
-              characterId={currentUserCharacterId || battle.characterId}
+              userTeam={userWarrior?.team}
+              characterId={characterId}
               cdnBaseUrl={cdnBaseUrl}
             />
             <div className="grid grid-cols-3 items-center justify-items-center">
@@ -101,7 +95,7 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
                   show={
                     battle.winningTeam === leftTeamNumber && !battle.hasFlee
                   }
-                  isUserTeamWinner={userTeam?.team === leftTeamNumber}
+                  isUserTeamWinner={userWarrior?.team === leftTeamNumber}
                 />
               </div>
               <div className="text-center">
@@ -114,7 +108,7 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
                   show={
                     battle.winningTeam === rightTeamNumber && !battle.hasFlee
                   }
-                  isUserTeamWinner={userTeam?.team === rightTeamNumber}
+                  isUserTeamWinner={userWarrior?.team === rightTeamNumber}
                 />
               </div>
             </div>
@@ -122,8 +116,8 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
             <BattleTeamSection
               team={rightTeam}
               teamNumber={rightTeamNumber}
-              userTeam={userTeam?.team}
-              characterId={currentUserCharacterId || battle.characterId}
+              userTeam={userWarrior?.team}
+              characterId={characterId}
               cdnBaseUrl={cdnBaseUrl}
             />
           </div>

--- a/apps/web/src/components/battle/utils/battle-team-presentation.spec.ts
+++ b/apps/web/src/components/battle/utils/battle-team-presentation.spec.ts
@@ -1,0 +1,95 @@
+import type { Battle, BattleWarrior } from "@/lib/api/battlelog-types";
+import { describe, expect, it } from "vitest";
+import { getBattleTeamPresentation } from "./battle-team-presentation";
+
+const createWarrior = ({
+  name,
+  originalId,
+  team,
+}: {
+  name: string;
+  originalId: string;
+  team: number;
+}): BattleWarrior =>
+  ({
+    name,
+    originalId,
+    team,
+  }) as BattleWarrior;
+
+const createBattle = (overrides: Partial<Battle> = {}): Battle =>
+  ({
+    characterId: "defender-user",
+    warriors: [
+      createWarrior({
+        name: "Attacker",
+        originalId: "attacker-user",
+        team: 1,
+      }),
+      createWarrior({
+        name: "Defender",
+        originalId: "defender-user",
+        team: 2,
+      }),
+      createWarrior({
+        name: "Defender Ally",
+        originalId: "defender-ally",
+        team: 2,
+      }),
+    ],
+    ...overrides,
+  }) as Battle;
+
+const getTeamNames = (team: BattleWarrior[]) =>
+  team.map((warrior) => warrior.name);
+
+describe("battle team presentation", () => {
+  it("orients teams from the battle character perspective by default", () => {
+    const presentation = getBattleTeamPresentation(createBattle());
+
+    expect(getTeamNames(presentation.leftTeam)).toEqual([
+      "Defender",
+      "Defender Ally",
+    ]);
+    expect(getTeamNames(presentation.rightTeam)).toEqual(["Attacker"]);
+    expect(presentation.leftTeamNumber).toBe(2);
+    expect(presentation.rightTeamNumber).toBe(1);
+    expect(presentation.characterId).toBe("defender-user");
+    expect(presentation.userWarrior?.name).toBe("Defender");
+  });
+
+  it("orients teams from the preferred character perspective when provided", () => {
+    const presentation = getBattleTeamPresentation(
+      createBattle(),
+      "attacker-user",
+    );
+
+    expect(getTeamNames(presentation.leftTeam)).toEqual(["Attacker"]);
+    expect(getTeamNames(presentation.rightTeam)).toEqual([
+      "Defender",
+      "Defender Ally",
+    ]);
+    expect(presentation.leftTeamNumber).toBe(1);
+    expect(presentation.rightTeamNumber).toBe(2);
+    expect(presentation.characterId).toBe("attacker-user");
+    expect(presentation.userWarrior?.name).toBe("Attacker");
+  });
+
+  it("treats an empty preferred character id as absent", () => {
+    const presentation = getBattleTeamPresentation(createBattle(), "");
+
+    expect(presentation.characterId).toBe("defender-user");
+    expect(presentation.userWarrior?.name).toBe("Defender");
+  });
+
+  it("falls back to defending-team-first when the character is not in the battle", () => {
+    const presentation = getBattleTeamPresentation(createBattle(), "missing");
+
+    expect(getTeamNames(presentation.leftTeam)).toEqual([
+      "Defender",
+      "Defender Ally",
+    ]);
+    expect(getTeamNames(presentation.rightTeam)).toEqual(["Attacker"]);
+    expect(presentation.userWarrior).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/battle/utils/battle-team-presentation.ts
+++ b/apps/web/src/components/battle/utils/battle-team-presentation.ts
@@ -1,0 +1,62 @@
+import type { Battle, BattleWarrior } from "@/lib/api/battlelog-types";
+
+type BattleTeamNumber = 1 | 2;
+
+type BattleTeamPresentation = {
+  characterId: string;
+  leftTeam: BattleWarrior[];
+  rightTeam: BattleWarrior[];
+  leftTeamNumber: BattleTeamNumber;
+  rightTeamNumber: BattleTeamNumber;
+  userWarrior: BattleWarrior | undefined;
+};
+
+const ATTACKING_TEAM_NUMBER = 1 satisfies BattleTeamNumber;
+const DEFENDING_TEAM_NUMBER = 2 satisfies BattleTeamNumber;
+
+const getPresentationCharacterId = (
+  battle: Battle,
+  preferredCharacterId: string | undefined,
+) => {
+  if (preferredCharacterId) {
+    return preferredCharacterId;
+  }
+
+  return battle.characterId;
+};
+
+export const getBattleTeamPresentation = (
+  battle: Battle,
+  preferredCharacterId?: string,
+): BattleTeamPresentation => {
+  const characterId = getPresentationCharacterId(battle, preferredCharacterId);
+  const attackingTeam = battle.warriors.filter(
+    (warrior) => warrior.team === ATTACKING_TEAM_NUMBER,
+  );
+  const defendingTeam = battle.warriors.filter(
+    (warrior) => warrior.team === DEFENDING_TEAM_NUMBER,
+  );
+  const userWarrior = battle.warriors.find(
+    (warrior) => warrior.originalId === characterId,
+  );
+
+  if (userWarrior?.team === ATTACKING_TEAM_NUMBER) {
+    return {
+      characterId,
+      leftTeam: attackingTeam,
+      rightTeam: defendingTeam,
+      leftTeamNumber: ATTACKING_TEAM_NUMBER,
+      rightTeamNumber: DEFENDING_TEAM_NUMBER,
+      userWarrior,
+    };
+  }
+
+  return {
+    characterId,
+    leftTeam: defendingTeam,
+    rightTeam: attackingTeam,
+    leftTeamNumber: DEFENDING_TEAM_NUMBER,
+    rightTeamNumber: ATTACKING_TEAM_NUMBER,
+    userWarrior,
+  };
+};


### PR DESCRIPTION
## Summary

- Extract shared battle team orientation logic into `getBattleTeamPresentation`.
- Reuse it from both regular and compact battle overview cards.
- Add focused unit coverage for default, preferred-character, empty-character, and missing-character orientation behavior.

## Verification

- `pnpm --filter @lootlog/web exec vitest run src/components/battle/utils/battle-team-presentation.spec.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm lint`
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/socket-parser build`
- `pnpm --filter @lootlog/web build`
- `pnpm format:check`
- `sh .husky/pre-commit`

Note: `pnpm --filter @lootlog/web exec vitest run` still has unrelated existing failures in the full web suite: missing `VITE_AUTH_SERVICE_URL` for Better Auth tests and an existing `event-coordination-page.spec.tsx` mock missing `getEventsMonitoringControllerGetCoordinationQueryKey`. The targeted new test passes.