### PR TITLE
fix: add Margonem proof grace period

### DIFF
--- a/apps/game-client/src/contexts/socket-context.test.tsx
+++ b/apps/game-client/src/contexts/socket-context.test.tsx
@@ -1,0 +1,127 @@
+import { render, waitFor } from "@testing-library/react";
+import { GatewayEvent } from "@/config/gateway";
+import { useGlobalStore } from "@/store/global.store";
+import { SocketProvider } from "./socket-context";
+
+const { mockRequestMargonemAccountProof, mockSocket } = vi.hoisted(() => ({
+  mockRequestMargonemAccountProof: vi.fn(),
+  mockSocket: {
+    auth: {},
+    connected: true,
+    id: "socket-1",
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    emit: vi.fn(),
+    off: vi.fn(),
+    on: vi.fn(),
+    onAny: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/margonem-account-proof", () => ({
+  requestMargonemAccountProof: mockRequestMargonemAccountProof,
+}));
+
+vi.mock("@/lib/socket", () => ({
+  getSocket: () => mockSocket,
+}));
+
+vi.mock("@/lib/game", () => ({
+  Game: {
+    getWorldName: () => "alpha",
+    hero: {
+      account: 20,
+      clan: undefined,
+      id: 10,
+      img: "hero-icon",
+      lvl: 100,
+      nick: "Hero",
+      prof: "w",
+      x: 1,
+      y: 2,
+    },
+    map: {
+      id: 100,
+      name: "Karka-han",
+    },
+  },
+}));
+
+const expectedJoinData = {
+  accountId: "20",
+  characterId: "10",
+  clan: undefined,
+  icon: "hero-icon",
+  location: {
+    map: "Karka-han",
+    x: 1,
+    y: 2,
+  },
+  lvl: 100,
+  name: "Hero",
+  prof: "w",
+  world: "alpha",
+};
+
+describe("SocketProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket.auth = {};
+    mockSocket.connected = true;
+    mockSocket.id = "socket-1";
+    useGlobalStore.setState({
+      gameState: { gameInitialized: true },
+      socketState: { connected: false, joined: false, joinedGuilds: [] },
+    });
+  });
+
+  it("emits join with Margonem account proof when proof request succeeds", async () => {
+    const proof = {
+      userId: "20",
+      characterId: "10",
+      token: "token",
+      ts: 1_700_000_000,
+      validatedString: "20+token+1700000000",
+      signatureBase64: "signature",
+    };
+    mockRequestMargonemAccountProof.mockResolvedValue(proof);
+
+    render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockSocket.emit).toHaveBeenCalledWith(GatewayEvent.JOIN, {
+        data: expectedJoinData,
+        margonemAccountProof: proof,
+      });
+    });
+    expect(mockRequestMargonemAccountProof).toHaveBeenCalledWith({
+      socketId: "socket-1",
+      accountId: "20",
+      characterId: "10",
+      clanId: undefined,
+    });
+  });
+
+  it("emits join without Margonem account proof when proof request fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    mockRequestMargonemAccountProof.mockRejectedValue(
+      new Error("Margonem unavailable"),
+    );
+
+    render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockSocket.emit).toHaveBeenCalledWith(GatewayEvent.JOIN, {
+        data: expectedJoinData,
+      });
+    });
+  });
+});

--- a/apps/game-client/src/contexts/socket-context.tsx
+++ b/apps/game-client/src/contexts/socket-context.tsx
@@ -64,6 +64,12 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
           accountId,
           characterId,
           clanId: Game.hero.clan?.id,
+        }).catch((error) => {
+          if (import.meta.env.DEV) {
+            console.warn("[Gateway] Failed to verify Margonem account", error);
+          }
+
+          return undefined;
         });
 
         if (cancelled || !socket.connected) {
@@ -92,14 +98,14 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
               map: Game.map.name,
             },
           },
-          margonemAccountProof,
+          ...(margonemAccountProof ? { margonemAccountProof } : {}),
         });
       }
     };
 
     void emitJoin().catch((error) => {
       if (import.meta.env.DEV) {
-        console.error("[Gateway] Failed to verify Margonem account", error);
+        console.warn("[Gateway] Failed to verify Margonem account", error);
       }
     });
 

--- a/apps/gateway/.env.example
+++ b/apps/gateway/.env.example
@@ -7,6 +7,7 @@ SERVICE_NAME=gateway
 API_URL=http://localhost/api/lootlog
 AUTH_URL=http://localhost/api/auth
 MARGONEM_SIGNING_KEY_URL=https://staticinfo.margonem.pl/.well-known/signing-key.pem
