### PR TITLE
[codex] share role permission range check

### DIFF
--- a/apps/api/src/shared/utils/can-view-chat-message.ts
+++ b/apps/api/src/shared/utils/can-view-chat-message.ts
@@ -1,3 +1,4 @@
+import { hasRolePermissionInLevelRange } from "@lootlog/api-helpers/permissions";
 import { getNpcRoutingTier, type NpcRoutingTier } from "@lootlog/types";
 import { Permission, type Role } from "src/generated/prisma/client";
 import { MessageType } from "src/chat/dto/send-message.dto";
@@ -22,17 +23,10 @@ const isNpcScopedMessage = (data: ChatStoredMessage) => {
   );
 };
 
-const isNpcLevelInRoleRange = (npc: NpcData, role: Role) => {
-  return role.lvlRangeFrom <= npc.lvl && role.lvlRangeTo >= npc.lvl;
-};
-
 const hasNpcTierPermission = (npc: NpcData, roles: Role[]) => {
   const permission = NPC_TIER_PERMISSIONS[getNpcRoutingTier(npc)];
 
-  return roles.some(
-    (role) =>
-      role.permissions.includes(permission) && isNpcLevelInRoleRange(npc, role),
-  );
+  return hasRolePermissionInLevelRange(roles, permission, npc.lvl);
 };
 
 export const canViewChatMessage = (

--- a/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
+++ b/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
@@ -4,7 +4,7 @@ export type NpcPermissionData = {
 };
 
 export type RolePermissionData = {
-  permissions: string[];
+  permissions: readonly string[];
   lvlRangeFrom: number;
   lvlRangeTo: number;
 };
@@ -37,6 +37,17 @@ const isNpcLevelWithinRoleRange = (
   npcLevel: number,
 ): boolean => role.lvlRangeFrom <= npcLevel && role.lvlRangeTo >= npcLevel;
 
+export const hasRolePermissionInLevelRange = (
+  roles: readonly RolePermissionData[],
+  permission: string,
+  npcLevel: number,
+): boolean =>
+  roles.some(
+    (role) =>
+      role.permissions.includes(permission) &&
+      isNpcLevelWithinRoleRange(role, npcLevel),
+  );
+
 const getRequiredTimerPermission = (npcType: string): TimerPermission =>
   TIMER_PERMISSION_BY_TIER[
     TIMER_PERMISSION_TIER_BY_NPC_TYPE[npcType] ?? "base"
@@ -44,15 +55,11 @@ const getRequiredTimerPermission = (npcType: string): TimerPermission =>
 
 export const canViewNpcTimer = (
   npc: NpcPermissionData | null,
-  roles: RolePermissionData[],
+  roles: readonly RolePermissionData[],
 ): boolean => {
   if (!npc) return false;
 
   const requiredTimerPermission = getRequiredTimerPermission(npc.type);
 
-  return roles.some(
-    (role) =>
-      role.permissions.includes(requiredTimerPermission) &&
-      isNpcLevelWithinRoleRange(role, npc.lvl),
-  );
+  return hasRolePermissionInLevelRange(roles, requiredTimerPermission, npc.lvl);
 };


### PR DESCRIPTION
## Summary

- Exported `hasRolePermissionInLevelRange` from `@lootlog/api-helpers/permissions`.
- Reused that helper in API chat message visibility checks instead of keeping a duplicate permission-plus-level predicate.
- Kept `canViewNpcTimer` behavior unchanged while delegating through the shared helper.

## Verification

- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/api-helpers build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/shared/utils/can-view-chat-message.spec.ts src/shared/utils/can-view-npc-timer.spec.ts`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm exec oxlint apps/api/src/shared/utils/can-view-chat-message.ts packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts`
- `pnpm format:check`
- `pnpm --filter @lootlog/api build`
- `pnpm --filter @lootlog/api test`
- `.husky/pre-commit`