### PR TITLE
Stabilize online presence and list refreshes

### DIFF
--- a/apps/game-client/src/features/online-players/hooks/use-players-presence.test.tsx
+++ b/apps/game-client/src/features/online-players/hooks/use-players-presence.test.tsx
@@ -326,6 +326,13 @@ describe("usePlayersPresence", () => {
   });
 
   it("refetches and clears stale players after permissions are updated", async () => {
+    let resolvePermissionsRefetch: (
+      value: Awaited<ReturnType<typeof emitWithAckSpy>>,
+    ) => void;
+    const permissionsRefetchPromise = new Promise((resolve) => {
+      resolvePermissionsRefetch = resolve;
+    });
+
     emitWithAckSpy
       .mockImplementationOnce(() =>
         Promise.resolve({
@@ -349,12 +356,7 @@ describe("usePlayersPresence", () => {
           },
         }),
       )
-      .mockImplementationOnce(() =>
-        Promise.resolve({
-          status: "forbidden",
-          code: "ONLINE_PLAYERS_ACCESS_DENIED",
-        }),
-      );
+      .mockImplementationOnce(() => permissionsRefetchPromise);
 
     const { result } = renderHook(() => usePlayersPresence("guild-1", "alpha"));
 
@@ -364,6 +366,16 @@ describe("usePlayersPresence", () => {
 
     act(() => {
       eventHandlers[GatewayEvent.PERMISSIONS_UPDATED]?.({});
+    });
+
+    expect(result.current[0]["discord-1"]).toHaveLength(1);
+
+    await act(async () => {
+      resolvePermissionsRefetch!({
+        status: "forbidden",
+        code: "ONLINE_PLAYERS_ACCESS_DENIED",
+      });
+      await permissionsRefetchPromise;
     });
 
     await waitFor(() => {

--- a/apps/game-client/src/features/online-players/hooks/use-players-presence.tsx
+++ b/apps/game-client/src/features/online-players/hooks/use-players-presence.tsx
@@ -33,6 +33,7 @@ export const usePlayersPresence = (
 
   const selectedGuildIdRef = useRef(selectedGuildId);
   const worldRef = useRef(world);
+  const visibleScopeRef = useRef({ guildId: selectedGuildId, world });
   const requestIdRef = useRef(0);
 
   useEffect(() => {
@@ -42,6 +43,8 @@ export const usePlayersPresence = (
 
   useEffect(() => {
     if (!selectedGuildId || !world) {
+      requestIdRef.current += 1;
+      visibleScopeRef.current = { guildId: selectedGuildId, world };
       setOnlinePlayers({});
       setLoading(false);
       setAccessState("allowed");
@@ -57,8 +60,16 @@ export const usePlayersPresence = (
     )
       return;
 
+    const scopeChanged =
+      visibleScopeRef.current.guildId !== selectedGuildId ||
+      visibleScopeRef.current.world !== world;
     const currentRequestId = ++requestIdRef.current;
-    setOnlinePlayers({});
+    visibleScopeRef.current = { guildId: selectedGuildId, world };
+
+    if (scopeChanged) {
+      setOnlinePlayers({});
+    }
+
     setAccessState("allowed");
     setLoading(true);
 
@@ -157,7 +168,6 @@ export const usePlayersPresence = (
     if (!socket || !connected || !joined) return;
 
     const handlePermissionsUpdated = () => {
-      setOnlinePlayers({});
       setPermissionsVersion((version) => version + 1);
     };
 

--- a/apps/gateway/src/gateway/dto/request-member-web-presence.dto.ts
+++ b/apps/gateway/src/gateway/dto/request-member-web-presence.dto.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { createZodDto } from "nestjs-zod";
+
+const RequestMemberWebPresenceSchema = z.object({
+  guildId: z.string().min(1),
+});
+
+export class RequestMemberWebPresenceDto extends createZodDto(
+  RequestMemberWebPresenceSchema,
+) {}

--- a/apps/gateway/src/gateway/enums/gateway-event.enum.ts
+++ b/apps/gateway/src/gateway/enums/gateway-event.enum.ts
@@ -4,6 +4,8 @@ export enum GatewayEvent {
   JOIN = "join",
   ONLINE_PLAYERS_PRESENCE_FETCH = "online-players:presence:fetch",
   ONLINE_PLAYERS_PRESENCE_UPDATE = "online-players:presence:update",
+  MEMBER_WEB_PRESENCE_FETCH = "member-web-presence:fetch",
+  MEMBER_WEB_PRESENCE_UPDATE = "member-web-presence:update",
   CHAT_MESSAGE = "chat-message",
   LOOTS_CREATE = "loots-create",
   LOOTS_SHARE_UPDATE = "loots-share-update",

--- a/apps/gateway/src/gateway/gateway.spec.ts
+++ b/apps/gateway/src/gateway/gateway.spec.ts
@@ -1,6 +1,7 @@
 import { Gateway } from "./gateway";
 import { GatewayEvent } from "./enums/gateway-event.enum";
 import { Platform } from "./enums/platform.enum";
+import { UserPresenceStatus } from "./enums/user-presence-status.enum";
 
 describe("Gateway", () => {
   const mockConnectionService = {
@@ -13,9 +14,11 @@ describe("Gateway", () => {
     emitDisconnectPresence: vi.fn(),
     broadcastPlayerDisconnect: vi.fn(),
     fetchOnlinePlayersPresence: vi.fn(),
+    fetchMemberWebPresence: vi.fn(),
     updatePlayerPresence: vi.fn(),
     fetchEventPresence: vi.fn(),
     checkPresenceForMap: vi.fn(),
+    emitMemberWebPresenceUpdate: vi.fn(),
   };
 
   const mockSubscriptionService = {
@@ -151,6 +154,53 @@ describe("Gateway", () => {
     );
   });
 
+  it("emits web presence offline when a web socket disconnects", async () => {
+    let disconnectingHandler!: () => Promise<void>;
+
+    const client = {
+      id: "socket-1",
+      request: { headers: {} },
+      disconnect: vi.fn(),
+      on: vi.fn((event: string, handler: () => Promise<void>) => {
+        if (event === GatewayEvent.DISCONNECTING) {
+          disconnectingHandler = handler;
+        }
+      }),
+      data: undefined,
+    };
+    const socketData = {
+      discordId: "discord-1",
+      userId: "user-1",
+      sessionId: "socket-1",
+      platform: Platform.WEB_APP,
+      guilds: [
+        {
+          guild: { id: "guild-1", ownerId: "owner-1" },
+          roles: [],
+        },
+      ],
+    };
+
+    mockConnectionService.getConnectionMetadata.mockReturnValue({
+      platform: Platform.WEB_APP,
+    });
+    mockGatewayAuthService.verifyConnectionIdentity.mockResolvedValue({
+      discordId: "discord-1",
+      userId: "user-1",
+    });
+    mockConnectionService.validateConnection.mockReturnValue({ valid: true });
+    mockConnectionService.initializeSocketData.mockReturnValue(socketData);
+    mockSubscriptionService.handleDisconnect.mockResolvedValue(undefined);
+    mockPresenceService.broadcastPlayerDisconnect.mockResolvedValue(undefined);
+
+    await gateway.handleConnection(client as never);
+    await disconnectingHandler();
+
+    expect(
+      mockPresenceService.emitMemberWebPresenceUpdate,
+    ).toHaveBeenCalledWith(mockServer, client, UserPresenceStatus.OFFLINE);
+  });
+
   it("emits join result returned by subscription service", async () => {
     const client = {
       emit: vi.fn(),
@@ -227,5 +277,38 @@ describe("Gateway", () => {
         } as never,
       ),
     ).resolves.toEqual(expectedPresence);
+  });
+
+  it("delegates member web presence fetch through the presence service", async () => {
+    const client = {
+      data: {
+        platform: Platform.WEB_APP,
+      },
+      rooms: new Set(["guild-1:presence"]),
+    };
+    const expectedPresence = {
+      status: "success",
+      sessions: {
+        "discord-1": [{ sessionId: "session-1" }],
+      },
+    };
+
+    mockPresenceService.fetchMemberWebPresence.mockResolvedValue(
+      expectedPresence,
+    );
+
+    await expect(
+      gateway.handleMemberWebPresenceFetch(
+        client as never,
+        {
+          guildId: "guild-1",
+        } as never,
+      ),
+    ).resolves.toEqual(expectedPresence);
+    expect(mockPresenceService.fetchMemberWebPresence).toHaveBeenCalledWith(
+      mockServer,
+      client,
+      "guild-1",
+    );
   });
 });

--- a/apps/gateway/src/gateway/gateway.ts
+++ b/apps/gateway/src/gateway/gateway.ts
@@ -10,10 +10,12 @@ import {
 import type { Server } from "socket.io";
 import type { JoinGatewayDto } from "src/gateway/dto/join-gateway.dto";
 import type { RequestOnlinePlayersPresenceDto } from "src/gateway/dto/request-online-players-presence.dto";
+import type { RequestMemberWebPresenceDto } from "src/gateway/dto/request-member-web-presence.dto";
 import type { PlayerPresenceUpdateDto } from "src/gateway/dto/player-presence-update.dto";
 import type { RequestEventPresenceDto } from "src/gateway/dto/request-event-presence.dto";
 import { GatewayEvent } from "src/gateway/enums/gateway-event.enum";
 import { GatewayConfig } from "src/gateway/constants/gateway-config.constant";
+import { UserPresenceStatus } from "src/gateway/enums/user-presence-status.enum";
 import { WsDiscordId, WsUserId } from "src/shared/decorators/user-id.decorator";
 import type {
   Socket,
@@ -21,6 +23,7 @@ import type {
 } from "src/gateway/types/socket-user.type";
 import { ConnectionService } from "./services/connection.service";
 import {
+  type MemberWebPresenceFetchResponse,
   type PresenceFetchResponse,
   PresenceService,
 } from "./services/presence.service";
@@ -73,6 +76,11 @@ export class Gateway {
     client.on(GatewayEvent.DISCONNECTING, async () => {
       if (client.data) {
         this.presenceService.emitDisconnectPresence(this.server, client);
+        this.presenceService.emitMemberWebPresenceUpdate(
+          this.server,
+          client,
+          UserPresenceStatus.OFFLINE,
+        );
 
         if (client.data.guilds) {
           await this.subscriptionService.handleDisconnect(
@@ -119,6 +127,19 @@ export class Gateway {
       client,
       guildId,
       world,
+    );
+  }
+
+  @UseFilters(new BaseWsExceptionFilter())
+  @SubscribeMessage(GatewayEvent.MEMBER_WEB_PRESENCE_FETCH)
+  async handleMemberWebPresenceFetch(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() { guildId }: RequestMemberWebPresenceDto,
+  ): Promise<MemberWebPresenceFetchResponse> {
+    return this.presenceService.fetchMemberWebPresence(
+      this.server,
+      client,
+      guildId,
     );
   }
 

--- a/apps/gateway/src/gateway/services/presence.service.spec.ts
+++ b/apps/gateway/src/gateway/services/presence.service.spec.ts
@@ -32,6 +32,18 @@ const createPresenceSocket = (
     },
   }) as Socket;
 
+const createWebPresenceSocket = (
+  discordId: string,
+  sessionId: string,
+): Socket =>
+  ({
+    data: {
+      discordId,
+      platform: Platform.WEB_APP,
+      sessionId,
+    },
+  }) as Socket;
+
 const createViewerClient = (
   guildId: string,
   permissions: Permission[] = [Permission.LOOTLOG_ONLINE_PLAYERS_READ],
@@ -98,6 +110,58 @@ describe("PresenceService", () => {
   async function flushPromises() {
     return new Promise((resolve) => setImmediate(resolve));
   }
+
+  describe("fetchMemberWebPresence", () => {
+    it("returns active web sessions grouped by discord id", async () => {
+      const guildId = "guild-1";
+      const client = createViewerClient(guildId);
+      const gameSocket = {
+        data: {
+          discordId: "discord-game",
+          platform: Platform.GAME,
+          sessionId: "session-game",
+        },
+      };
+
+      mockFetchSockets.mockResolvedValue([
+        createWebPresenceSocket("discord-1", "session-1"),
+        createWebPresenceSocket("discord-1", "session-2"),
+        createWebPresenceSocket("discord-2", "session-3"),
+        gameSocket,
+      ]);
+
+      const result = await service.fetchMemberWebPresence(
+        mockServer as never,
+        client,
+        guildId,
+      );
+
+      expect(result).toEqual({
+        status: "success",
+        sessions: {
+          "discord-1": [{ sessionId: "session-1" }, { sessionId: "session-2" }],
+          "discord-2": [{ sessionId: "session-3" }],
+        },
+      });
+    });
+
+    it("returns forbidden when viewer cannot access online players", async () => {
+      const guildId = "guild-1";
+      const client = createViewerClient(guildId, []);
+
+      const result = await service.fetchMemberWebPresence(
+        mockServer as never,
+        client,
+        guildId,
+      );
+
+      expect(result).toEqual({
+        status: "forbidden",
+        code: "ONLINE_PLAYERS_ACCESS_DENIED",
+      });
+      expect(mockServer.in).not.toHaveBeenCalled();
+    });
+  });
 
   describe("fetchEventPresence", () => {
     it("returns all guild presence when world is not provided", async () => {

--- a/apps/gateway/src/gateway/services/presence.service.ts
+++ b/apps/gateway/src/gateway/services/presence.service.ts
@@ -31,10 +31,23 @@ export type PresenceFetchResponse<TPlayers> =
       status: "success";
       players: TPlayers;
     }
+  | OnlinePlayersForbiddenResponse;
+
+type OnlinePlayersForbiddenResponse = {
+  status: "forbidden";
+  code: typeof ONLINE_PLAYERS_ACCESS_DENIED_CODE;
+};
+
+export type MemberWebPresenceSession = {
+  sessionId: string;
+};
+
+export type MemberWebPresenceFetchResponse =
   | {
-      status: "forbidden";
-      code: typeof ONLINE_PLAYERS_ACCESS_DENIED_CODE;
-    };
+      status: "success";
+      sessions: Record<string, MemberWebPresenceSession[]>;
+    }
+  | OnlinePlayersForbiddenResponse;
 
 type FetchedSocket = Awaited<ReturnType<Server["fetchSockets"]>>[number];
 
@@ -147,6 +160,39 @@ export class PresenceService {
         excludeSourceSocket: true,
       });
     }
+  }
+
+  emitMemberWebPresenceUpdate(
+    server: Server,
+    client: Socket,
+    status: UserPresenceStatus,
+  ): void {
+    if (client.data.platform !== Platform.WEB_APP) {
+      return;
+    }
+
+    const { discordId, sessionId } = client.data;
+    if (!discordId || !sessionId) {
+      return;
+    }
+
+    client.rooms.forEach((room) => {
+      const parsed = parseRoomName(room);
+      if (!parsed || parsed.feature !== "presence") return;
+
+      this.emitPresenceToOnlinePlayersRoom({
+        server,
+        sourceClient: client,
+        guildId: parsed.guildId,
+        event: GatewayEvent.MEMBER_WEB_PRESENCE_UPDATE,
+        payload: {
+          guildId: parsed.guildId,
+          discordId,
+          sessionId,
+          status,
+        },
+      });
+    });
   }
 
   async broadcastPlayerDisconnect(
@@ -340,6 +386,52 @@ export class PresenceService {
     };
   }
 
+  async fetchMemberWebPresence(
+    server: Server,
+    client: Socket,
+    guildId: string,
+  ): Promise<MemberWebPresenceFetchResponse> {
+    const presenceRoom = buildRoomName(guildId, "presence");
+    const onlinePlayersRoom = buildRoomName(guildId, "online-players");
+
+    if (
+      !client.rooms.has(presenceRoom) ||
+      !client.rooms.has(onlinePlayersRoom)
+    ) {
+      return this.createOnlinePlayersForbiddenResponse();
+    }
+
+    const viewerGuildData = this.getSocketGuildData(client, guildId);
+    if (!this.canViewOnlinePlayers(client, viewerGuildData)) {
+      return this.createOnlinePlayersForbiddenResponse();
+    }
+
+    const socketsInRoom = await this.fetchSocketsSafely(
+      () => server.in(presenceRoom).fetchSockets(),
+      `member web presence room ${presenceRoom}`,
+    );
+    const sessions: Record<string, MemberWebPresenceSession[]> = {};
+
+    for (const socket of socketsInRoom) {
+      if (socket.data.platform !== Platform.WEB_APP) {
+        continue;
+      }
+
+      const { discordId, sessionId } = socket.data;
+      if (!discordId || !sessionId) {
+        continue;
+      }
+
+      sessions[discordId] ??= [];
+      sessions[discordId].push({ sessionId });
+    }
+
+    return {
+      status: "success",
+      sessions,
+    };
+  }
+
   async fetchOnlinePlayersPresence(
     server: Server,
     client: Socket,
@@ -474,7 +566,7 @@ export class PresenceService {
     }
   }
 
-  private createOnlinePlayersForbiddenResponse(): PresenceFetchResponse<never> {
+  private createOnlinePlayersForbiddenResponse(): OnlinePlayersForbiddenResponse {
     return {
       status: "forbidden",
       code: ONLINE_PLAYERS_ACCESS_DENIED_CODE,

--- a/apps/gateway/src/gateway/services/subscription.service.spec.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.spec.ts
@@ -5,6 +5,7 @@ import { Platform } from "../enums/platform.enum";
 import { ResponseStatus } from "../enums/response-status.enum";
 import { ErrorMessages } from "../constants/error-messages.constant";
 import { ActivityType } from "../enums/activity-type.enum";
+import { UserPresenceStatus } from "../enums/user-presence-status.enum";
 import { buildRoomName } from "../utils/room-utils";
 import type { MargonemAccountProofDto } from "../dto/join-gateway.dto";
 import type { SocketUserPlayer } from "../types/socket-user.type";
@@ -113,6 +114,7 @@ describe("SubscriptionService", () => {
   const mockPresenceService = {
     emitPresenceToRooms: vi.fn(),
     emitInitialPresence: vi.fn(),
+    emitMemberWebPresenceUpdate: vi.fn(),
   };
 
   const mockActivityService = {
@@ -387,6 +389,43 @@ describe("SubscriptionService", () => {
       "discord-owner",
       ["guild-1"],
     );
+  });
+
+  it("emits live web presence when a web client joins", async () => {
+    const guilds = [
+      createGuild({
+        discordId: "discord-1",
+        permissions: [Permission.LOOTLOG_ONLINE_PLAYERS_READ],
+      }),
+    ];
+    const client = {
+      id: "socket-1",
+      data: {
+        discordId: "discord-1",
+        sessionId: "socket-1",
+        userId: "user-1",
+        platform: Platform.WEB_APP,
+      },
+      join: vi.fn(),
+      request: { headers: { "user-agent": "Vitest" } },
+    };
+
+    mockGuildsService.getUserGuilds.mockResolvedValue(guilds);
+
+    const result = await service.handleJoin(
+      mockServer as never,
+      client as never,
+      "discord-1",
+      "user-1",
+      undefined,
+    );
+
+    expect(result.status).toBe(ResponseStatus.SUCCESS);
+    expect(client.join).toHaveBeenCalledWith(result.featureRooms);
+    expect(
+      mockPresenceService.emitMemberWebPresenceUpdate,
+    ).toHaveBeenCalledWith(mockServer, client, UserPresenceStatus.ONLINE);
+    expect(mockPresenceService.emitInitialPresence).not.toHaveBeenCalled();
   });
 
   it("does not treat LOOTLOG_MANAGE as an admin bypass", async () => {

--- a/apps/gateway/src/gateway/services/subscription.service.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.ts
@@ -11,6 +11,7 @@ import { GuildsService } from "src/guilds/guilds.service";
 import { PresenceService } from "./presence.service";
 import { ActivityService } from "./activity.service";
 import { ActivityType } from "src/gateway/enums/activity-type.enum";
+import { UserPresenceStatus } from "src/gateway/enums/user-presence-status.enum";
 import type { MargonemAccountProofDto } from "src/gateway/dto/join-gateway.dto";
 import type {
   Socket,
@@ -105,6 +106,11 @@ export class SubscriptionService {
         client,
         user,
         GatewayEvent.ONLINE_PLAYERS_PRESENCE_UPDATE,
+      );
+      this.presenceService.emitMemberWebPresenceUpdate(
+        server,
+        client,
+        UserPresenceStatus.ONLINE,
       );
 
       await this.activityService.publishActivityEvent(

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@rolldown/plugin-babel": "^0.2.3",
     "@tanstack/router-plugin": "^1.168.18",
+    "@testing-library/react": "^16.3.2",
     "@types/lodash": "^4.17.24",
     "@types/node": "^25.6.0",
     "@types/qs": "^6.15.0",
@@ -73,6 +74,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "happy-dom": "^20.10.3",
     "typescript": "~6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"

--- a/apps/web/src/config/gateway.ts
+++ b/apps/web/src/config/gateway.ts
@@ -15,6 +15,8 @@ export enum GatewayEvent {
   LOOTS_SHARE_UPDATE = "loots-share-update",
   ONLINE_PLAYERS_PRESENCE_FETCH = "online-players:presence:fetch",
   ONLINE_PLAYERS_PRESENCE_UPDATE = "online-players:presence:update",
+  MEMBER_WEB_PRESENCE_FETCH = "member-web-presence:fetch",
+  MEMBER_WEB_PRESENCE_UPDATE = "member-web-presence:update",
   TIMERS_CREATE = "timers-create",
   TIMERS_DELETE = "timers-delete",
   RESERVATIONS_CREATE = "reservations-create",

--- a/apps/web/src/features/guild/settings/members/components/member-data.tsx
+++ b/apps/web/src/features/guild/settings/members/components/member-data.tsx
@@ -7,7 +7,6 @@ import { cn } from "@lootlog/ui/lib/utils";
 import { PERMISSION_CATEGORIES } from "@/features/guild/settings/roles/constants/permission-categories";
 import { Badge } from "@lootlog/ui/components/badge";
 import { Card } from "@lootlog/ui/components/card";
-import { isMemberOnlineOnWeb } from "@/features/guild/settings/members/member-activity-stats.utils";
 import { format } from "date-fns";
 import {
   Activity,
@@ -31,6 +30,7 @@ export type MemberDataProps = {
   member: GuildMember;
   webActivityStats?: MemberActivityStats;
   gameActivityStats?: MemberActivityStats;
+  isOnlineOnWeb?: boolean;
   isOnlineInGame?: boolean;
 };
 
@@ -82,10 +82,10 @@ export const MemberData = ({
   member,
   webActivityStats,
   gameActivityStats,
+  isOnlineOnWeb = false,
   isOnlineInGame = false,
 }: MemberDataProps) => {
   const { t } = useTranslation();
-  const isOnlineOnWeb = isMemberOnlineOnWeb(webActivityStats);
   const isOnline = isOnlineOnWeb || isOnlineInGame;
   const accessState = getMemberAccessState({ member, isOnline });
   const hasProblem = isMemberProblematic(member);

--- a/apps/web/src/features/guild/settings/members/member-activity-stats.utils.spec.ts
+++ b/apps/web/src/features/guild/settings/members/member-activity-stats.utils.spec.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  isMemberOnlineOnWeb,
   mapMemberActivityStatsByDiscordIdAndSource,
   mapMemberActivityStatsByDiscordId,
 } from "./member-activity-stats.utils";
@@ -47,18 +46,5 @@ describe("member activity stats utils", () => {
 
     expect(mapped.get("discord-1")?.WEB_APP?.visitCount).toBe(2);
     expect(mapped.get("discord-1")?.GAME?.visitCount).toBe(7);
-  });
-
-  it("detects online web sessions", () => {
-    expect(isMemberOnlineOnWeb(buildStats({ activeSessionCount: 1 }))).toBe(
-      true,
-    );
-    expect(isMemberOnlineOnWeb(buildStats({ activeSessionCount: 0 }))).toBe(
-      false,
-    );
-  });
-
-  it("treats missing stats as offline", () => {
-    expect(isMemberOnlineOnWeb(undefined)).toBe(false);
   });
 });

--- a/apps/web/src/features/guild/settings/members/member-activity-stats.utils.ts
+++ b/apps/web/src/features/guild/settings/members/member-activity-stats.utils.ts
@@ -32,6 +32,3 @@ export const mapMemberActivityStatsByDiscordId = (
 
   return statsByDiscordId;
 };
-
-export const isMemberOnlineOnWeb = (stats: MemberActivityStats | undefined) =>
-  (stats?.activeSessionCount ?? 0) > 0;

--- a/apps/web/src/features/guild/settings/members/member-game-presence.utils.spec.ts
+++ b/apps/web/src/features/guild/settings/members/member-game-presence.utils.spec.ts
@@ -8,8 +8,8 @@ import {
   mapMemberGamePresenceByDiscordId,
   resolveMemberPresenceGuildId,
 } from "./member-game-presence.utils";
+import { mapMemberWebPresenceByDiscordId } from "./member-web-presence.utils";
 import type { PlayerPresence } from "@/features/guild/events/hooks/socket/use-event-presence";
-import type { MemberActivityStats } from "./member-activity-stats-api";
 
 const buildPresence = (overrides: Partial<PlayerPresence>): PlayerPresence => ({
   world: "alpha",
@@ -22,20 +22,6 @@ const buildPresence = (overrides: Partial<PlayerPresence>): PlayerPresence => ({
   isAfk: false,
   updatedAt: 1,
   sessionId: "session-1",
-  ...overrides,
-});
-
-const buildStats = (
-  overrides: Partial<MemberActivityStats>,
-): MemberActivityStats => ({
-  guildId: "guild-1",
-  discordId: "discord-1",
-  source: "WEB_APP",
-  lastSeenAt: "2026-01-01T00:00:00.000Z",
-  visitCount: 1,
-  activeSessionCount: 0,
-  createdAt: "2026-01-01T00:00:00.000Z",
-  updatedAt: "2026-01-01T00:00:00.000Z",
   ...overrides,
 });
 
@@ -133,35 +119,38 @@ describe("member game presence utils", () => {
   });
 
   it("combines web and game online sources", () => {
-    const mapped = mapMemberGamePresenceByDiscordId({
+    const gamePresence = mapMemberGamePresenceByDiscordId({
       "discord-1": [buildPresence({ sessionId: "session-1" })],
+    });
+    const webPresence = mapMemberWebPresenceByDiscordId({
+      "discord-1": [{ sessionId: "web-session-1" }],
     });
 
     expect(
       getMemberOnlineSources({
-        activityStats: undefined,
+        webPresenceByDiscordId: undefined,
         gamePresenceByDiscordId: undefined,
         discordId: "discord-1",
       }),
     ).toEqual({ web: false, game: false, online: false });
     expect(
       getMemberOnlineSources({
-        activityStats: buildStats({ activeSessionCount: 1 }),
+        webPresenceByDiscordId: webPresence,
         gamePresenceByDiscordId: undefined,
         discordId: "discord-1",
       }),
     ).toEqual({ web: true, game: false, online: true });
     expect(
       getMemberOnlineSources({
-        activityStats: buildStats({ activeSessionCount: 0 }),
-        gamePresenceByDiscordId: mapped,
+        webPresenceByDiscordId: undefined,
+        gamePresenceByDiscordId: gamePresence,
         discordId: "discord-1",
       }),
     ).toEqual({ web: false, game: true, online: true });
     expect(
       getMemberOnlineSources({
-        activityStats: buildStats({ activeSessionCount: 1 }),
-        gamePresenceByDiscordId: mapped,
+        webPresenceByDiscordId: webPresence,
+        gamePresenceByDiscordId: gamePresence,
         discordId: "discord-1",
       }),
     ).toEqual({ web: true, game: true, online: true });

--- a/apps/web/src/features/guild/settings/members/member-game-presence.utils.ts
+++ b/apps/web/src/features/guild/settings/members/member-game-presence.utils.ts
@@ -1,5 +1,8 @@
 import type { PlayerPresence } from "@/features/guild/events/hooks/socket/use-event-presence";
-import type { MemberActivityStats } from "@/features/guild/settings/members/member-activity-stats-api";
+import {
+  isMemberOnlineOnWeb,
+  type MemberWebPresenceByDiscordId,
+} from "@/features/guild/settings/members/member-web-presence.utils";
 
 export type MemberGamePresenceByDiscordId = Map<string, PlayerPresence[]>;
 export type MemberGamePresenceGuild = {
@@ -95,15 +98,15 @@ export const getMemberGameSessionCount = (
 ) => presenceByDiscordId?.get(discordId)?.length ?? 0;
 
 export const getMemberOnlineSources = ({
-  activityStats,
+  webPresenceByDiscordId,
   gamePresenceByDiscordId,
   discordId,
 }: {
-  activityStats?: MemberActivityStats;
+  webPresenceByDiscordId?: MemberWebPresenceByDiscordId;
   gamePresenceByDiscordId?: MemberGamePresenceByDiscordId;
   discordId: string;
 }) => {
-  const web = (activityStats?.activeSessionCount ?? 0) > 0;
+  const web = isMemberOnlineOnWeb(webPresenceByDiscordId, discordId);
   const game = isMemberOnlineInGame(gamePresenceByDiscordId, discordId);
 
   return {

--- a/apps/web/src/features/guild/settings/members/member-settings-detail-page.tsx
+++ b/apps/web/src/features/guild/settings/members/member-settings-detail-page.tsx
@@ -19,7 +19,9 @@ import {
   isMemberOnlineInGame,
   resolveMemberPresenceGuildId,
 } from "@/features/guild/settings/members/member-game-presence.utils";
+import { isMemberOnlineOnWeb } from "@/features/guild/settings/members/member-web-presence.utils";
 import { useMemberGamePresence } from "@/features/guild/settings/members/use-member-game-presence";
+import { useMemberWebPresence } from "@/features/guild/settings/members/use-member-web-presence";
 import { MemberData } from "@/features/guild/settings/members/components/member-data";
 import { RefreshStatusProvider } from "@/features/guild/settings/members/contexts/refresh-status-context";
 import { MemberSyncButton } from "@/features/guild/settings/members/components/member-sync-button";
@@ -45,6 +47,7 @@ const MemberSettingsDetailPageContent = () => {
     memberActivityStatsQueryOptions(resolvedGuildId),
   );
   const memberGamePresenceByDiscordId = useMemberGamePresence(resolvedGuildId);
+  const memberWebPresenceByDiscordId = useMemberWebPresence(resolvedGuildId);
   const memberActivityStatsByDiscordIdAndSource = useMemo(
     () => mapMemberActivityStatsByDiscordIdAndSource(memberActivityStats),
     [memberActivityStats],
@@ -170,6 +173,10 @@ const MemberSettingsDetailPageContent = () => {
             }
             isOnlineInGame={isMemberOnlineInGame(
               memberGamePresenceByDiscordId,
+              member.userId,
+            )}
+            isOnlineOnWeb={isMemberOnlineOnWeb(
+              memberWebPresenceByDiscordId,
               member.userId,
             )}
           />

--- a/apps/web/src/features/guild/settings/members/member-web-presence.utils.spec.ts
+++ b/apps/web/src/features/guild/settings/members/member-web-presence.utils.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMemberWebPresenceUpdate,
+  getMemberWebSessionCount,
+  isMemberOnlineOnWeb,
+  mapMemberWebPresenceByDiscordId,
+} from "./member-web-presence.utils";
+
+describe("member web presence utils", () => {
+  it("maps web sessions by Discord ID and skips empty entries", () => {
+    const mapped = mapMemberWebPresenceByDiscordId({
+      "discord-1": [{ sessionId: "session-1" }, { sessionId: "session-2" }],
+      "discord-2": [],
+    });
+
+    expect(mapped.get("discord-1")).toEqual(
+      new Set(["session-1", "session-2"]),
+    );
+    expect(mapped.has("discord-2")).toBe(false);
+  });
+
+  it("adds and removes web presence sessions from live updates", () => {
+    const added = applyMemberWebPresenceUpdate(undefined, {
+      guildId: "guild-1",
+      discordId: "discord-1",
+      sessionId: "session-1",
+      status: "online",
+    });
+    const updated = applyMemberWebPresenceUpdate(added, {
+      guildId: "guild-1",
+      discordId: "discord-1",
+      sessionId: "session-1",
+      status: "offline",
+    });
+
+    expect(isMemberOnlineOnWeb(added, "discord-1")).toBe(true);
+    expect(isMemberOnlineOnWeb(updated, "discord-1")).toBe(false);
+  });
+
+  it("counts active web sessions from live presence", () => {
+    const mapped = mapMemberWebPresenceByDiscordId({
+      "discord-1": [{ sessionId: "session-1" }, { sessionId: "session-2" }],
+    });
+
+    expect(getMemberWebSessionCount(mapped, "discord-1")).toBe(2);
+    expect(getMemberWebSessionCount(mapped, "discord-2")).toBe(0);
+  });
+});

--- a/apps/web/src/features/guild/settings/members/member-web-presence.utils.ts
+++ b/apps/web/src/features/guild/settings/members/member-web-presence.utils.ts
@@ -1,0 +1,76 @@
+export type MemberWebPresenceSession = {
+  sessionId: string;
+};
+
+export type MemberWebPresenceByDiscordId = Map<string, Set<string>>;
+
+export type MemberWebPresenceUpdatePayload = {
+  guildId: string;
+  discordId: string;
+  sessionId?: string;
+  status: "online" | "offline";
+};
+
+export const mapMemberWebPresenceByDiscordId = (
+  sessions: Record<string, MemberWebPresenceSession[]> | undefined,
+): MemberWebPresenceByDiscordId => {
+  const presenceByDiscordId: MemberWebPresenceByDiscordId = new Map();
+
+  for (const [discordId, memberSessions] of Object.entries(sessions ?? {})) {
+    const sessionIds = memberSessions
+      .map((session) => session.sessionId)
+      .filter((sessionId) => sessionId.length > 0);
+
+    if (sessionIds.length > 0) {
+      presenceByDiscordId.set(discordId, new Set(sessionIds));
+    }
+  }
+
+  return presenceByDiscordId;
+};
+
+export const applyMemberWebPresenceUpdate = (
+  presenceByDiscordId: MemberWebPresenceByDiscordId | undefined,
+  payload: MemberWebPresenceUpdatePayload,
+): MemberWebPresenceByDiscordId => {
+  const nextPresenceByDiscordId = new Map(presenceByDiscordId ?? []);
+  const { discordId, sessionId, status } = payload;
+
+  if (!sessionId) {
+    return nextPresenceByDiscordId;
+  }
+
+  if (status === "offline") {
+    const existingSessions = nextPresenceByDiscordId.get(discordId);
+    if (!existingSessions) {
+      return nextPresenceByDiscordId;
+    }
+
+    const nextSessions = new Set(existingSessions);
+    nextSessions.delete(sessionId);
+
+    if (nextSessions.size === 0) {
+      nextPresenceByDiscordId.delete(discordId);
+    } else {
+      nextPresenceByDiscordId.set(discordId, nextSessions);
+    }
+
+    return nextPresenceByDiscordId;
+  }
+
+  const nextSessions = new Set(nextPresenceByDiscordId.get(discordId) ?? []);
+  nextSessions.add(sessionId);
+  nextPresenceByDiscordId.set(discordId, nextSessions);
+
+  return nextPresenceByDiscordId;
+};
+
+export const isMemberOnlineOnWeb = (
+  presenceByDiscordId: MemberWebPresenceByDiscordId | undefined,
+  discordId: string,
+) => (presenceByDiscordId?.get(discordId)?.size ?? 0) > 0;
+
+export const getMemberWebSessionCount = (
+  presenceByDiscordId: MemberWebPresenceByDiscordId | undefined,
+  discordId: string,
+) => presenceByDiscordId?.get(discordId)?.size ?? 0;

--- a/apps/web/src/features/guild/settings/members/members-settings-content.tsx
+++ b/apps/web/src/features/guild/settings/members/members-settings-content.tsx
@@ -6,14 +6,12 @@ import {
   statusFilters,
 } from "@/features/guild/settings/members/members.constants";
 import { memberActivityStatsQueryOptions } from "@/features/guild/settings/members/member-activity-stats-api";
-import {
-  isMemberOnlineOnWeb,
-  mapMemberActivityStatsByDiscordIdAndSource,
-} from "@/features/guild/settings/members/member-activity-stats.utils";
+import { mapMemberActivityStatsByDiscordIdAndSource } from "@/features/guild/settings/members/member-activity-stats.utils";
 import {
   isMemberOnlineInGame,
   resolveMemberPresenceGuildId,
 } from "@/features/guild/settings/members/member-game-presence.utils";
+import { isMemberOnlineOnWeb } from "@/features/guild/settings/members/member-web-presence.utils";
 import {
   compareMemberListSortValues,
   isMemberProblematic,
@@ -22,6 +20,7 @@ import {
   type MemberStatusFilter,
 } from "@/features/guild/settings/members/member-list-item.utils";
 import { useMemberGamePresence } from "@/features/guild/settings/members/use-member-game-presence";
+import { useMemberWebPresence } from "@/features/guild/settings/members/use-member-web-presence";
 import { useGuildPermissions } from "@/hooks/api/use-guild-permissions";
 import { useGuildId } from "@/hooks/context/use-guild-id";
 import { useGuildsControllerGetGuildById } from "@/lib/api/generated/main/guilds/guilds";
@@ -67,6 +66,7 @@ export const MembersSettingsContent = () => {
     memberActivityStatsQueryOptions(resolvedGuildId),
   );
   const memberGamePresenceByDiscordId = useMemberGamePresence(resolvedGuildId);
+  const memberWebPresenceByDiscordId = useMemberWebPresence(resolvedGuildId);
   const memberActivityStatsByDiscordIdAndSource = useMemo(
     () => mapMemberActivityStatsByDiscordIdAndSource(memberActivityStats),
     [memberActivityStats],
@@ -96,11 +96,8 @@ export const MembersSettingsContent = () => {
     };
 
     for (const member of members ?? []) {
-      const activityStats = memberActivityStatsByDiscordIdAndSource.get(
-        member.userId,
-      )?.WEB_APP;
       const isOnline =
-        isMemberOnlineOnWeb(activityStats) ||
+        isMemberOnlineOnWeb(memberWebPresenceByDiscordId, member.userId) ||
         isMemberOnlineInGame(memberGamePresenceByDiscordId, member.userId);
 
       stats.totalMembers += 1;
@@ -120,11 +117,7 @@ export const MembersSettingsContent = () => {
     }
 
     return stats;
-  }, [
-    memberActivityStatsByDiscordIdAndSource,
-    memberGamePresenceByDiscordId,
-    members,
-  ]);
+  }, [memberGamePresenceByDiscordId, memberWebPresenceByDiscordId, members]);
 
   const filteredMembers = useMemo(() => {
     if (!members) return [];
@@ -143,11 +136,8 @@ export const MembersSettingsContent = () => {
       return highestRolePosition;
     };
     const filtered = members.filter((member) => {
-      const activityStats = memberActivityStatsByDiscordIdAndSource.get(
-        member.userId,
-      )?.WEB_APP;
       const isOnline =
-        isMemberOnlineOnWeb(activityStats) ||
+        isMemberOnlineOnWeb(memberWebPresenceByDiscordId, member.userId) ||
         isMemberOnlineInGame(memberGamePresenceByDiscordId, member.userId);
 
       return (
@@ -174,8 +164,8 @@ export const MembersSettingsContent = () => {
     );
   }, [
     guildRolePositionById,
-    memberActivityStatsByDiscordIdAndSource,
     memberGamePresenceByDiscordId,
+    memberWebPresenceByDiscordId,
     members,
     searchValue,
     statusFilter,
@@ -241,6 +231,7 @@ export const MembersSettingsContent = () => {
                     memberGamePresenceByDiscordId={
                       memberGamePresenceByDiscordId
                     }
+                    memberWebPresenceByDiscordId={memberWebPresenceByDiscordId}
                     guildId={routeGuildId ?? ""}
                   />
                 )}

--- a/apps/web/src/features/guild/settings/members/members-table.tsx
+++ b/apps/web/src/features/guild/settings/members/members-table.tsx
@@ -2,14 +2,15 @@ import { PermissionCategoryTooltip } from "@/features/guild/settings/components/
 import { MemberDeactivationButton } from "@/features/guild/settings/members/components/member-deactivation-button";
 import { MemberDiscordSyncIndicator } from "@/features/guild/settings/members/components/member-discord-sync-indicator";
 import { MemberSyncButton } from "@/features/guild/settings/members/components/member-sync-button";
-import {
-  isMemberOnlineOnWeb,
-  type MemberActivityStatsByDiscordId,
-} from "@/features/guild/settings/members/member-activity-stats.utils";
+import type { MemberActivityStatsByDiscordId } from "@/features/guild/settings/members/member-activity-stats.utils";
 import {
   isMemberGamePresenceVerified,
   isMemberOnlineInGame,
 } from "@/features/guild/settings/members/member-game-presence.utils";
+import {
+  isMemberOnlineOnWeb,
+  type MemberWebPresenceByDiscordId,
+} from "@/features/guild/settings/members/member-web-presence.utils";
 import { getMemberOnlineSources } from "@/features/guild/settings/members/member-list-item.utils";
 import { MemberStatusBadge } from "@/features/guild/settings/members/member-status-badge";
 import type { GuildMember } from "@/features/guild/settings/members/members.types";
@@ -64,6 +65,7 @@ type MembersTableProps = {
   isMobile: boolean;
   canManageMembers: boolean;
   memberGamePresenceByDiscordId: Parameters<typeof isMemberOnlineInGame>[0];
+  memberWebPresenceByDiscordId: MemberWebPresenceByDiscordId | undefined;
   guildId: string;
 };
 
@@ -75,6 +77,7 @@ export const MembersTable = ({
   isMobile,
   canManageMembers,
   memberGamePresenceByDiscordId,
+  memberWebPresenceByDiscordId,
   guildId,
 }: MembersTableProps) => {
   const { t } = useTranslation();
@@ -116,7 +119,10 @@ export const MembersTable = ({
           const gameActivityStats = activityStatsByDiscordIdAndSource.get(
             member.userId,
           )?.GAME;
-          const isOnlineOnWeb = isMemberOnlineOnWeb(webActivityStats);
+          const isOnlineOnWeb = isMemberOnlineOnWeb(
+            memberWebPresenceByDiscordId,
+            member.userId,
+          );
           const isOnlineInGame = isMemberOnlineInGame(
             memberGamePresenceByDiscordId,
             member.userId,
@@ -276,7 +282,10 @@ export const MembersTable = ({
           const gameActivityStats = activityStatsByDiscordIdAndSource.get(
             member.userId,
           )?.GAME;
-          const isOnlineOnWeb = isMemberOnlineOnWeb(webActivityStats);
+          const isOnlineOnWeb = isMemberOnlineOnWeb(
+            memberWebPresenceByDiscordId,
+            member.userId,
+          );
           const isOnlineInGame = isMemberOnlineInGame(
             memberGamePresenceByDiscordId,
             member.userId,

--- a/apps/web/src/features/guild/settings/members/use-member-game-presence.spec.tsx
+++ b/apps/web/src/features/guild/settings/members/use-member-game-presence.spec.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayEvent } from "@/config/gateway";
+import { isMemberOnlineInGame } from "./member-game-presence.utils";
+import { useMemberGamePresence } from "./use-member-game-presence";
+
+const mockUseGateway = vi.fn();
+
+vi.mock("@/hooks/utils/use-gateway", () => ({
+  useGateway: () => mockUseGateway(),
+}));
+
+describe("useMemberGamePresence", () => {
+  const eventHandlers: Record<string, (data: unknown) => void> = {};
+  const emitSpy = vi.fn();
+  const mockSocket = {
+    emit(
+      event: string,
+      payload: { guildId: string },
+      callback?: (response: unknown) => void,
+    ) {
+      emitSpy(event, payload, callback);
+    },
+    on: vi.fn((event: string, handler: (data: unknown) => void) => {
+      eventHandlers[event] = handler;
+    }),
+    off: vi.fn((event: string) => {
+      delete eventHandlers[event];
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    for (const eventName of Object.keys(eventHandlers)) {
+      delete eventHandlers[eventName];
+    }
+
+    mockUseGateway.mockReturnValue({
+      socket: mockSocket,
+      connected: true,
+      joined: true,
+    });
+  });
+
+  it("keeps current presence visible while a permissions refetch is pending", async () => {
+    let pendingCallback: ((response: unknown) => void) | undefined;
+
+    emitSpy
+      .mockImplementationOnce((_, __, callback) => {
+        callback?.({
+          status: "success",
+          players: {
+            "discord-1": [
+              {
+                world: "alpha",
+                name: "Hero",
+                characterId: "10",
+                accountId: "20",
+                icon: "hero.png",
+                lvl: "123",
+                prof: "w",
+                isAfk: false,
+                updatedAt: 100,
+                sessionId: "session-1",
+              },
+            ],
+          },
+        });
+      })
+      .mockImplementationOnce((_, __, callback) => {
+        pendingCallback = callback;
+      });
+
+    const { result } = renderHook(() => useMemberGamePresence("guild-1"));
+
+    await waitFor(() => {
+      expect(isMemberOnlineInGame(result.current, "discord-1")).toBe(true);
+    });
+
+    act(() => {
+      eventHandlers[GatewayEvent.PERMISSIONS_UPDATED]?.({});
+    });
+
+    expect(isMemberOnlineInGame(result.current, "discord-1")).toBe(true);
+
+    act(() => {
+      pendingCallback?.({
+        status: "forbidden",
+        code: "ONLINE_PLAYERS_ACCESS_DENIED",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/features/guild/settings/members/use-member-web-presence.spec.tsx
+++ b/apps/web/src/features/guild/settings/members/use-member-web-presence.spec.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayEvent } from "@/config/gateway";
+import { isMemberOnlineOnWeb } from "./member-web-presence.utils";
+import { useMemberWebPresence } from "./use-member-web-presence";
+
+const mockUseGateway = vi.fn();
+
+vi.mock("@/hooks/utils/use-gateway", () => ({
+  useGateway: () => mockUseGateway(),
+}));
+
+describe("useMemberWebPresence", () => {
+  const eventHandlers: Record<string, (data: unknown) => void> = {};
+  const emitSpy = vi.fn();
+  const mockSocket = {
+    emit(
+      event: string,
+      payload: { guildId: string },
+      callback?: (response: unknown) => void,
+    ) {
+      emitSpy(event, payload, callback);
+    },
+    on: vi.fn((event: string, handler: (data: unknown) => void) => {
+      eventHandlers[event] = handler;
+    }),
+    off: vi.fn((event: string) => {
+      delete eventHandlers[event];
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    for (const eventName of Object.keys(eventHandlers)) {
+      delete eventHandlers[eventName];
+    }
+
+    mockUseGateway.mockReturnValue({
+      socket: mockSocket,
+      connected: true,
+      joined: true,
+    });
+  });
+
+  it("fetches initial web presence from the gateway", async () => {
+    emitSpy.mockImplementation((_, __, callback) => {
+      callback?.({
+        status: "success",
+        sessions: {
+          "discord-1": [{ sessionId: "session-1" }],
+        },
+      });
+    });
+
+    const { result } = renderHook(() => useMemberWebPresence("guild-1"));
+
+    await waitFor(() => {
+      expect(isMemberOnlineOnWeb(result.current, "discord-1")).toBe(true);
+    });
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      GatewayEvent.MEMBER_WEB_PRESENCE_FETCH,
+      { guildId: "guild-1" },
+      expect.any(Function),
+    );
+  });
+
+  it("applies online and offline web presence updates", async () => {
+    emitSpy.mockImplementation((_, __, callback) => {
+      callback?.({
+        status: "success",
+        sessions: {},
+      });
+    });
+
+    const { result } = renderHook(() => useMemberWebPresence("guild-1"));
+
+    await waitFor(() => {
+      expect(result.current?.size).toBe(0);
+    });
+
+    act(() => {
+      eventHandlers[GatewayEvent.MEMBER_WEB_PRESENCE_UPDATE]?.({
+        guildId: "guild-1",
+        discordId: "discord-1",
+        sessionId: "session-1",
+        status: "online",
+      });
+    });
+
+    expect(isMemberOnlineOnWeb(result.current, "discord-1")).toBe(true);
+
+    act(() => {
+      eventHandlers[GatewayEvent.MEMBER_WEB_PRESENCE_UPDATE]?.({
+        guildId: "guild-1",
+        discordId: "discord-1",
+        sessionId: "session-1",
+        status: "offline",
+      });
+    });
+
+    expect(isMemberOnlineOnWeb(result.current, "discord-1")).toBe(false);
+  });
+});

--- a/apps/web/src/features/guild/settings/members/use-member-web-presence.ts
+++ b/apps/web/src/features/guild/settings/members/use-member-web-presence.ts
@@ -1,28 +1,28 @@
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { GatewayEvent } from "@/config/gateway";
 import { useGateway } from "@/hooks/utils/use-gateway";
-import type { PlayerPresence } from "@/features/guild/events/hooks/socket/use-event-presence";
 import {
-  applyMemberGamePresenceUpdate,
-  mapMemberGamePresenceByDiscordId,
-  type MemberGamePresenceByDiscordId,
-  type MemberGamePresenceUpdatePayload,
-} from "@/features/guild/settings/members/member-game-presence.utils";
+  applyMemberWebPresenceUpdate,
+  mapMemberWebPresenceByDiscordId,
+  type MemberWebPresenceByDiscordId,
+  type MemberWebPresenceSession,
+  type MemberWebPresenceUpdatePayload,
+} from "@/features/guild/settings/members/member-web-presence.utils";
 
-type MemberGamePresenceFetchPayload =
+type MemberWebPresenceFetchPayload =
   | {
       status: "success";
-      players: Record<string, PlayerPresence[]>;
+      sessions: Record<string, MemberWebPresenceSession[]>;
     }
   | {
       status: "forbidden";
       code: "ONLINE_PLAYERS_ACCESS_DENIED";
     };
 
-export const useMemberGamePresence = (guildId: string | undefined) => {
+export const useMemberWebPresence = (guildId: string | undefined) => {
   const { socket, connected, joined } = useGateway();
   const [presenceByDiscordId, setPresenceByDiscordId] = useState<
-    MemberGamePresenceByDiscordId | undefined
+    MemberWebPresenceByDiscordId | undefined
   >(undefined);
   const [refreshVersion, setRefreshVersion] = useState(0);
   const requestIdRef = useRef(0);
@@ -34,9 +34,9 @@ export const useMemberGamePresence = (guildId: string | undefined) => {
     const requestId = ++requestIdRef.current;
 
     socket.emit(
-      GatewayEvent.EVENT_PRESENCE_FETCH,
+      GatewayEvent.MEMBER_WEB_PRESENCE_FETCH,
       { guildId },
-      (response?: MemberGamePresenceFetchPayload) => {
+      (response?: MemberWebPresenceFetchPayload) => {
         if (requestIdRef.current !== requestId || !response) return;
 
         if (response.status === "forbidden") {
@@ -45,18 +45,18 @@ export const useMemberGamePresence = (guildId: string | undefined) => {
         }
 
         setPresenceByDiscordId(
-          mapMemberGamePresenceByDiscordId(response.players),
+          mapMemberWebPresenceByDiscordId(response.sessions),
         );
       },
     );
   });
 
   const handlePresenceUpdate = useEffectEvent(
-    (payload: MemberGamePresenceUpdatePayload) => {
+    (payload: MemberWebPresenceUpdatePayload) => {
       if (payload.guildId !== guildId) return;
 
       setPresenceByDiscordId((currentPresenceByDiscordId) =>
-        applyMemberGamePresenceUpdate(currentPresenceByDiscordId, payload),
+        applyMemberWebPresenceUpdate(currentPresenceByDiscordId, payload),
       );
     },
   );
@@ -86,10 +86,10 @@ export const useMemberGamePresence = (guildId: string | undefined) => {
 
     requestPresence();
 
-    socket.on(GatewayEvent.EVENT_PRESENCE_UPDATE, handlePresenceUpdate);
+    socket.on(GatewayEvent.MEMBER_WEB_PRESENCE_UPDATE, handlePresenceUpdate);
 
     return () => {
-      socket.off(GatewayEvent.EVENT_PRESENCE_UPDATE, handlePresenceUpdate);
+      socket.off(GatewayEvent.MEMBER_WEB_PRESENCE_UPDATE, handlePresenceUpdate);
     };
   }, [socket, connected, joined, guildId, refreshVersion]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 7.7.0
       '@prisma/client':
         specifier: ^7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       axios:
         specifier: ^1.17.0
         version: 1.17.0
@@ -227,7 +227,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: 7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       axios:
         specifier: ^1.17.0
         version: 1.17.0
@@ -327,7 +327,7 @@ importers:
     dependencies:
       '@better-auth/drizzle-adapter':
         specifier: ^1.6.18
-        version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
+        version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
       '@better-auth/redis-storage':
         specifier: 1.6.18
         version: 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(ioredis@5.10.1)
@@ -357,13 +357,13 @@ importers:
         version: 11.4.4(@fastify/static@9.1.3)(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)
       better-auth:
         specifier: ^1.6.18
-        version: 1.6.18(df0e75ab93c07479697be824656bde2f)
+        version: 1.6.18(c2b8dc529298bb43ee07413ad5db29ee)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
@@ -782,7 +782,7 @@ importers:
         version: 5.99.2(@tanstack/react-query@5.99.2(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.6.18
-        version: 1.6.18(fd441e0228e25a5e7a2512523e1950f8)
+        version: 1.6.18(ca5bc9b5e34e2620b1a74d4a76b57822)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1109,7 +1109,7 @@ importers:
         version: 7.6.0
       '@prisma/client':
         specifier: 7.8.0
-        version: 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1313,6 +1313,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.168.18
         version: 1.168.18(@tanstack/react-router@1.168.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/lodash':
         specifier: ^4.17.24
         version: 4.17.24
@@ -1337,6 +1340,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.39.4(jiti@2.7.0))
+      happy-dom:
+        specifier: ^20.10.3
+        version: 20.10.3
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -11423,9 +11429,6 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
-  pg-protocol@1.13.0:
-    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
-
   pg-protocol@1.14.0:
     resolution: {integrity: sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==}
 
@@ -14020,12 +14023,12 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))':
+  '@better-auth/drizzle-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))':
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
     optionalDependencies:
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
 
   '@better-auth/kysely-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)':
     dependencies:
@@ -14046,12 +14049,12 @@ snapshots:
     optionalDependencies:
       mongodb: 7.1.0
 
-  '@better-auth/prisma-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))':
+  '@better-auth/prisma-adapter@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))':
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.1
     optionalDependencies:
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
 
   '@better-auth/redis-storage@1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(ioredis@5.10.1)':
@@ -15508,7 +15511,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -15966,7 +15969,7 @@ snapshots:
       '@grpc/proto-loader': 0.8.1
       '@nestjs/axios': 4.0.1(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.17.0)(rxjs@7.8.2)
       '@nestjs/microservices': 11.1.26(@grpc/grpc-js@1.14.4)(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/websockets@11.1.26)(amqp-connection-manager@5.0.0(amqplib@0.10.9))(amqplib@0.10.9)(cache-manager@7.2.8)(ioredis@5.10.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
 
   '@nestjs/testing@11.1.26(@nestjs/common@11.1.26(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.26)(@nestjs/microservices@11.1.26)(@nestjs/platform-express@11.1.26)':
     dependencies:
@@ -17180,7 +17183,7 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.8.0': {}
 
-  '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)':
+  '@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.8.0
     optionalDependencies:
@@ -18932,36 +18935,14 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@tanstack/react-start-rsc@0.1.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))':
+  '@tanstack/react-start-rsc@0.1.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-core': 1.171.13
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.12
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
-      '@tanstack/start-server-core': 1.169.14(crossws@0.4.5(srvx@0.11.16))
-      '@tanstack/start-storage-context': 1.167.15
-      pathe: 2.0.3
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - crossws
-      - supports-color
-      - vite
-      - vite-plugin-solid
-      - webpack
-    optional: true
-
-  '@tanstack/react-start-rsc@0.1.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))':
-    dependencies:
-      '@tanstack/react-router': 1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))
+      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.14(crossws@0.4.5(srvx@0.11.16))
       '@tanstack/start-storage-context': 1.167.15
       pathe: 2.0.3
@@ -19007,45 +18988,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))':
+  '@tanstack/react-start@1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-start-client': 1.168.13(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.1.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      '@tanstack/react-start-rsc': 0.1.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.167.19(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.169.14(crossws@0.4.5(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - crossws
-      - react-server-dom-rspack
-      - supports-color
-      - vite-plugin-solid
-      - webpack
-    optional: true
-
-  '@tanstack/react-start@1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))':
-    dependencies:
-      '@tanstack/react-router': 1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-client': 1.168.13(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-start-rsc': 0.1.24(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))
-      '@tanstack/react-start-server': 1.167.19(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))
-      '@tanstack/start-server-core': 1.169.14(crossws@0.4.5(srvx@0.11.16))
-      pathe: 2.0.3
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - crossws
@@ -19142,7 +19099,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))':
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -19156,26 +19113,6 @@ snapshots:
     optionalDependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))':
-    dependencies:
-      '@babel/core': 7.29.7
-      '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-utils': 1.162.2
-      chokidar: 5.0.0
-      unplugin: 3.0.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@tanstack/react-router': 1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
-      webpack: 5.106.2(@swc/core@1.15.30)(esbuild@0.28.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -19220,14 +19157,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))':
+  '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.13
       '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
+      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.14(crossws@0.4.5(srvx@0.11.16))
       exsolve: 1.0.8
@@ -19244,38 +19181,6 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@tanstack/react-router'
-      - crossws
-      - supports-color
-      - vite-plugin-solid
-      - webpack
-    optional: true
-
-  '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(crossws@0.4.5(srvx@0.11.16))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/core': 7.29.7
-      '@babel/types': 7.29.7
-      '@tanstack/router-core': 1.171.13
-      '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))
-      '@tanstack/router-utils': 1.162.2
-      '@tanstack/start-server-core': 1.169.14(crossws@0.4.5(srvx@0.11.16))
-      exsolve: 1.0.8
-      lightningcss: 1.32.0
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      seroval: 1.5.4
-      source-map: 0.7.6
-      srvx: 0.11.16
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      vitefu: 1.1.3(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      xmlbuilder2: 4.0.3
-      zod: 4.4.3
-    optionalDependencies:
-      vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
       - crossws
@@ -19372,7 +19277,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -19433,7 +19338,7 @@ snapshots:
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -19442,13 +19347,13 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/cookiejar@2.1.5': {}
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/d3-array@3.2.2': {}
 
@@ -19482,13 +19387,13 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/ssh2': 1.15.5
 
   '@types/eslint-scope@3.7.7':
@@ -19533,7 +19438,7 @@ snapshots:
 
   '@types/memcached@2.2.10':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/methods@1.1.4': {}
 
@@ -19549,7 +19454,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/node@12.20.55': {}
 
@@ -19567,7 +19472,7 @@ snapshots:
 
   '@types/oracledb@6.5.2':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -19575,14 +19480,14 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 25.6.0
-      pg-protocol: 1.13.0
+      '@types/node': 25.9.3
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
 
   '@types/qs@6.15.0': {}
@@ -19601,11 +19506,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.5':
@@ -19618,7 +19523,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       form-data: 4.0.6
 
   '@types/supertest@7.2.0':
@@ -19628,7 +19533,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/three@0.183.1':
     dependencies:
@@ -20233,14 +20138,14 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.6.18(d6a072e780113fcdfede0e28c030d377):
+  better-auth@1.6.18(c2b8dc529298bb43ee07413ad5db29ee):
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
+      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
       '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
       '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
       '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
       '@better-auth/telemetry': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)
       '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.3.0
@@ -20253,10 +20158,10 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.3.6
     optionalDependencies:
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       '@tanstack/react-start': 1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
       mongodb: 7.1.0
       mysql2: 3.15.3
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -20270,14 +20175,14 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.18(df0e75ab93c07479697be824656bde2f):
+  better-auth@1.6.18(ca5bc9b5e34e2620b1a74d4a76b57822):
     dependencies:
       '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
+      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
       '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
       '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
       '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
       '@better-auth/telemetry': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)
       '@better-auth/utils': 0.4.1
       '@better-fetch/fetch': 1.3.0
@@ -20290,47 +20195,10 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.3.6
     optionalDependencies:
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
-      '@tanstack/react-start': 1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(@swc/core@1.15.30)(esbuild@0.28.1))
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@tanstack/react-start': 1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
-      mongodb: 7.1.0
-      mysql2: 3.15.3
-      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      pg: 8.20.0
-      prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      solid-js: 1.9.12
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(jsdom@29.0.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.6.18(fd441e0228e25a5e7a2512523e1950f8):
-    dependencies:
-      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
-      '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
-      '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
-      '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
-      '@better-auth/telemetry': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)
-      '@better-auth/utils': 0.4.1
-      '@better-fetch/fetch': 1.3.0
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
-      better-call: 1.3.6(zod@4.3.6)
-      defu: 6.1.7
-      jose: 6.2.3
-      kysely: 0.29.2
-      nanostores: 1.3.0
-      zod: 4.3.6
-    optionalDependencies:
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
-      '@tanstack/react-start': 1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
-      drizzle-kit: 0.31.10
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
       mongodb: 7.1.0
       mysql2: 3.15.3
       next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -20340,6 +20208,43 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       solid-js: 1.9.12
       vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(jsdom@29.0.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-auth@1.6.18(d6a072e780113fcdfede0e28c030d377):
+    dependencies:
+      '@better-auth/core': 1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)))
+      '@better-auth/kysely-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(kysely@0.29.2)
+      '@better-auth/memory-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)
+      '@better-auth/mongo-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      '@better-auth/telemetry': 1.6.18(@better-auth/core@1.6.18(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.3.6))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.0)
+      '@better-auth/utils': 0.4.1
+      '@better-fetch/fetch': 1.3.0
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.6(zod@4.3.6)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.2
+      nanostores: 1.3.0
+      zod: 4.3.6
+    optionalDependencies:
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@tanstack/react-start': 1.168.25(crossws@0.4.5(srvx@0.11.16))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.28.1))
+      drizzle-kit: 0.31.10
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))
+      mongodb: 7.1.0
+      mysql2: 3.15.3
+      next: 16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      pg: 8.20.0
+      prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      solid-js: 1.9.12
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@20.10.3)(jsdom@29.0.1(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -21068,11 +20973,11 @@ snapshots:
       get-tsconfig: 4.14.0
       jiti: 2.7.0
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(kysely@0.29.2)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.1
       '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react@19.2.14)(magicast@0.5.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3))(typescript@6.0.3)
       '@types/pg': 8.20.0
       kysely: 0.29.2
       mysql2: 3.15.3
@@ -21157,7 +21062,7 @@ snapshots:
   engine.io@6.6.8:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -24026,8 +23931,6 @@ snapshots:
     dependencies:
       pg: 8.20.0
 
-  pg-protocol@1.13.0: {}
-
   pg-protocol@1.14.0: {}
 
   pg-types@2.2.0:
@@ -24042,7 +23945,7 @@ snapshots:
     dependencies:
       pg-connection-string: 2.12.0
       pg-pool: 3.13.0(pg@8.20.0)
-      pg-protocol: 1.13.0
+      pg-protocol: 1.14.0
       pg-types: 2.2.0
       pgpass: 1.0.5
     optionalDependencies:
@@ -25339,18 +25242,6 @@ snapshots:
       '@swc/core': 1.15.30
       esbuild: 0.28.1
 
-  terser-webpack-plugin@5.6.1(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.48.0
-      webpack: 5.106.2(esbuild@0.28.1)(postcss@8.5.15)
-    optionalDependencies:
-      esbuild: 0.28.1
-      postcss: 8.5.15
-    optional: true
-
   terser-webpack-plugin@5.6.1(esbuild@0.28.1)(webpack@5.106.2(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -26056,47 +25947,6 @@ snapshots:
       schema-utils: 4.3.3
       tapable: 2.3.3
       terser-webpack-plugin: 5.6.1(esbuild@0.28.1)(webpack@5.106.2(esbuild@0.28.1))
-      watchpack: 2.5.2
-      webpack-sources: 3.5.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-    optional: true
-
-  webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.2
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.0
-      es-module-lexer: 2.1.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(esbuild@0.28.1)(postcss@8.5.15)(webpack@5.106.2(esbuild@0.28.1)(postcss@8.5.15))
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Adds live member web presence in the gateway using active web sockets in the existing presence rooms.
- Uses live web presence, plus game presence, to drive members settings online badges, online counts, and the online filter.
- Keeps existing activity stats for historical visits and last-seen data only.
- Prevents same-scope permission refetches from clearing online player/member presence lists while the refetch is pending.

## Root Cause

Web online state in members settings was using asynchronous activity stats, so gateway connect/disconnect writes could race page load and show stale offline states. The flicker came from client hooks clearing presence before same-scope refetches resolved.

## Validation

- `pnpm -s --filter @lootlog/web exec vitest run src/features/guild/settings/members`
- `pnpm -s --filter @lootlog/game-client test -- --run use-players-presence.test.tsx online-players-list.test.tsx`
- `pnpm -s --filter @lootlog/gateway test -- --run presence.service.spec.ts gateway.spec.ts gateway.service.spec.ts subscription.service.spec.ts`
- `pnpm -s --filter @lootlog/web exec tsc -b --pretty false`
- `pnpm -s --filter @lootlog/web lint`
- `pnpm -s --filter @lootlog/gateway lint`
- Pre-commit checks passed during commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live web presence support for guild members, including online/offline updates and presence lookup for the settings experience.
  * Member lists and detail views now show web online status alongside in-game status.

* **Bug Fixes**
  * Improved presence refresh behavior so member lists no longer clear prematurely while permissions or refetches are still resolving.
  * Fixed web presence updates so disconnects and permission changes are reflected more reliably in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->