### PR TITLE
[codex] derive gateway room types from permissions

### DIFF
--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -8,9 +8,6 @@ import type { UserGuildData, GuildRole } from "src/guilds/types/guild.types";
 import { isOwnerOrAdminFromRoles } from "src/guilds/utils/is-administrative-user";
 import { Platform } from "src/gateway/enums/platform.enum";
 
-export type FeatureName = "chat" | "timers" | "notifications" | "loots";
-export type TierName = NpcRoutingTier;
-
 const FEATURE_ROOMS = {
   chat: {
     base: Permission.LOOTLOG_CHAT_READ,
@@ -32,7 +29,10 @@ const FEATURE_ROOMS = {
     titans: Permission.LOOTLOG_LOOTS_TITANS_READ,
     heroes: Permission.LOOTLOG_LOOTS_HEROES_READ,
   },
-} as const;
+} as const satisfies Record<string, Record<NpcRoutingTier, Permission>>;
+
+export type FeatureName = keyof typeof FEATURE_ROOMS;
+export type TierName = keyof (typeof FEATURE_ROOMS)[FeatureName];
 
 type FeatureRoom = { feature: FeatureName; tier: TierName };
 


### PR DESCRIPTION
## Summary

- Derive gateway `FeatureName` and `TierName` from the `FEATURE_ROOMS` permission map instead of maintaining parallel manual type aliases.
- Add a `satisfies` constraint so the permission map must continue to cover every shared NPC routing tier.

## Verification

- `corepack pnpm --filter @lootlog/gateway format`
- `corepack pnpm --filter @lootlog/gateway lint`
- `corepack pnpm turbo run lint --filter=@lootlog/gateway`
- `corepack pnpm turbo run build --filter=@lootlog/gateway`
- `corepack pnpm turbo run test --filter=@lootlog/gateway`
- `corepack pnpm format:check -- apps/gateway/src/gateway/utils/room-utils.ts`
- `corepack pnpm turbo run check-types --filter=@lootlog/gateway` (no gateway `check-types` task is configured; build provided TypeScript coverage)
- pre-commit hook during `git commit` passed lint-staged, lint, format check, and tests for changed packages

Note: dependency install used the repo-pinned `pnpm@10.32.1`; pnpm reported that `necord@6.14.0` build scripts remain ignored by existing workspace policy.