### PR TITLE
refactor(search): share query list parsing

### DIFF
--- a/apps/search/src/npcs/dto/get-npcs.dto.ts
+++ b/apps/search/src/npcs/dto/get-npcs.dto.ts
@@ -1,35 +1,18 @@
 import { createZodDto, type ZodDto } from "nestjs-zod";
+import {
+  parseCommaSeparatedQueryList,
+  parseSearchTermsQuery,
+} from "src/shared/query-list.utils";
 import { z } from "zod";
-
-function parseCommaSeparatedQuery(value: unknown) {
-  if (typeof value !== "string") {
-    return value;
-  }
-
-  return value
-    .split(",")
-    .map((searchTerm) => searchTerm.trim())
-    .filter(Boolean);
-}
 
 export const getNpcsQuerySchema = z.object({
   ids: z
-    .preprocess(parseCommaSeparatedQuery, z.array(z.coerce.number().int()))
+    .preprocess(parseCommaSeparatedQueryList, z.array(z.coerce.number().int()))
     .optional(),
   limit: z.coerce.number().optional().default(10),
   search: z
     .preprocess(
-      (value) => {
-        if (typeof value !== "string") {
-          return value;
-        }
-
-        if (!value.includes(",")) {
-          return value;
-        }
-
-        return parseCommaSeparatedQuery(value);
-      },
+      parseSearchTermsQuery,
       z.union([z.string(), z.array(z.string())]),
     )
     .optional(),

--- a/apps/search/src/players/dto/get-players.dto.ts
+++ b/apps/search/src/players/dto/get-players.dto.ts
@@ -1,25 +1,14 @@
 import { createZodDto, type ZodDto } from "nestjs-zod";
+import { parseSearchTermsQuery } from "src/shared/query-list.utils";
 import { z } from "zod";
-
-function parseSearchQuery(value: unknown) {
-  if (typeof value !== "string") {
-    return value;
-  }
-
-  if (!value.includes(",")) {
-    return value;
-  }
-
-  return value
-    .split(",")
-    .map((searchTerm) => searchTerm.trim())
-    .filter(Boolean);
-}
 
 export const getPlayersQuerySchema = z.object({
   limit: z.coerce.number().optional().default(10),
   search: z
-    .preprocess(parseSearchQuery, z.union([z.string(), z.array(z.string())]))
+    .preprocess(
+      parseSearchTermsQuery,
+      z.union([z.string(), z.array(z.string())]),
+    )
     .optional(),
   world: z.string().optional(),
 });

--- a/apps/search/src/shared/query-list.utils.spec.ts
+++ b/apps/search/src/shared/query-list.utils.spec.ts
@@ -1,0 +1,37 @@
+import {
+  parseCommaSeparatedQueryList,
+  parseSearchTermsQuery,
+} from "./query-list.utils";
+
+describe("query list utils", () => {
+  describe("parseCommaSeparatedQueryList", () => {
+    it("splits and trims comma-separated strings", () => {
+      expect(parseCommaSeparatedQueryList("1, 2,,3 ")).toEqual(["1", "2", "3"]);
+    });
+
+    it("preserves non-string values", () => {
+      expect(parseCommaSeparatedQueryList(["1", "2"])).toEqual(["1", "2"]);
+      expect(parseCommaSeparatedQueryList(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("parseSearchTermsQuery", () => {
+    it("keeps single search terms as strings", () => {
+      expect(parseSearchTermsQuery("tanroth")).toBe("tanroth");
+    });
+
+    it("splits comma-separated search terms", () => {
+      expect(parseSearchTermsQuery("Tanroth, Mushita,,")).toEqual([
+        "Tanroth",
+        "Mushita",
+      ]);
+    });
+
+    it("preserves non-string values", () => {
+      expect(parseSearchTermsQuery(["Tanroth", "Mushita"])).toEqual([
+        "Tanroth",
+        "Mushita",
+      ]);
+    });
+  });
+});

--- a/apps/search/src/shared/query-list.utils.ts
+++ b/apps/search/src/shared/query-list.utils.ts
@@ -1,0 +1,21 @@
+const splitCommaSeparatedQuery = (value: string) =>
+  value
+    .split(",")
+    .map((searchTerm) => searchTerm.trim())
+    .filter(Boolean);
+
+export function parseCommaSeparatedQueryList(value: unknown) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return splitCommaSeparatedQuery(value);
+}
+
+export function parseSearchTermsQuery(value: unknown) {
+  if (typeof value !== "string" || !value.includes(",")) {
+    return value;
+  }
+
+  return splitCommaSeparatedQuery(value);
+}


### PR DESCRIPTION
## Summary

- Extract shared query-list parsing helpers for search DTO preprocessing.
- Reuse the shared parser in NPC and player query DTOs while preserving existing behavior for single search strings and comma-separated lists.
- Add focused unit coverage for the shared parser helpers.

## Verification

- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --filter @lootlog/search test`
- `pnpm --filter @lootlog/search build`
- `pnpm format:check`
- `pnpm exec oxlint apps/search/src/shared/query-list.utils.ts apps/search/src/shared/query-list.utils.spec.ts apps/search/src/players/dto/get-players.dto.ts apps/search/src/npcs/dto/get-npcs.dto.ts`
- `pnpm lint-staged`
- `pnpm turbo run lint --filter='[HEAD]'`
- `pnpm turbo run format:check --filter='[HEAD]'`
- `pnpm turbo run test --filter='[HEAD]'`
- `pnpm turbo run build --filter='[HEAD]'`

Note: `pnpm turbo run lint --filter='[HEAD]'` and `pnpm turbo run format:check --filter='[HEAD]'` found no package-level tasks for `@lootlog/search`, matching the package scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of comma-separated NPC IDs and search terms.
  * Trims entries and removes empty values for more consistent search filtering.
  * Preserves existing behavior for single-term searches and array inputs.

* **Tests**
  * Added coverage for comma-separated lists, whitespace trimming, empty entries, arrays, and undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->