### PR TITLE
refactor(ui): use calendar date library formatter

### DIFF
--- a/packages/ui/src/components/calendar.tsx
+++ b/packages/ui/src/components/calendar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import * as React from "react";
-import { format } from "date-fns";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -10,6 +9,7 @@ import {
 import {
   type DayButton,
   DayPicker,
+  defaultDateLib,
   getDefaultClassNames,
 } from "react-day-picker";
 
@@ -41,9 +41,8 @@ function Calendar({
       )}
       captionLayout={captionLayout}
       formatters={{
-        formatMonthDropdown: (date) =>
-          // @ts-expect-error locale type mismatch
-          format(date, "LLLL", { locale: props.locale }),
+        formatMonthDropdown: (date, dateLib) =>
+          (dateLib ?? defaultDateLib).format(date, "LLLL"),
         ...formatters,
       }}
       classNames={{


### PR DESCRIPTION
## Summary

- Removed the direct `date-fns` formatter call from the shared UI calendar month dropdown formatter.
- Reused DayPicker's provided `DateLib` so locale-aware month formatting stays centralized and typed.
- Deleted the `@ts-expect-error` suppression that was hiding the partial-locale mismatch.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt packages/ui/src/components/calendar.tsx`
- `corepack pnpm exec tsc --noEmit -p packages/ui/tsconfig.json`
- `corepack pnpm turbo run lint --filter=@lootlog/ui`
- `corepack pnpm turbo run build --filter=@lootlog/web --filter=@lootlog/wiki --filter=@lootlog/landing --filter=@lootlog/developer`
- `corepack pnpm format:check`
- `git diff --check`
- `.husky/pre-commit`
- `git commit` hook

Notes: `@lootlog/ui` has no package-level `test` or `format:check` scripts, so the hook reported no tasks for those package-scoped phases. Existing warnings observed: `@lootlog/ui` `npc-tile.tsx` `no-img-element`, `/themes/rias-bg.png` unresolved at build time, third-party `lottie-web` direct `eval`, plugin timing, and cached module-type warnings.