### PR TITLE
[codex] refactor web filter imports

### DIFF
--- a/apps/web/src/components/filters/index.ts
+++ b/apps/web/src/components/filters/index.ts
@@ -1,4 +1,0 @@
-export { LevelRangeFilter } from "./level-range-filter";
-export { PeriodSelector } from "./period-selector";
-export { CharacterSelector } from "./character-selector";
-export { WarriorSearchFilter } from "./warrior-search-filter";

--- a/apps/web/src/features/user/battle-panel/battle-panel-abyss/abyss-hub.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-abyss/abyss-hub.tsx
@@ -1,4 +1,5 @@
-import { CharacterSelector, LevelRangeFilter } from "@/components/filters";
+import { CharacterSelector } from "@/components/filters/character-selector";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
 import { SectionHeader } from "@/components/layout/section-header";
 import { ROUTES } from "@/config/routes";
 import {

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filter-toolbar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filter-toolbar.tsx
@@ -1,5 +1,6 @@
 import { PlayerTile } from "@/components/battle";
-import { LevelRangeFilter, WarriorSearchFilter } from "@/components/filters";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { WarriorSearchFilter } from "@/components/filters/warrior-search-filter";
 import { MARGONEM_CDN_CHARACTERS_URL } from "@/constants/margonem";
 import type { SearchWarrior as Warrior } from "@/lib/api/battlelog-types";
 import { capitalizeFirstLetter } from "@/utils/capitalize-first-letter";

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-desktop.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-desktop.tsx
@@ -31,7 +31,8 @@ import { MARGONEM_CDN_CHARACTERS_URL } from "@/constants/margonem";
 import { capitalizeFirstLetter } from "@/utils/capitalize-first-letter";
 import type { BattleFilters } from "./battles-list-filters";
 import { FilterPopover } from "@lootlog/ui/components/filter-popover";
-import { LevelRangeFilter, WarriorSearchFilter } from "@/components/filters";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { WarriorSearchFilter } from "@/components/filters/warrior-search-filter";
 import type { SearchWarrior as Warrior } from "@/lib/api/battlelog-types";
 import { useTranslation } from "react-i18next";
 

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-mobile.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-mobile.tsx
@@ -41,7 +41,7 @@ import { MARGONEM_CDN_CHARACTERS_URL } from "@/constants/margonem";
 import { Badge } from "@lootlog/ui/components/badge";
 import { capitalizeFirstLetter } from "@/utils/capitalize-first-letter";
 import type { BattleFilters } from "./battles-list-filters";
-import { WarriorSearchFilter } from "@/components/filters";
+import { WarriorSearchFilter } from "@/components/filters/warrior-search-filter";
 import type { SearchWarrior as Warrior } from "@/lib/api/battlelog-types";
 import { useTranslation } from "react-i18next";
 

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/filters-sidebar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/filters-sidebar.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import { cn } from "@lootlog/ui/lib/utils";
 import { FilterPopover } from "@lootlog/ui/components/filter-popover";
-import { LevelRangeFilter } from "@/components/filters";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
 import { useBattlesControllerGetUserWorlds } from "@/lib/api/generated/battlelog/battles/battles";
 import { capitalizeFirstLetter } from "@/utils/capitalize-first-letter";
 import {

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-filter-toolbar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-filter-toolbar.tsx
@@ -1,9 +1,7 @@
-import {
-  CharacterSelector,
-  LevelRangeFilter,
-  PeriodSelector,
-  WarriorSearchFilter,
-} from "@/components/filters";
+import { CharacterSelector } from "@/components/filters/character-selector";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { PeriodSelector } from "@/components/filters/period-selector";
+import { WarriorSearchFilter } from "@/components/filters/warrior-search-filter";
 import type { SearchWarrior as Warrior } from "@/lib/api/battlelog-types";
 import type { Period } from "@/features/user/battle-panel/battle-panel-search";
 import { Button } from "@lootlog/ui/components/button";

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-filters-panel.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-filters-panel.tsx
@@ -1,9 +1,7 @@
-import {
-  CharacterSelector,
-  PeriodSelector,
-  LevelRangeFilter,
-  WarriorSearchFilter,
-} from "@/components/filters";
+import { CharacterSelector } from "@/components/filters/character-selector";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { PeriodSelector } from "@/components/filters/period-selector";
+import { WarriorSearchFilter } from "@/components/filters/warrior-search-filter";
 import { Separator } from "@lootlog/ui/components/separator";
 import { Label } from "@lootlog/ui/components/label";
 import { Checkbox } from "@lootlog/ui/components/checkbox";

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/player-vs-player-filter-toolbar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/player-vs-player-filter-toolbar.tsx
@@ -1,4 +1,5 @@
-import { LevelRangeFilter, PeriodSelector } from "@/components/filters";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { PeriodSelector } from "@/components/filters/period-selector";
 import type { Period } from "@/features/user/battle-panel/battle-panel-search";
 import { Button } from "@lootlog/ui/components/button";
 import { Label } from "@lootlog/ui/components/label";

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/statistics-filters-desktop.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/statistics-filters-desktop.tsx
@@ -1,9 +1,7 @@
 import { Label } from "@lootlog/ui/components/label";
-import {
-  CharacterSelector,
-  PeriodSelector,
-  LevelRangeFilter,
-} from "@/components/filters";
+import { CharacterSelector } from "@/components/filters/character-selector";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { PeriodSelector } from "@/components/filters/period-selector";
 import { Checkbox } from "@lootlog/ui/components/checkbox";
 import { Swords, Award } from "lucide-react";
 import type { Period } from "@/features/user/battle-panel/battle-panel-search";

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/player-vs-player-full-page.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/player-vs-player-full-page.tsx
@@ -1,5 +1,6 @@
 import { PlayerTile } from "@/components/battle";
-import { LevelRangeFilter, PeriodSelector } from "@/components/filters";
+import { LevelRangeFilter } from "@/components/filters/level-range-filter";
+import { PeriodSelector } from "@/components/filters/period-selector";
 import { TanStackTableBody } from "@/components/ui/tanstack-table-body";
 import { TanStackTableHeader } from "@/components/ui/tanstack-table-header";
 import { TableRowsSkeleton } from "@/components/ui/table-rows-skeleton";


### PR DESCRIPTION
## Summary

- Removed the re-export-only `apps/web/src/components/filters/index.ts` wrapper.
- Updated battle panel filter consumers to import `CharacterSelector`, `LevelRangeFilter`, `PeriodSelector`, and `WarriorSearchFilter` from their concrete component modules.

## Impact

This keeps the web imports aligned with the repository rule against re-export-only wrappers without changing runtime behavior.

## Verification

- `corepack pnpm turbo run lint --filter=@lootlog/web`
- `corepack pnpm turbo run build --filter=@lootlog/web`
- `corepack pnpm format:check`
- `.husky/pre-commit`
- Commit hook pre-commit checks during `git commit`

Note: `@lootlog/web` does not define package-level `test` or `format:check` scripts, so the hook's changed-package Turbo steps had no web task for those names; the explicit full repo format check and web build/typecheck passed.