### PR TITLE
[codex] share battle team side logic

### DIFF
--- a/apps/web/src/components/battle/battle-compact-overview-card.tsx
+++ b/apps/web/src/components/battle/battle-compact-overview-card.tsx
@@ -3,16 +3,14 @@ import { cn } from "@lootlog/ui/lib/utils";
 import { Flag, Trophy, type LucideIcon } from "lucide-react";
 import type { FC } from "react";
 import { useTranslation } from "react-i18next";
-import type {
-  Battle,
-  BattleWarrior as Warrior,
-} from "@/lib/api/battlelog-types";
+import type { Battle } from "@/lib/api/battlelog-types";
 import {
   BATTLE_BADGE_COLORS,
   BATTLE_SURFACE_COLORS,
 } from "./utils/battle-color-palette";
 import { BattleCompactTeam } from "./battle-compact-team";
 import { BattleMetadata } from "./battle-metadata";
+import { getBattleTeamSides } from "./utils/battle-team-sides";
 
 export type BattleCompactOverviewCardProps = {
   battle: Battle;
@@ -42,19 +40,8 @@ export const BattleCompactOverviewCard: FC<BattleCompactOverviewCardProps> = ({
 }) => {
   const { t } = useTranslation();
   const characterId = currentUserCharacterId ?? battle.characterId;
-  const attackingTeam = battle.warriors.filter(
-    (warrior: Warrior) => warrior.team === 1,
-  );
-  const defendingTeam = battle.warriors.filter(
-    (warrior: Warrior) => warrior.team === 2,
-  );
-  const userWarrior = battle.warriors.find(
-    (warrior: Warrior) => warrior.originalId === characterId,
-  );
-  const leftTeam = userWarrior?.team === 1 ? attackingTeam : defendingTeam;
-  const rightTeam = userWarrior?.team === 1 ? defendingTeam : attackingTeam;
-  const leftTeamNumber = userWarrior?.team === 1 ? 1 : 2;
-  const rightTeamNumber = userWarrior?.team === 1 ? 2 : 1;
+  const { leftTeam, rightTeam, leftTeamNumber, rightTeamNumber } =
+    getBattleTeamSides(battle, characterId);
   const winnerResult = getWinnerResult(battle);
   const isLeftTeamWinner = battle.winningTeam === leftTeamNumber;
   const isRightTeamWinner = battle.winningTeam === rightTeamNumber;

--- a/apps/web/src/components/battle/battle-overview-card.tsx
+++ b/apps/web/src/components/battle/battle-overview-card.tsx
@@ -4,13 +4,11 @@ import { BattleOverviewHeader } from "./battle-overview-header";
 import { BattleTeamSection } from "./battle-team-section";
 import { AnimatedTrophy } from "./animated-trophy";
 import { BattleMetadata } from "./battle-metadata";
-import type {
-  Battle,
-  BattleWarrior as Warrior,
-} from "@/lib/api/battlelog-types";
+import type { Battle } from "@/lib/api/battlelog-types";
 import { useTranslation } from "react-i18next";
 import { cn } from "@lootlog/ui/lib/utils";
 import { BATTLE_SURFACE_COLORS } from "./utils/battle-color-palette";
+import { getBattleTeamSides } from "./utils/battle-team-sides";
 
 export type BattleOverviewCardProps = {
   battle: Battle;
@@ -38,18 +36,9 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
   showHeader = true,
 }) => {
   const { t } = useTranslation();
-  const attackingTeam = battle.warriors.filter((w: Warrior) => w.team === 1);
-  const defendingTeam = battle.warriors.filter((w: Warrior) => w.team === 2);
-
-  const userTeam = battle.warriors.find(
-    (w: Warrior) =>
-      w.originalId === (currentUserCharacterId || battle.characterId),
-  );
-
-  const leftTeam = userTeam?.team === 1 ? attackingTeam : defendingTeam;
-  const rightTeam = userTeam?.team === 1 ? defendingTeam : attackingTeam;
-  const leftTeamNumber = userTeam?.team === 1 ? 1 : 2;
-  const rightTeamNumber = userTeam?.team === 1 ? 2 : 1;
+  const characterId = currentUserCharacterId || battle.characterId;
+  const { leftTeam, rightTeam, leftTeamNumber, rightTeamNumber, userWarrior } =
+    getBattleTeamSides(battle, characterId);
 
   const handleShareClick = () => {
     onShare?.(battle.id);
@@ -91,8 +80,8 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
             <BattleTeamSection
               team={leftTeam}
               teamNumber={leftTeamNumber}
-              userTeam={userTeam?.team}
-              characterId={currentUserCharacterId || battle.characterId}
+              userTeam={userWarrior?.team}
+              characterId={characterId}
               cdnBaseUrl={cdnBaseUrl}
             />
             <div className="grid grid-cols-3 items-center justify-items-center">
@@ -101,7 +90,7 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
                   show={
                     battle.winningTeam === leftTeamNumber && !battle.hasFlee
                   }
-                  isUserTeamWinner={userTeam?.team === leftTeamNumber}
+                  isUserTeamWinner={userWarrior?.team === leftTeamNumber}
                 />
               </div>
               <div className="text-center">
@@ -114,7 +103,7 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
                   show={
                     battle.winningTeam === rightTeamNumber && !battle.hasFlee
                   }
-                  isUserTeamWinner={userTeam?.team === rightTeamNumber}
+                  isUserTeamWinner={userWarrior?.team === rightTeamNumber}
                 />
               </div>
             </div>
@@ -122,8 +111,8 @@ export const BattleOverviewCard: FC<BattleOverviewCardProps> = ({
             <BattleTeamSection
               team={rightTeam}
               teamNumber={rightTeamNumber}
-              userTeam={userTeam?.team}
-              characterId={currentUserCharacterId || battle.characterId}
+              userTeam={userWarrior?.team}
+              characterId={characterId}
               cdnBaseUrl={cdnBaseUrl}
             />
           </div>

--- a/apps/web/src/components/battle/utils/battle-team-sides.spec.ts
+++ b/apps/web/src/components/battle/utils/battle-team-sides.spec.ts
@@ -1,0 +1,70 @@
+import type { Battle, BattleWarrior } from "@/lib/api/battlelog-types";
+import { describe, expect, it } from "vitest";
+import { getBattleTeamSides } from "./battle-team-sides";
+
+const createWarrior = ({
+  name,
+  originalId,
+  team,
+}: {
+  name: string;
+  originalId: string;
+  team: number;
+}): BattleWarrior =>
+  ({
+    id: originalId,
+    name,
+    originalId,
+    team,
+  }) as BattleWarrior;
+
+const createBattle = (characterId = "defender"): Battle =>
+  ({
+    characterId,
+    warriors: [
+      createWarrior({
+        name: "Attacker",
+        originalId: "attacker",
+        team: 1,
+      }),
+      createWarrior({
+        name: "Defender",
+        originalId: "defender",
+        team: 2,
+      }),
+    ],
+  }) as Battle;
+
+describe("battle team sides", () => {
+  it("places the user team on the left with team numbers", () => {
+    const sides = getBattleTeamSides(createBattle());
+
+    expect(sides.leftTeam.map((warrior) => warrior.name)).toEqual(["Defender"]);
+    expect(sides.rightTeam.map((warrior) => warrior.name)).toEqual([
+      "Attacker",
+    ]);
+    expect(sides.leftTeamNumber).toBe(2);
+    expect(sides.rightTeamNumber).toBe(1);
+    expect(sides.userWarrior?.name).toBe("Defender");
+  });
+
+  it("uses an explicit character id when provided", () => {
+    const sides = getBattleTeamSides(createBattle(), "attacker");
+
+    expect(sides.leftTeam.map((warrior) => warrior.name)).toEqual(["Attacker"]);
+    expect(sides.rightTeam.map((warrior) => warrior.name)).toEqual([
+      "Defender",
+    ]);
+    expect(sides.leftTeamNumber).toBe(1);
+    expect(sides.rightTeamNumber).toBe(2);
+    expect(sides.userWarrior?.name).toBe("Attacker");
+  });
+
+  it("falls back to defender-left ordering when the user warrior is missing", () => {
+    const sides = getBattleTeamSides(createBattle("missing"));
+
+    expect(sides.leftTeamNumber).toBe(2);
+    expect(sides.rightTeamNumber).toBe(1);
+    expect(sides.userWarrior).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/battle/utils/battle-team-sides.ts
+++ b/apps/web/src/components/battle/utils/battle-team-sides.ts
@@ -1,0 +1,40 @@
+import type { Battle, BattleWarrior } from "@/lib/api/battlelog-types";
+
+type BattleTeamNumber = 1 | 2;
+
+type BattleTeamSides = {
+  leftTeam: BattleWarrior[];
+  rightTeam: BattleWarrior[];
+  leftTeamNumber: BattleTeamNumber;
+  rightTeamNumber: BattleTeamNumber;
+  userWarrior: BattleWarrior | undefined;
+};
+
+export const getBattleTeamSides = (
+  battle: Battle,
+  characterId = battle.characterId,
+): BattleTeamSides => {
+  const attackingTeam = battle.warriors.filter((warrior) => warrior.team === 1);
+  const defendingTeam = battle.warriors.filter((warrior) => warrior.team === 2);
+  const userWarrior = battle.warriors.find(
+    (warrior) => warrior.originalId === characterId,
+  );
+
+  if (userWarrior?.team === 1) {
+    return {
+      leftTeam: attackingTeam,
+      rightTeam: defendingTeam,
+      leftTeamNumber: 1,
+      rightTeamNumber: 2,
+      userWarrior,
+    };
+  }
+
+  return {
+    leftTeam: defendingTeam,
+    rightTeam: attackingTeam,
+    leftTeamNumber: 2,
+    rightTeamNumber: 1,
+    userWarrior,
+  };
+};

--- a/apps/web/src/features/user/battle-panel/components/battle-panel-battle-presentation.ts
+++ b/apps/web/src/features/user/battle-panel/components/battle-panel-battle-presentation.ts
@@ -3,28 +3,13 @@ import type {
   BattleWarrior,
   PlayerVsPlayerBattle,
 } from "@/lib/api/battlelog-types";
+import { getBattleTeamSides } from "@/components/battle/utils/battle-team-sides";
 import type { BattleResultStatusValue } from "./battle-result-status";
 
 export const getBattleTeams = (battle: Battle) => {
-  const attackingTeam = battle.warriors.filter((warrior) => warrior.team === 1);
-  const defendingTeam = battle.warriors.filter((warrior) => warrior.team === 2);
-  const userWarrior = battle.warriors.find(
-    (warrior) => warrior.originalId === battle.characterId,
-  );
+  const { leftTeam, rightTeam, userWarrior } = getBattleTeamSides(battle);
 
-  if (userWarrior?.team === 1) {
-    return {
-      leftTeam: attackingTeam,
-      rightTeam: defendingTeam,
-      userWarrior,
-    };
-  }
-
-  return {
-    leftTeam: defendingTeam,
-    rightTeam: attackingTeam,
-    userWarrior,
-  };
+  return { leftTeam, rightTeam, userWarrior };
 };
 
 export const getBattleResult = (battle: Battle): BattleResultStatusValue => {


### PR DESCRIPTION
## Summary

- Added a shared `getBattleTeamSides` battle utility for user-perspective left/right team ordering and team numbers.
- Reused it in the standard and compact battle overview cards.
- Delegated the existing battle-panel presentation helper to the shared utility and added focused coverage for team ordering behavior.

## Verification

- `corepack pnpm --filter @lootlog/web exec vitest run src/components/battle/utils/battle-team-sides.spec.ts src/features/user/battle-panel/components/battle-panel-battle-presentation.spec.ts`
- `corepack pnpm exec oxfmt --check apps/web/src/components/battle/utils/battle-team-sides.ts apps/web/src/components/battle/utils/battle-team-sides.spec.ts apps/web/src/components/battle/battle-overview-card.tsx apps/web/src/components/battle/battle-compact-overview-card.tsx apps/web/src/features/user/battle-panel/components/battle-panel-battle-presentation.ts`
- `corepack pnpm --filter @lootlog/web lint`
- `corepack pnpm turbo run lint --filter='[HEAD]'`
- `corepack pnpm turbo run test --filter='[HEAD]'`
- `corepack pnpm turbo run build --filter='[HEAD]'`
- `git commit` with pre-commit hooks enabled

Notes: the Turbo lint step replayed an existing cached `@lootlog/ui` warning about `src/components/npc-tile.tsx` using `<img>`. The build also reported the existing `lottie-web` direct `eval` dependency warning. Neither is introduced by this PR.