+MARGONEM_ACCOUNT_PROOF_REQUIRED=false
 
 # RabbitMQ Message Queue
 RABBITMQ_URI=amqp://rabbitmq_user:rabbitmq_password@localhost:5672

--- a/apps/gateway/src/config/env.ts
+++ b/apps/gateway/src/config/env.ts
@@ -38,6 +38,7 @@ const parsedEnv = createEnv(
     AXIOM_DATASET: z.string().optional(),
     AXIOM_TOKEN: z.string().optional(),
     DEV_PERMISSION_OVERRIDE_ENABLED: booleanEnv.default(false),
+    MARGONEM_ACCOUNT_PROOF_REQUIRED: booleanEnv.default(false),
     ACTIVITY_EVENT_SIGNATURE_SECRET: z.string().min(32).optional(),
   }),
 );

--- a/apps/gateway/src/gateway/services/subscription.service.spec.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from "@nestjs/common";
 import { Permission } from "@lootlog/types";
 import { SubscriptionService } from "./subscription.service";
 import { Platform } from "../enums/platform.enum";
@@ -8,6 +9,7 @@ import { buildRoomName } from "../utils/room-utils";
 import type { MargonemAccountProofDto } from "../dto/join-gateway.dto";
 import type { SocketUserPlayer } from "../types/socket-user.type";
 import type { UserGuildData, GuildRole } from "src/guilds/types/guild.types";
