### PR TITLE
[codex] refactor battle warrior stat normalization

### DIFF
--- a/apps/battlelog-service/src/battles/battle-warrior-stats.ts
+++ b/apps/battlelog-service/src/battles/battle-warrior-stats.ts
@@ -12,6 +12,9 @@ const BOOLEAN_STATS_KEYS = new Set<BattleWarriorStatsKey>([
 ]);
 
 type BattleWarriorStatsSource = Partial<Record<BattleWarriorStatsKey, unknown>>;
+type BattleWarriorStatsFallback = (
+  key: BattleWarriorStatsKey,
+) => BattleWarriorStats[BattleWarriorStatsKey];
 
 export type InflatedBattleWarrior = Omit<
   BattleWarrior,
@@ -35,7 +38,7 @@ function normalizeStatValue(
   key: BattleWarriorStatsKey,
   value: unknown,
   fallback: BattleWarriorStats[BattleWarriorStatsKey],
-): unknown {
+): BattleWarriorStats[BattleWarriorStatsKey] {
   if (key === "spellsUsedMap") {
     return value && typeof value === "object" && !Array.isArray(value)
       ? (value as Record<string, number>)
@@ -49,18 +52,22 @@ function normalizeStatValue(
   return typeof value === "number" ? value : fallback;
 }
 
-export function buildBattleWarriorStats(
+function normalizeBattleWarriorStats(
   source: BattleWarriorStatsSource,
+  getFallback: BattleWarriorStatsFallback,
 ): BattleWarriorStats {
   return BATTLE_WARRIOR_STATS_KEYS.reduce<
     Partial<Record<BattleWarriorStatsKey, unknown>>
   >((stats, key) => {
-    const fallback = getDefaultStatValue(
-      key,
-    ) as BattleWarriorStats[BattleWarriorStatsKey];
-    stats[key] = normalizeStatValue(key, source[key], fallback);
+    stats[key] = normalizeStatValue(key, source[key], getFallback(key));
     return stats;
   }, {}) as BattleWarriorStats;
+}
+
+export function buildBattleWarriorStats(
+  source: BattleWarriorStatsSource,
+): BattleWarriorStats {
+  return normalizeBattleWarriorStats(source, getDefaultStatValue);
 }
 
 function mergeBattleWarriorStats(
@@ -73,16 +80,10 @@ function mergeBattleWarriorStats(
 
   const storedStatsRecord = storedStats as Partial<BattleWarriorStats>;
 
-  return BATTLE_WARRIOR_STATS_KEYS.reduce<
-    Partial<Record<BattleWarriorStatsKey, unknown>>
-  >((stats, key) => {
-    stats[key] = normalizeStatValue(
-      key,
-      storedStatsRecord[key],
-      legacyStats[key],
-    );
-    return stats;
-  }, {}) as BattleWarriorStats;
+  return normalizeBattleWarriorStats(
+    storedStatsRecord,
+    (key) => legacyStats[key],
+  );
 }
 
 export function inflateBattleWarrior(


### PR DESCRIPTION
## Summary

- Extract the shared `BATTLE_WARRIOR_STATS_KEYS` normalization loop into `normalizeBattleWarriorStats`.
- Keep the two existing fallback paths explicit: default stat values for new payloads and legacy-column values for stored JSON stats inflation.
- Narrow `normalizeStatValue` from `unknown` to the battle warrior stat value union.

## Validation

- `pnpm --filter @lootlog/battlelog-service exec vitest run --config ./vitest.config.ts src/battles/battle-warrior-stats.spec.ts`
- `pnpm --filter @lootlog/battlelog-service test`
- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm exec oxfmt --check apps/battlelog-service/src/battles/battle-warrior-stats.ts`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/battlelog-service build`
- `pnpm turbo run build --filter=@lootlog/battlelog-service...`
- `.husky/pre-commit`

Note: a raw `pnpm --filter @lootlog/battlelog-service exec tsc --noEmit --project tsconfig.json` is not a configured package script and currently includes existing spec DTO mock type errors unrelated to this refactor. The configured Nest build type-check passed with zero issues.