### PR TITLE
[codex] Reuse notification trigger window seconds

### DIFF
--- a/apps/api/src/notifications/notification-rule.service.ts
+++ b/apps/api/src/notifications/notification-rule.service.ts
@@ -39,6 +39,9 @@ import {
 
 const GUILD_NOTIFICATION_TEST_TRIGGER_LIMIT = 10;
 const GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_MS = 15 * 60_000;
+const GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_SECONDS = Math.floor(
+  GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_MS / 1000,
+);
 const GUILD_NOTIFICATION_MAX_NPCS_PER_RULE = 5;
 const USER_NOTIFICATION_RULE_LIMIT = 50;
 
@@ -104,9 +107,8 @@ export class NotificationRuleService {
         ruleCount: rules.length,
         maxNpcsPerRule: GUILD_NOTIFICATION_MAX_NPCS_PER_RULE,
         testTriggerLimit: GUILD_NOTIFICATION_TEST_TRIGGER_LIMIT,
-        testTriggerWindowSeconds: Math.floor(
-          GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_MS / 1000,
-        ),
+        testTriggerWindowSeconds:
+          GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_SECONDS,
       },
     };
   }
@@ -211,7 +213,7 @@ export class NotificationRuleService {
         limit: worstUsage?.limit ?? GUILD_NOTIFICATION_TEST_TRIGGER_LIMIT,
         windowSeconds:
           worstUsage?.windowSeconds ??
-          Math.floor(GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_MS / 1000),
+          GUILD_NOTIFICATION_TEST_TRIGGER_WINDOW_SECONDS,
         nextAvailableAt: worstUsage?.nextAvailableAt ?? null,
       });
     }


### PR DESCRIPTION
## Summary

- Extracted the guild notification test-trigger window seconds into a named constant.
- Reused the constant in guild rule limits and test-trigger limit responses to avoid repeating the millisecond-to-second conversion.

## Verification

- `pnpm --filter @lootlog/api build`
- `pnpm turbo run lint --filter=@lootlog/api`
- `pnpm exec oxfmt --check apps/api/src/notifications/notification-rule.service.ts`
- `pnpm -C apps/api exec vitest run --config ./vitest.config.ts src/notifications/notifications.service.spec.ts`
- `pnpm turbo run test --filter=@lootlog/api`
- `sh .husky/pre-commit`

Notes: API lint passes with existing warnings elsewhere in the package; no lint errors were reported.