### PR TITLE
[codex] drop empty settings tabs props

### DIFF
--- a/apps/game-client/src/features/settings/components/settings-tabs.tsx
+++ b/apps/game-client/src/features/settings/components/settings-tabs.tsx
@@ -35,10 +35,8 @@ import {
   Volume2,
   type LucideIcon,
 } from "lucide-react";
-import type { FC, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-
-type SettingsTabsProps = {};
 
 type SettingsTabDefinition = {
   value: SettingsTabValue;
@@ -57,7 +55,7 @@ const SETTINGS_TAB_TRIGGER_REGULAR_CLASSES =
 const SETTINGS_TAB_TRIGGER_COMPACT_CLASSES =
   "ll:relative ll:justify-center ll:border-gray-500/40 ll:bg-black/5 ll:px-1.5 ll:text-gray-300 ll:hover:border-gray-300/70 ll:hover:bg-gray-500/18 ll:data-[state=active]:border-purple-300/80 ll:data-[state=active]:bg-purple-500/24 ll:data-[state=active]:text-white";
 
-export const SettingsTabs: FC<SettingsTabsProps> = () => {
+export const SettingsTabs = () => {
   const activeTab = useWindowsStore((state) => state.settings.state?.activeTab);
   const settingsWidth = useWindowsStore((state) => state.settings.size.width);
   const setSettingsActiveTab = useWindowsStore(


### PR DESCRIPTION
## Summary

- Removed the empty `SettingsTabsProps` type from the game-client settings tabs component.
- Dropped the now-unneeded `FC` import and let TypeScript infer the no-props component type directly.

## Verification

- `pnpm --dir apps/game-client exec vitest run src/features/settings/components/settings-tabs.test.tsx`
- `pnpm exec oxlint apps/game-client/src/features/settings/components/settings-tabs.tsx`
- `pnpm exec oxfmt --check apps/game-client/src/features/settings/components/settings-tabs.tsx`
- `pnpm turbo run lint '--filter=[HEAD]'` (no package lint task configured for `@lootlog/game-client`)
- `pnpm turbo run format:check '--filter=[HEAD]'` (no package format task configured for `@lootlog/game-client`)
- `pnpm turbo run build --filter=@lootlog/game-client`
- `pnpm turbo run test '--filter=[HEAD]'`
- `.husky/pre-commit` via `git commit`

Notes: the game-client build still emits existing warnings about `.all:b` CSS and unresolved runtime cursor assets; the build completed successfully.