### PR TITLE
[codex] simplify permissions guild mapping

### DIFF
--- a/apps/game-client/src/contexts/socket-context.test.tsx
+++ b/apps/game-client/src/contexts/socket-context.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { GatewayEvent } from "@/config/gateway";
 import { useGlobalStore } from "@/store/global.store";
 import { SocketProvider } from "./socket-context";
@@ -63,6 +63,18 @@ const expectedJoinData = {
   world: "alpha",
 };
 
+const getSocketEventHandler = <Payload,>(event: GatewayEvent) => {
+  const handler = mockSocket.on.mock.calls.find(
+    ([registeredEvent]) => registeredEvent === event,
+  )?.[1];
+
+  if (typeof handler !== "function") {
+    throw new Error(`Missing socket handler for ${event}`);
+  }
+
+  return handler as (data: Payload) => void;
+};
+
 describe("SocketProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -122,6 +134,38 @@ describe("SocketProvider", () => {
       expect(mockSocket.emit).toHaveBeenCalledWith(GatewayEvent.JOIN, {
         data: expectedJoinData,
       });
+    });
+  });
+
+  it("syncs joined guild ids from permissions updates", async () => {
+    render(
+      <SocketProvider>
+        <div />
+      </SocketProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockSocket.on).toHaveBeenCalledWith(
+        GatewayEvent.PERMISSIONS_UPDATED,
+        expect.any(Function),
+      );
+    });
+
+    const handlePermissionsUpdated = getSocketEventHandler<{
+      guilds: { guild: { id: string } }[];
+    }>(GatewayEvent.PERMISSIONS_UPDATED);
+
+    act(() => {
+      handlePermissionsUpdated({
+        guilds: [{ guild: { id: "guild-1" } }, { guild: { id: "guild-2" } }],
+      });
+    });
+
+    await waitFor(() => {
+      expect(useGlobalStore.getState().socketState.joinedGuilds).toEqual([
+        "guild-1",
+        "guild-2",
+      ]);
     });
   });
 });

--- a/apps/game-client/src/contexts/socket-context.tsx
+++ b/apps/game-client/src/contexts/socket-context.tsx
@@ -23,6 +23,10 @@ type SocketContextValue = {
   joinedGuilds: string[];
 };
 
+type PermissionsUpdatedPayload = {
+  guilds?: { guild: { id: string } }[];
+};
+
 const SocketContext = createContext<SocketContextValue>({
   socket: null,
   connected: false,
@@ -140,9 +144,7 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
         isAfk: false,
       });
     };
-    const handlePermissionsUpdated = (data: {
-      guilds: { guild: { id: string } }[];
-    }) => {
+    const handlePermissionsUpdated = (data: PermissionsUpdatedPayload) => {
       if (import.meta.env.DEV) {
         console.log("[Gateway] Rooms rebalanced:", data);
       }
@@ -156,7 +158,7 @@ export const SocketProvider = ({ children }: { children: ReactNode }) => {
         return;
       }
 
-      setJoinedGuilds(data.guilds.map((g) => g.guild.id) || []);
+      setJoinedGuilds(data.guilds.map(({ guild }) => guild.id));
     };
 
     socket.on(GatewayEvent.CONNECT, handleConnect);


### PR DESCRIPTION
## Summary

- Type the permissions update payload to match the existing missing-guilds guard.
- Remove the redundant empty-array fallback after mapping guild ids.
- Add SocketProvider coverage for syncing guild ids from permissions updates.

## Verification

- `pnpm --dir apps/game-client exec vitest run src/contexts/socket-context.test.tsx`
- `pnpm exec oxfmt --check apps/game-client/src/contexts/socket-context.tsx apps/game-client/src/contexts/socket-context.test.tsx`
- `pnpm exec oxlint apps/game-client/src/contexts/socket-context.tsx apps/game-client/src/contexts/socket-context.test.tsx` (warnings only from existing dev console calls)
- `pnpm --filter @lootlog/game-client build`
- `.husky/pre-commit`