### PR TITLE
refactor(api): simplify guild permission override delegation

### DIFF
--- a/apps/api/src/guilds/guilds-internal.controller.spec.ts
+++ b/apps/api/src/guilds/guilds-internal.controller.spec.ts
@@ -79,6 +79,7 @@ describe("GuildsInternalController", () => {
       expect(guildsService.getUserGuildsWithPermissions).toHaveBeenCalledWith(
         "discord-1",
         "user-1",
+        { devPermissionOverride: undefined },
       );
     });
   });

--- a/apps/api/src/guilds/guilds-internal.controller.ts
+++ b/apps/api/src/guilds/guilds-internal.controller.ts
@@ -46,17 +46,17 @@ export class GuildsInternalController {
       return Promise.resolve([]);
     }
 
-    const parsedDevPermissionOverride = parseDevPermissionOverrideHeader(
-      devPermissionOverride,
+    const guildPermissionOptions = {
+      devPermissionOverride: parseDevPermissionOverrideHeader(
+        devPermissionOverride,
+      ),
+    };
+
+    return this.guildsService.getUserGuildsWithPermissions(
+      discordId,
+      userId,
+      guildPermissionOptions,
     );
-
-    if (!parsedDevPermissionOverride) {
-      return this.guildsService.getUserGuildsWithPermissions(discordId, userId);
-    }
-
-    return this.guildsService.getUserGuildsWithPermissions(discordId, userId, {
-      devPermissionOverride: parsedDevPermissionOverride,
-    });
   }
 
   @Get(":idOrVanityUrl")

--- a/apps/api/src/guilds/guilds.controller.spec.ts
+++ b/apps/api/src/guilds/guilds.controller.spec.ts
@@ -61,6 +61,7 @@ describe("GuildsController", () => {
       "discord-user-current",
       "auth-user-current",
       "game",
+      { devPermissionOverride: undefined },
     );
   });
 
@@ -75,6 +76,7 @@ describe("GuildsController", () => {
     expect(mockGuildsService.getUserGuildsWithPermissions).toHaveBeenCalledWith(
       "discord-user-current",
       "auth-user-current",
+      { devPermissionOverride: undefined },
     );
   });
 });

--- a/apps/api/src/guilds/guilds.controller.ts
+++ b/apps/api/src/guilds/guilds.controller.ts
@@ -62,23 +62,24 @@ export class GuildsController {
     required: false,
     description: "Legacy source selector kept for backward compatibility",
   })
-  async getUserGuilds(
+  getUserGuilds(
     @DiscordId() discordId: string,
     @UserId() userId: string,
     @Query("source") source?: string,
     @Headers(DEV_PERMISSION_OVERRIDE_HEADER) devPermissionOverride?: string,
   ) {
-    const parsedDevPermissionOverride = parseDevPermissionOverrideHeader(
-      devPermissionOverride,
+    const guildPermissionOptions = {
+      devPermissionOverride: parseDevPermissionOverrideHeader(
+        devPermissionOverride,
+      ),
+    };
+
+    return this.guildsService.getUserGuilds(
+      discordId,
+      userId,
+      source,
+      guildPermissionOptions,
     );
-
-    if (!parsedDevPermissionOverride) {
-      return this.guildsService.getUserGuilds(discordId, userId, source);
-    }
-
-    return this.guildsService.getUserGuilds(discordId, userId, source, {
-      devPermissionOverride: parsedDevPermissionOverride,
-    });
   }
 
   @Get("/@me/permissions")
@@ -98,17 +99,17 @@ export class GuildsController {
     @UserId() userId: string,
     @Headers(DEV_PERMISSION_OVERRIDE_HEADER) devPermissionOverride?: string,
   ): Promise<UserGuildPermissionsDto[]> {
-    const parsedDevPermissionOverride = parseDevPermissionOverrideHeader(
-      devPermissionOverride,
+    const guildPermissionOptions = {
+      devPermissionOverride: parseDevPermissionOverrideHeader(
+        devPermissionOverride,
+      ),
+    };
+
+    return this.guildsService.getUserGuildsWithPermissions(
+      discordId,
+      userId,
+      guildPermissionOptions,
     );
-
-    if (!parsedDevPermissionOverride) {
-      return this.guildsService.getUserGuildsWithPermissions(discordId, userId);
-    }
-
-    return this.guildsService.getUserGuildsWithPermissions(discordId, userId, {
-      devPermissionOverride: parsedDevPermissionOverride,
-    });
   }
 
   @Get("/@me/manageable")


### PR DESCRIPTION
## Summary
- Simplifies guild permission override delegation in public and internal guild controllers by building the service options once and making a single service call.
- Removes an unnecessary `async` from the touched guild list controller method.
- Updates controller specs to assert the explicit no-override delegation shape.

## Verification
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/api-helpers build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/guilds/guilds.controller.spec.ts src/guilds/guilds-internal.controller.spec.ts`
- `pnpm --filter @lootlog/api lint` (passes with existing warnings)
- `pnpm exec oxfmt --check apps/api/src/guilds/guilds.controller.ts apps/api/src/guilds/guilds-internal.controller.ts apps/api/src/guilds/guilds.controller.spec.ts apps/api/src/guilds/guilds-internal.controller.spec.ts`
- `pnpm --filter @lootlog/api build`
- Pre-commit hook passed, including lint-staged, package lint/build, and `@lootlog/api` tests (`86` files, `902` tests).