### PR TITLE
[codex] extract loot share map builders

### DIFF
--- a/apps/web/src/features/guild/loots-list/components/loots-list/loot-details-dialog.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-list/loot-details-dialog.tsx
@@ -20,7 +20,6 @@ import { useSelectedLoot } from "@/hooks/use-selected-loot";
 import { useLootFromCache } from "@/hooks/use-loot-from-cache";
 import { useIsOwner } from "@/hooks/context/use-is-owner";
 import { useGuildId } from "@/hooks/context/use-guild-id";
-import { LOOT_SHARE_COLOR_PALETTE } from "@/features/guild/loots-list/constants/loot-share-color-palette";
 import { useTranslation } from "react-i18next";
 import { ThemeSurfaceOverlay } from "@/themes";
 import type { Loot } from "@/lib/loots/loot-types";
@@ -29,32 +28,9 @@ import {
   getLootsControllerFetchLootByIdQueryKey,
   useLootsControllerFetchLootById,
 } from "@/lib/api/generated/main/loots/loots";
+import { buildLootShareMaps } from "@/features/guild/loots-list/utils/build-loot-share-maps";
 
 const MANAGE_LOOTS_PERMISSIONS = ["LOOTLOG_MANAGE", "ADMIN"] as const;
-
-type PlayerColorMap = Record<string, { color: string; idx: number }>;
-type ItemOwnerMap = Record<string, string | undefined>;
-
-const computeLootMaps = (loot: Loot) => {
-  const playerColorMap = loot.players.reduce<PlayerColorMap>(
-    (acc, player, idx) => {
-      const color =
-        LOOT_SHARE_COLOR_PALETTE[idx % LOOT_SHARE_COLOR_PALETTE.length] ?? "";
-      acc[player.id] = { color, idx };
-      return acc;
-    },
-    {},
-  );
-
-  const itemOwnerMap: ItemOwnerMap = {};
-  Object.entries(loot.lootShare || {}).forEach(([playerId, itemIds]) => {
-    itemIds.forEach((itemId) => {
-      itemOwnerMap[itemId] = playerId;
-    });
-  });
-
-  return { playerColorMap, itemOwnerMap };
-};
 
 const LoadingState: FC = () => (
   <div className="flex items-center justify-center h-64">
@@ -85,7 +61,7 @@ const LootDetailsContent: FC<LootDetailsContentProps> = ({
   const { t } = useTranslation();
   const date = timestampToDate(loot.createdAt);
   const isMobile = useIsMobile();
-  const { playerColorMap, itemOwnerMap } = computeLootMaps(loot);
+  const { playerColorMap, itemOwnerMap } = buildLootShareMaps(loot);
 
   return (
     <div

--- a/apps/web/src/features/guild/loots-list/components/loots-list/loots-list-item.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-list/loots-list-item.tsx
@@ -1,7 +1,6 @@
 import { ItemRarity, type Loot, type Item } from "@/lib/loots/loot-types";
 import { PlayerTile } from "@/features/guild/loots-list/components/loots-list/player-tile";
 import { timestampToDate } from "@/utils/date/parse-timestamp-to-date";
-import { LOOT_SHARE_COLOR_PALETTE } from "@/features/guild/loots-list/constants/loot-share-color-palette";
 import type { WatchedItemScope } from "@/features/user/notifications/types/watched-item-scope";
 import { Card } from "@lootlog/ui/components/card";
 import { LootNpcs } from "@/features/guild/loots-list/components/loots-list/loot-npcs";
@@ -22,33 +21,17 @@ import { motion, useReducedMotion } from "framer-motion";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useThemeMeta } from "@/themes";
+import { buildLootItemOwnerMap } from "@/features/guild/loots-list/utils/build-loot-share-maps";
 
 type Props = {
   loot: Loot;
   isNew?: boolean;
 };
 
-type PlayerColorMap = Record<string, { color: string; idx: number }>;
-type ItemOwnerMap = Record<string, string | undefined>;
 type ItemsByPlayer = Record<string, Item[]>;
 
 const buildLootData = (loot: Loot) => {
-  const playerColorMap = loot.players.reduce<PlayerColorMap>(
-    (acc, player, idx) => {
-      const color =
-        LOOT_SHARE_COLOR_PALETTE[idx % LOOT_SHARE_COLOR_PALETTE.length] ?? "";
-      acc[player.id] = { color, idx };
-      return acc;
-    },
-    {},
-  );
-
-  const itemOwnerMap: ItemOwnerMap = {};
-  Object.entries(loot.lootShare || {}).forEach(([playerId, itemIds]) => {
-    itemIds.forEach((itemId) => {
-      itemOwnerMap[itemId] = playerId;
-    });
-  });
+  const itemOwnerMap = buildLootItemOwnerMap(loot.lootShare);
 
   const itemsByPlayer = loot.players.reduce<ItemsByPlayer>((acc, player) => {
     acc[player.id] = [];
@@ -83,8 +66,6 @@ const buildLootData = (loot: Loot) => {
   });
 
   return {
-    playerColorMap,
-    itemOwnerMap,
     itemsByPlayer,
     unassignedItems,
     hasLegendaryItem,

--- a/apps/web/src/features/guild/loots-list/utils/build-loot-share-maps.spec.ts
+++ b/apps/web/src/features/guild/loots-list/utils/build-loot-share-maps.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { Loot } from "@/lib/loots/loot-types";
+import {
+  buildLootItemOwnerMap,
+  buildLootPlayerColorMap,
+  buildLootShareMaps,
+} from "./build-loot-share-maps";
+
+describe("buildLootShareMaps", () => {
+  const players = [{ id: "player-1" }, { id: "player-2" }] as Loot["players"];
+
+  it("assigns stable player colors by display order", () => {
+    expect(buildLootPlayerColorMap(players)).toEqual({
+      "player-1": { color: "#e6194b", idx: 0 },
+      "player-2": { color: "#3cb44b", idx: 1 },
+    });
+  });
+
+  it("maps shared item ids to their owning player", () => {
+    expect(
+      buildLootItemOwnerMap({
+        "player-1": ["item-1", "item-2"],
+        "player-2": ["item-3"],
+      }),
+    ).toEqual({
+      "item-1": "player-1",
+      "item-2": "player-1",
+      "item-3": "player-2",
+    });
+  });
+
+  it("keeps missing share data as an empty owner map", () => {
+    expect(buildLootItemOwnerMap(undefined)).toEqual({});
+  });
+
+  it("builds color and owner maps together", () => {
+    const loot = {
+      players,
+      lootShare: {
+        "player-1": ["item-1"],
+      },
+    } as Pick<Loot, "players" | "lootShare">;
+
+    expect(buildLootShareMaps(loot)).toEqual({
+      playerColorMap: {
+        "player-1": { color: "#e6194b", idx: 0 },
+        "player-2": { color: "#3cb44b", idx: 1 },
+      },
+      itemOwnerMap: {
+        "item-1": "player-1",
+      },
+    });
+  });
+});

--- a/apps/web/src/features/guild/loots-list/utils/build-loot-share-maps.ts
+++ b/apps/web/src/features/guild/loots-list/utils/build-loot-share-maps.ts
@@ -1,0 +1,36 @@
+import { LOOT_SHARE_COLOR_PALETTE } from "@/features/guild/loots-list/constants/loot-share-color-palette";
+import type { Loot } from "@/lib/loots/loot-types";
+
+export type LootPlayerColorMap = Record<string, { color: string; idx: number }>;
+export type LootItemOwnerMap = Record<string, string | undefined>;
+
+export const buildLootPlayerColorMap = (
+  players: Loot["players"],
+): LootPlayerColorMap =>
+  players.reduce<LootPlayerColorMap>((acc, player, idx) => {
+    const color =
+      LOOT_SHARE_COLOR_PALETTE[idx % LOOT_SHARE_COLOR_PALETTE.length] ?? "";
+    acc[player.id] = { color, idx };
+    return acc;
+  }, {});
+
+export const buildLootItemOwnerMap = (
+  lootShare: Loot["lootShare"] | null | undefined,
+): LootItemOwnerMap => {
+  const itemOwnerMap: LootItemOwnerMap = {};
+
+  Object.entries(lootShare ?? {}).forEach(([playerId, itemIds]) => {
+    itemIds.forEach((itemId) => {
+      itemOwnerMap[itemId] = playerId;
+    });
+  });
+
+  return itemOwnerMap;
+};
+
+export const buildLootShareMaps = (
+  loot: Pick<Loot, "players" | "lootShare">,
+) => ({
+  playerColorMap: buildLootPlayerColorMap(loot.players),
+  itemOwnerMap: buildLootItemOwnerMap(loot.lootShare),
+});


### PR DESCRIPTION
## Summary
- Extract shared loot-share player color and item owner map builders into a typed feature utility.
- Reuse the helper from the loot list item and loot details dialog, removing duplicated map construction.
- Add focused Vitest coverage for color assignment, item owner mapping, and missing share data tolerance.

## Verification
- `pnpm exec oxfmt --check apps/web/src/features/guild/loots-list/components/loots-list/loots-list-item.tsx apps/web/src/features/guild/loots-list/components/loots-list/loot-details-dialog.tsx apps/web/src/features/guild/loots-list/utils/build-loot-share-maps.ts apps/web/src/features/guild/loots-list/utils/build-loot-share-maps.spec.ts`
- `pnpm --filter @lootlog/web exec vitest run src/features/guild/loots-list/utils/build-loot-share-maps.spec.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web... --output-logs=full`
- Pre-commit hook passed (`lint-staged`, changed package lint/test checks).

Notes: the web build completed with existing third-party `lottie-web` direct-eval and Rolldown plugin timing warnings.