### PR TITLE
[codex] refactor(cli): simplify auth postgres env lookup

### DIFF
--- a/packages/cli/src/utils/env-generator.ts
+++ b/packages/cli/src/utils/env-generator.ts
@@ -304,28 +304,15 @@ const deriveAuthPostgresValue = (
   sharedValues: Map<string, string>,
 ): string | null => {
   const credentials = getDatabaseCredentials(sharedValues, "users");
+  const postgresValuesByKey: Partial<Record<string, string>> = {
+    POSTGRESQL_HOST: DEFAULT_POSTGRESQL_HOST,
+    POSTGRESQL_PORT: credentials.port,
+    POSTGRESQL_USER: credentials.user,
+    POSTGRESQL_PASSWORD: credentials.password,
+    POSTGRESQL_DATABASE: credentials.database,
+  };
 
-  if (key === "POSTGRESQL_HOST") {
-    return DEFAULT_POSTGRESQL_HOST;
-  }
-
-  if (key === "POSTGRESQL_PORT") {
-    return credentials.port;
-  }
-
-  if (key === "POSTGRESQL_USER") {
-    return credentials.user;
-  }
-
-  if (key === "POSTGRESQL_PASSWORD") {
-    return credentials.password;
-  }
-
-  if (key === "POSTGRESQL_DATABASE") {
-    return credentials.database;
-  }
-
-  return null;
+  return postgresValuesByKey[key] ?? null;
 };
 
 export const enhanceVariablesWithDerivedValues = (


### PR DESCRIPTION
## Summary

- Replaced the auth Postgres env key `if` ladder with a keyed lookup map in the CLI env generator.
- Keeps the same fallback behavior while making the supported auth Postgres keys easier to scan and extend.

## Verification

- `pnpm --filter @lootlog/cli test`
- `pnpm exec oxfmt --check packages/cli/src/utils/env-generator.ts`
- `pnpm exec oxlint packages/cli/src/utils/env-generator.ts`
- `pnpm --filter @lootlog/cli exec tsc --ignoreConfig --noEmit --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --noUncheckedIndexedAccess --skipLibCheck --esModuleInterop --types node src/types.ts src/utils/env-generator.ts --pretty false`
- Pre-commit hook passed for staged file formatting/linting and changed-package tests.

Note: `pnpm exec tsc --noEmit --project tsconfig.json --pretty false` was attempted, but the root config is not a valid whole-repo check here because it default-includes app test/JSX/decorator files without their app-specific tsconfigs.