+import { env } from "src/config/env";
 
 function createRole(
   permissions: Permission[],
@@ -127,6 +129,7 @@ describe("SubscriptionService", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    env.MARGONEM_ACCOUNT_PROOF_REQUIRED = false;
     service = new SubscriptionService(
       mockGuildsService as never,
       mockPresenceService as never,
@@ -167,7 +170,16 @@ describe("SubscriptionService", () => {
     expect(mockMargonemAccountProofService.verifyProof).not.toHaveBeenCalled();
   });
 
-  it("rejects game joins without a valid Margonem account proof before resolving guilds", async () => {
+  it("allows game joins without a valid Margonem account proof during the grace period", async () => {
+    const warnSpy = vi
+      .spyOn(Logger.prototype, "warn")
+      .mockImplementation(() => undefined);
+    const guilds = [
+      createGuild({
+        discordId: "discord-1",
+        permissions: [Permission.LOOTLOG_ONLINE_PLAYERS_READ],
+      }),
+    ];
     const client = {
       id: "socket-1",
       data: {
@@ -179,6 +191,112 @@ describe("SubscriptionService", () => {
       join: vi.fn(),
       request: { headers: {} },
     };
+
+    mockMargonemAccountProofService.verifyProof.mockResolvedValueOnce({
+      valid: false,
+      reason: "missing proof",
+    });
+    mockGuildsService.getUserGuilds.mockResolvedValue(guilds);
+
+    const result = await service.handleJoin(
+      mockServer as never,
+      client as never,
+      "discord-1",
+      "user-1",
+      createPlayer(),
+      undefined,
+    );
+
+    expect(result.status).toBe(ResponseStatus.SUCCESS);
+    expect(result.guildIds).toEqual(["guild-1"]);
+    expect(mockMargonemAccountProofService.verifyProof).toHaveBeenCalledWith({
+      proof: undefined,
+      socketId: "socket-1",
+      accountId: "20",
+      characterId: "10",
+      clanId: undefined,
+    });
+    expect(client.data.margonemAccountVerified).toBe(false);
+    expect(client.join).toHaveBeenCalledWith(result.featureRooms);
+    expect(mockActivityService.publishActivityEvent).toHaveBeenCalledWith(
+      ActivityType.CONNECT_EVENT,
+      client,
+      guilds,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Accepted unverified game join for discord-1: missing proof",
+    );
+  });
+
+  it("allows game joins with invalid Margonem account proof during the grace period", async () => {
+    const warnSpy = vi
+      .spyOn(Logger.prototype, "warn")
+      .mockImplementation(() => undefined);
+    const guilds = [
+      createGuild({
+        discordId: "discord-1",
+        permissions: [Permission.LOOTLOG_ONLINE_PLAYERS_READ],
+      }),
+    ];
+    const client = {
+      id: "socket-1",
+      data: {
+        discordId: "discord-1",
+        sessionId: "socket-1",
+        userId: "user-1",
+        platform: Platform.GAME,
+      },
+      join: vi.fn(),
+      request: { headers: {} },
+    };
+    const proof = createMargonemAccountProof();
+
+    mockMargonemAccountProofService.verifyProof.mockResolvedValueOnce({
+      valid: false,
+      reason: "invalid proof signature",
+    });
+    mockGuildsService.getUserGuilds.mockResolvedValue(guilds);
+
+    const result = await service.handleJoin(
+      mockServer as never,
+      client as never,
+      "discord-1",
+      "user-1",
+      createPlayer(),
+      proof,
+    );
+
+    expect(result.status).toBe(ResponseStatus.SUCCESS);
+    expect(mockMargonemAccountProofService.verifyProof).toHaveBeenCalledWith({
+      proof,
+      socketId: "socket-1",
+      accountId: "20",
+      characterId: "10",
+      clanId: undefined,
+    });
+    expect(client.data.margonemAccountVerified).toBe(false);
+    expect(client.join).toHaveBeenCalledWith(result.featureRooms);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Accepted unverified game join for discord-1: invalid proof signature",
+    );
+  });
+
+  it("rejects game joins without a valid Margonem account proof when proof is required", async () => {
+    const warnSpy = vi
+      .spyOn(Logger.prototype, "warn")
+      .mockImplementation(() => undefined);
+    const client = {
+      id: "socket-1",
+      data: {
+        discordId: "discord-1",
+        sessionId: "socket-1",
+        userId: "user-1",
+        platform: Platform.GAME,
+      },
+      join: vi.fn(),
+      request: { headers: {} },
+    };
+    env.MARGONEM_ACCOUNT_PROOF_REQUIRED = true;
 
     mockMargonemAccountProofService.verifyProof.mockResolvedValueOnce({
       valid: false,
@@ -199,16 +317,12 @@ describe("SubscriptionService", () => {
       code: "MARGONEM_ACCOUNT_PROOF_INVALID",
       message: ErrorMessages.MARGONEM_ACCOUNT_PROOF_INVALID,
     });
-    expect(mockMargonemAccountProofService.verifyProof).toHaveBeenCalledWith({
-      proof: undefined,
-      socketId: "socket-1",
-      accountId: "20",
-      characterId: "10",
-      clanId: undefined,
-    });
     expect(mockGuildsService.getUserGuilds).not.toHaveBeenCalled();
     expect(client.join).not.toHaveBeenCalled();
     expect(mockActivityService.publishActivityEvent).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Rejected game join for discord-1: missing proof",
+    );
   });
 
   it("grants owner full room access and emits initial presence for game clients", async () => {

--- a/apps/gateway/src/gateway/services/subscription.service.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.ts
@@ -172,29 +172,29 @@ export class SubscriptionService {
         clanId: player.clan?.id,
       });
 
-    if (proofVerification.valid) {
-      client.data.margonemAccountVerified = true;
+    if (proofVerification.valid === false) {
+      client.data.margonemAccountVerified = false;
+
+      if (env.MARGONEM_ACCOUNT_PROOF_REQUIRED) {
+        this.logger.warn(
+          `Rejected game join for ${discordId}: ${proofVerification.reason}`,
+        );
+
+        return {
+          status: ResponseStatus.ERROR,
+          code: "MARGONEM_ACCOUNT_PROOF_INVALID",
+          message: ErrorMessages.MARGONEM_ACCOUNT_PROOF_INVALID,
+        };
+      }
+
+      this.logger.warn(
+        `Accepted unverified game join for ${discordId}: ${proofVerification.reason}`,
+      );
+
       return null;
     }
 
-    client.data.margonemAccountVerified = false;
-
-    if (env.MARGONEM_ACCOUNT_PROOF_REQUIRED) {
-      this.logger.warn(
-        `Rejected game join for ${discordId}: ${proofVerification.reason}`,
-      );
-
-      return {
-        status: ResponseStatus.ERROR,
-        code: "MARGONEM_ACCOUNT_PROOF_INVALID",
-        message: ErrorMessages.MARGONEM_ACCOUNT_PROOF_INVALID,
-      };
-    }
-
-    this.logger.warn(
-      `Accepted unverified game join for ${discordId}: ${proofVerification.reason}`,
-    );
-
+    client.data.margonemAccountVerified = true;
     return null;
   }
 }

--- a/apps/gateway/src/gateway/services/subscription.service.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.ts
@@ -18,6 +18,7 @@ import type {
 } from "src/gateway/types/socket-user.type";
 import type { UserGuildData } from "src/guilds/types/guild.types";
 import { MargonemAccountProofService } from "./margonem-account-proof.service";
+import { env } from "src/config/env";
 
 interface JoinResult {
   status: ResponseStatus;
@@ -57,28 +58,16 @@ export class SubscriptionService {
           };
         }
 
-        const proofVerification =
-          await this.margonemAccountProofService.verifyProof({
-            proof: margonemAccountProof,
-            socketId: client.id,
-            accountId: player.accountId,
-            characterId: player.characterId,
-            clanId: player.clan?.id,
-          });
+        const proofError = await this.verifyMargonemAccountProof({
+          client,
+          discordId,
+          player,
+          margonemAccountProof,
+        });
 
-        if (proofVerification.valid === false) {
-          this.logger.warn(
-            `Rejected game join for ${discordId}: ${proofVerification.reason}`,
-          );
-
-          return {
-            status: ResponseStatus.ERROR,
-            code: "MARGONEM_ACCOUNT_PROOF_INVALID",
-            message: ErrorMessages.MARGONEM_ACCOUNT_PROOF_INVALID,
-          };
+        if (proofError) {
+          return proofError;
         }
-
-        client.data.margonemAccountVerified = true;
       }
 
       const guilds = await this.guildsService.getUserGuilds({
@@ -161,5 +150,51 @@ export class SubscriptionService {
       client,
       guilds,
     );
+  }
+
+  private async verifyMargonemAccountProof({
+    client,
+    discordId,
+    player,
+    margonemAccountProof,
+  }: {
+    client: Socket;
+    discordId: string;
+    player: SocketUserPlayer;
+    margonemAccountProof?: MargonemAccountProofDto;
+  }): Promise<JoinResult | null> {
+    const proofVerification =
+      await this.margonemAccountProofService.verifyProof({
+        proof: margonemAccountProof,
+        socketId: client.id,
+        accountId: player.accountId,
+        characterId: player.characterId,
+        clanId: player.clan?.id,
+      });
+
+    if (proofVerification.valid) {
+      client.data.margonemAccountVerified = true;
+      return null;
+    }
+
+    client.data.margonemAccountVerified = false;
+
+    if (env.MARGONEM_ACCOUNT_PROOF_REQUIRED) {
+      this.logger.warn(
+        `Rejected game join for ${discordId}: ${proofVerification.reason}`,
+      );
+
+      return {
+        status: ResponseStatus.ERROR,
+        code: "MARGONEM_ACCOUNT_PROOF_INVALID",
+        message: ErrorMessages.MARGONEM_ACCOUNT_PROOF_INVALID,
+      };
+    }
+
+    this.logger.warn(
+      `Accepted unverified game join for ${discordId}: ${proofVerification.reason}`,
+    );
+
+    return null;
   }
 }

--- a/apps/gateway/src/types/environment.d.ts
+++ b/apps/gateway/src/types/environment.d.ts
@@ -23,6 +23,7 @@ declare global {
       OTEL_TRACES_EXPORTER: string;
       SERVICE_NAMESPACE: string;
       DEV_PERMISSION_OVERRIDE_ENABLED: string;
+      MARGONEM_ACCOUNT_PROOF_REQUIRED: string;
     }
   }
 }

--- a/apps/gateway/vitest.setup.ts
+++ b/apps/gateway/vitest.setup.ts
@@ -20,6 +20,7 @@ vi.mock("src/config/env", () => ({
     AXIOM_DATASET: "",
     AXIOM_TOKEN: "",
     DEV_PERMISSION_OVERRIDE_ENABLED: false,
+    MARGONEM_ACCOUNT_PROOF_REQUIRED: false,
     ACTIVITY_EVENT_SIGNATURE_SECRET:
       "local-development-activity-event-signature-secret",
   },


### PR DESCRIPTION
## Summary
- add gateway grace period for missing or invalid Margonem account proof
- keep strict rejection behind MARGONEM_ACCOUNT_PROOF_REQUIRED=true
- let game-client join without proof when Margonem proof request fails
- verify lootlog-prod gateway/activity event signature secret wiring

## Test Plan
- pnpm --filter @lootlog/gateway test -- src/gateway/services/subscription.service.spec.ts
- pnpm --filter @lootlog/game-client test -- src/contexts/socket-context.test.tsx

## Prod Secret Check
- gateway-secrets.activityEventSignatureSecret exists in lootlog-prod
- activity-secrets.activityEventSignatureSecret exists in lootlog-prod
- both decode to 64 bytes and have identical values
- gateway and activity deployments map ACTIVITY_EVENT_SIGNATURE_SECRET from those secrets
