### PR TITLE
[codex] Reuse online player profession options

### DIFF
--- a/apps/game-client/src/store/online-players.store.ts
+++ b/apps/game-client/src/store/online-players.store.ts
@@ -1,5 +1,7 @@
 import {
   ALL_PROFESSIONS_VALUE,
+  PROFESSION_OPTIONS,
+  type ProfessionFilterValue,
   type OnlinePlayersFiltersValue,
 } from "@/features/online-players/online-players-list.helpers";
 import type { OnlinePlayersViewMode } from "@/features/online-players/online-players.types";
@@ -10,7 +12,16 @@ import { createJSONStorage, persist } from "zustand/middleware";
 const STORAGE_KEY = storageKey("ll-online-players-state");
 const DEFAULT_VIEW_MODE: OnlinePlayersViewMode = "accounts";
 const DEFAULT_FILTERS_VISIBLE = true;
-const VALID_PROFESSIONS = ["all", "p", "w", "h", "m", "b", "t"];
+const VALID_PROFESSIONS: readonly ProfessionFilterValue[] = [
+  ALL_PROFESSIONS_VALUE,
+  ...PROFESSION_OPTIONS,
+];
+
+const isProfessionFilterValue = (
+  value: string,
+): value is ProfessionFilterValue => {
+  return VALID_PROFESSIONS.some((profession) => profession === value);
+};
 
 type OnlinePlayersState = {
   viewMode: OnlinePlayersViewMode;
@@ -38,7 +49,7 @@ const isOnlinePlayersFiltersValue = (
     typeof candidate.minLvl === "number" &&
     typeof candidate.maxLvl === "number" &&
     typeof candidate.selectedProfession === "string" &&
-    VALID_PROFESSIONS.includes(candidate.selectedProfession)
+    isProfessionFilterValue(candidate.selectedProfession)
   );
 };
 


### PR DESCRIPTION
## Summary

- Replaced the duplicated persisted online-player profession list in the game-client store with the shared `ALL_PROFESSIONS_VALUE` and `PROFESSION_OPTIONS` constants.
- Added a small `ProfessionFilterValue` type guard so persisted filter migration keeps runtime validation while staying aligned with the shared profession type.

## Verification

- `pnpm install --frozen-lockfile` populated dependencies; it exited nonzero only because pnpm requires build-script approvals for existing third-party packages.
- `pnpm --filter @lootlog/types build`
- `pnpm exec oxlint apps/game-client/src/store/online-players.store.ts`
- `pnpm exec oxfmt --check apps/game-client/src/store/online-players.store.ts`
- `pnpm --filter @lootlog/game-client exec vitest run src/store/online-players.store.test.ts`
- `pnpm turbo run build --filter=@lootlog/game-client...`
- `pnpm turbo run test --filter='[HEAD]'`
- `pnpm turbo run build --filter='[HEAD]'`
- `pnpm turbo run lint --filter='[HEAD]'` (no package task configured)
- `pnpm turbo run check-types --filter='[HEAD]'` (no package task configured)
- `pnpm turbo run format:check --filter='[HEAD]'` (no package task configured)
- actual `.husky/pre-commit` during commit