### PR TITLE
[codex] simplify gateway admin permission checks

### DIFF
--- a/apps/gateway/src/guilds/utils/is-administrative-user.ts
+++ b/apps/gateway/src/guilds/utils/is-administrative-user.ts
@@ -6,11 +6,6 @@ const ADMINISTRATIVE_PERMISSIONS = [
   Permission.OWNER,
 ] as const;
 
-const OWNER_OR_ADMIN_PERMISSIONS = [
-  Permission.ADMIN,
-  Permission.OWNER,
-] as const;
-
 const hasAnyPermission = (
   permissions: Permission[],
   requiredPermissions: readonly Permission[],
@@ -20,8 +15,13 @@ const hasAnyPermission = (
   );
 };
 
-const getRolePermissions = (roles: GuildRole[]) => {
-  return roles.flatMap((role) => role.permissions);
+const hasAnyRolePermission = (
+  roles: GuildRole[],
+  requiredPermissions: readonly Permission[],
+) => {
+  return roles.some((role) =>
+    hasAnyPermission(role.permissions, requiredPermissions),
+  );
 };
 
 export const isAdministrativeUser = (permissions: Permission[]) => {
@@ -29,13 +29,13 @@ export const isAdministrativeUser = (permissions: Permission[]) => {
 };
 
 export const isAdministrativeUserFromRoles = (roles: GuildRole[]) => {
-  return isAdministrativeUser(getRolePermissions(roles));
+  return hasAnyRolePermission(roles, ADMINISTRATIVE_PERMISSIONS);
 };
 
 export const isOwnerOrAdmin = (permissions: Permission[]) => {
-  return hasAnyPermission(permissions, OWNER_OR_ADMIN_PERMISSIONS);
+  return isAdministrativeUser(permissions);
 };
 
 export const isOwnerOrAdminFromRoles = (roles: GuildRole[]) => {
-  return isOwnerOrAdmin(getRolePermissions(roles));
+  return isAdministrativeUserFromRoles(roles);
 };


### PR DESCRIPTION
## Summary

- Remove the duplicate owner/admin permission list in the gateway administrative-user helper.
- Check role permissions directly with a shared helper instead of flattening every role before testing.
- Keep the existing exported API names and behavior intact.

## Verification

- `pnpm exec oxlint apps/gateway/src/guilds/utils/is-administrative-user.ts`
- `pnpm exec oxfmt --check apps/gateway/src/guilds/utils/is-administrative-user.ts`
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/gateway exec vitest run --config ./vitest.config.ts src/guilds/utils/is-administrative-user.spec.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway test`
- `pnpm --filter @lootlog/gateway build`
- `pnpm turbo run lint --filter='[HEAD]'`
- `pnpm turbo run test --filter='[HEAD]'`
- `pnpm turbo run build --filter='[HEAD]'`
- `pnpm turbo run check-types --filter='[HEAD]'` (no affected package task configured)
- `.husky/pre-commit`

Note: `pnpm install --frozen-lockfile` populated this fresh worktree but exited nonzero because pnpm requires explicit approval for third-party build scripts. No generated workspace configuration changes were kept.