### PR TITLE
fix(activity): bind RabbitMQ request headers

### DIFF
--- a/apps/activity/src/activities/services/activities-events.service.spec.ts
+++ b/apps/activity/src/activities/services/activities-events.service.spec.ts
@@ -1,3 +1,5 @@
+import { RABBIT_REQUEST_TYPE } from "@golevelup/nestjs-rabbitmq";
+import { ROUTE_ARGS_METADATA } from "@nestjs/common/constants";
 import { ActivitySource, ActivityType } from "src/generated/prisma/client";
 import { RoutingKey } from "src/enum/routing-key.enum";
 import { ActivitiesEventsService } from "./activities-events.service";
@@ -45,6 +47,23 @@ describe("ActivitiesEventsService", () => {
       logger as never,
     );
   });
+
+  it.each(["handleActivityCreate", "handleGuildMemberRemoved"] as const)(
+    "binds %s AMQP message argument as a RabbitMQ request",
+    (methodName) => {
+      const metadata = Reflect.getMetadata(
+        ROUTE_ARGS_METADATA,
+        ActivitiesEventsService,
+        methodName,
+      );
+
+      expect(metadata).toMatchObject({
+        [`${RABBIT_REQUEST_TYPE}:1`]: {
+          index: 1,
+        },
+      });
+    },
+  );
 
   it("rejects unsigned activity create events", async () => {
     await service.handleActivityCreate(validPayload, {

--- a/apps/activity/src/activities/services/activities-events.service.ts
+++ b/apps/activity/src/activities/services/activities-events.service.ts
@@ -1,6 +1,7 @@
 import {
   MessageHandlerErrorBehavior,
   RabbitPayload,
+  RabbitRequest,
   RabbitSubscribe,
 } from "@golevelup/nestjs-rabbitmq";
 import { Inject, Injectable } from "@nestjs/common";
@@ -60,6 +61,7 @@ export class ActivitiesEventsService {
   })
   async handleActivityCreate(
     @RabbitPayload() data: unknown,
+    @RabbitRequest()
     amqpMsg: AmqpMessage,
   ) {
     const headers = amqpMsg?.properties.headers ?? {};
@@ -159,6 +161,7 @@ export class ActivitiesEventsService {
   })
   async handleGuildMemberRemoved(
     @RabbitPayload() data: unknown,
+    @RabbitRequest()
     amqpMsg: AmqpMessage,
   ) {
     const result = GuildMemberRemovedSchema.safeParse(data);


### PR DESCRIPTION
## Summary
- bind activity RabbitMQ handlers' raw AMQP message argument with `@RabbitRequest()`
- keep signed activity payload format and retry/DLQ behavior unchanged
- add a regression test that verifies handlers reading AMQP headers are decorated as RabbitMQ requests

## Root cause
After PR #1068, the activity service verifies signed gateway activity events. The handler read `amqpMsg.properties.headers`, but the second method parameter was not decorated. In `@golevelup/nestjs-rabbitmq`, the raw AMQP message is only bound through `@RabbitRequest()`, so the signature header was not visible and connect/disconnect events were rejected as invalid signatures.

## Validation
- `pnpm --filter @lootlog/activity test -- src/activities/services/activities-events.service.spec.ts`
- `pnpm --filter @lootlog/activity lint`
- pre-commit changed-package lint/test checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of activity-related event messages so key message context is reliably available during processing.
  * Added coverage to confirm the expected message binding is present for supported event handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->