### PR TITLE
[codex] simplify item stat value mapping

### DIFF
--- a/apps/web/src/components/tiles/item-tile.tsx
+++ b/apps/web/src/components/tiles/item-tile.tsx
@@ -11,18 +11,35 @@ export type ItemTileProps = {
   shareNickname?: string;
 };
 
+const STAT_VALUE_SEPARATOR = ",\u00A0";
+
+const formatStringValue = (rawValue: string) => {
+  return rawValue.replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+};
+
 const formatValue = (
   rawValue: string | string[] | number | boolean | undefined,
 ) => {
   if (Array.isArray(rawValue)) {
-    return rawValue.join(",\u00A0");
+    return rawValue.join(STAT_VALUE_SEPARATOR);
   }
 
   if (typeof rawValue === "string") {
-    return rawValue.replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+    return formatStringValue(rawValue);
   }
 
   return rawValue;
+};
+
+const mapUntranslatedArrayValues = (rawValues: string[]) => {
+  return rawValues.reduce<Record<string, string>>(
+    (acc, rawValue, valueIndex) => {
+      acc[`value${valueIndex + 1}`] = formatStringValue(rawValue);
+
+      return acc;
+    },
+    {},
+  );
 };
 
 export const ItemTile: FC<ItemTileProps> = ({
@@ -32,6 +49,9 @@ export const ItemTile: FC<ItemTileProps> = ({
   shareNickname,
 }) => {
   const { t } = useTranslation();
+  const typeLabels = item.type
+    ? { [item.type]: t(`itemType.${item.type}`) }
+    : {};
   const labels = {
     obtainedBy: t("loots.list.obtainedBy"),
     rarity: {
@@ -41,10 +61,26 @@ export const ItemTile: FC<ItemTileProps> = ({
       [ItemRarity.UNIQUE]: t("itemRarity.UNIQUE"),
       [ItemRarity.UPGRADED]: t("itemRarity.UPGRADED"),
     },
-    type: {
-      [item.type ?? ""]: item.type ? t(`itemType.${item.type}`) : "",
-    },
+    type: typeLabels,
     typePrefix: t("itemType.prefix"),
+  };
+
+  const getTranslatedValues = (displayValue: ItemDisplayValue) => {
+    if (!Array.isArray(displayValue.value)) {
+      return { value: formatValue(displayValue.value) };
+    }
+
+    if (!displayValue.translateKey) {
+      return mapUntranslatedArrayValues(displayValue.value);
+    }
+
+    return {
+      value: displayValue.value
+        .map((translationKey) =>
+          t(`${displayValue.translateKey}.${translationKey}`),
+        )
+        .join(STAT_VALUE_SEPARATOR),
+    };
   };
 
   const renderStat = (displayValue: ItemDisplayValue) => {
@@ -52,26 +88,7 @@ export const ItemTile: FC<ItemTileProps> = ({
       return null;
     }
 
-    const translatedValues =
-      Array.isArray(displayValue.value) && !displayValue.translateKey
-        ? displayValue.value.reduce(
-            (acc: Record<string, string>, rawValue, valueIndex) => {
-              acc[`value${valueIndex + 1}`] = formatValue(rawValue) as string;
-
-              return acc;
-            },
-            {},
-          )
-        : {
-            value:
-              displayValue.translateKey && Array.isArray(displayValue.value)
-                ? displayValue.value
-                    .map((translationKey) =>
-                      t(`${displayValue.translateKey}.${translationKey}`),
-                    )
-                    .join(",\u00A0")
-                : formatValue(displayValue.value),
-          };
+    const translatedValues = getTranslatedValues(displayValue);
 
     return (
       <Trans


### PR DESCRIPTION
## Summary
- Refactor `ItemTile` stat value mapping to replace nested ternaries with explicit scalar, untranslated array, and translated array paths.
- Name the non-breaking-space separator and reuse the existing string formatting logic through small helpers.
- Keep item type label behavior unchanged while avoiding the empty-key label object.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm turbo run lint --filter=@lootlog/web`
- `corepack pnpm turbo run build --filter=@lootlog/web`
- `corepack pnpm format:check`
- `.husky/pre-commit`
- Commit hook via `git commit`

Notes: web build still emits the existing third-party `lottie-web` direct-eval warning; lint still replays an existing cached `@lootlog/ui` `no-img-element` warning outside this change.