### PR TITLE
[codex] refactor types npc routing checks

### DIFF
--- a/packages/types/src/common/npc-routing.types.ts
+++ b/packages/types/src/common/npc-routing.types.ts
@@ -8,7 +8,15 @@ export type NpcRoutingData = {
   wt?: number | string | null;
 };
 
-const NPC_TYPE_VALUES = new Set<string>(Object.values(NpcTypeEnum));
+const NPC_TYPE_VALUES = new Set<NpcTypeEnum>(Object.values(NpcTypeEnum));
+const HERO_ROUTING_NPC_TYPES = new Set<NpcTypeEnum>([
+  NpcTypeEnum.HERO,
+  NpcTypeEnum.EVENT_HERO,
+]);
+
+function isNpcTypeEnum(value: string): value is NpcTypeEnum {
+  return NPC_TYPE_VALUES.has(value as NpcTypeEnum);
+}
 
 function normalizeNpcWeight(weight?: number | string | null): number | null {
   if (typeof weight === "number" && Number.isFinite(weight)) {
@@ -33,8 +41,8 @@ export function resolveNpcType(
     return null;
   }
 
-  if (typeof npc.type === "string" && NPC_TYPE_VALUES.has(npc.type)) {
-    return npc.type as NpcTypeEnum;
+  if (typeof npc.type === "string" && isNpcTypeEnum(npc.type)) {
+    return npc.type;
   }
 
   const weight = normalizeNpcWeight(npc.wt);
@@ -58,7 +66,7 @@ export function getNpcRoutingTier(npc?: NpcRoutingData | null): NpcRoutingTier {
     return "titans";
   }
 
-  if (npcType === NpcTypeEnum.HERO || npcType === NpcTypeEnum.EVENT_HERO) {
+  if (npcType && HERO_ROUTING_NPC_TYPES.has(npcType)) {
     return "heroes";
   }
 


### PR DESCRIPTION
## Summary
- Add an explicit `NpcTypeEnum` type guard for NPC routing type strings.
- Centralize hero-tier NPC routing types in a typed set.
- Preserve existing routing behavior while removing the direct enum cast at the call site.

## Verification
- `pnpm --filter @lootlog/types build`
- `pnpm turbo run build --filter=@lootlog/types`
- `pnpm turbo run lint --filter=@lootlog/types` (no package task configured)
- `pnpm turbo run check-types --filter=@lootlog/types` (no package task configured)
- `pnpm turbo run test --filter=@lootlog/types` (no package task configured)
- `pnpm exec oxlint packages/types/src/common/npc-routing.types.ts`
- `pnpm exec oxfmt --check packages/types/src/common/npc-routing.types.ts`
- `pnpm exec tsc --noEmit -p packages/types/tsconfig.json`
- `pnpm exec tsx -e "import { strict as assert } from 'node:assert'; import { getNpcRoutingTier, resolveNpcType, NpcTypeEnum } from './packages/types/src/index.ts'; assert.equal(resolveNpcType({ type: 'HERO' }), NpcTypeEnum.HERO); assert.equal(getNpcRoutingTier({ type: 'EVENT_HERO' }), 'heroes'); assert.equal(getNpcRoutingTier({ wt: 101 }), 'titans'); assert.equal(getNpcRoutingTier({ wt: 35 }), 'base'); assert.equal(resolveNpcType({ type: 'UNKNOWN', wt: null }), null);"`
- `sh .husky/pre-commit`

Note: `pnpm install --frozen-lockfile` populated dependencies but exited nonzero because pnpm requires build-script approval for third-party packages; no lockfile/source config changes were kept from that installer side effect.