### PR TITLE
[codex] remove gateway owner admin permission aliases

### DIFF
--- a/apps/gateway/src/gateway/gateway.service.ts
+++ b/apps/gateway/src/gateway/gateway.service.ts
@@ -20,7 +20,7 @@ import type { SendPartyGatheringDto } from "src/gateway/dto/send-party-gathering
 import type { VolunteerNotificationDto } from "src/gateway/dto/volunteer-notification.dto";
 import { GatewayEvent } from "src/gateway/enums/gateway-event.enum";
 import { Gateway } from "src/gateway/gateway";
-import { isOwnerOrAdminFromRoles } from "src/guilds/utils/is-administrative-user";
+import { isAdministrativeUserFromRoles } from "src/guilds/utils/is-administrative-user";
 import { RedisService } from "@lootlog/nest-shared/redis";
 import { GuildsService } from "src/guilds/guilds.service";
 import type { UserGuildData } from "src/guilds/types/guild.types";
@@ -97,7 +97,7 @@ export class GatewayService {
 
             // Owner/Admin bypass level checks
             const isOwner = guildData.guild.ownerId === socket.data.discordId;
-            if (isOwner || isOwnerOrAdminFromRoles(guildData.roles)) {
+            if (isOwner || isAdministrativeUserFromRoles(guildData.roles)) {
               socket.emit(event, data);
               return;
             }
@@ -203,7 +203,7 @@ export class GatewayService {
 
           const isOwner = guildData.guild.ownerId === socket.data.discordId;
           const isOwnerOrAdmin =
-            isOwner || isOwnerOrAdminFromRoles(guildData.roles);
+            isOwner || isAdministrativeUserFromRoles(guildData.roles);
 
           if (
             routing.npcLevel !== undefined &&

--- a/apps/gateway/src/gateway/services/presence.service.ts
+++ b/apps/gateway/src/gateway/services/presence.service.ts
@@ -14,7 +14,7 @@ import {
   hasOnlinePlayersAccess,
   parseRoomName,
 } from "src/gateway/utils/room-utils";
-import { isOwnerOrAdminFromRoles } from "src/guilds/utils/is-administrative-user";
+import { isAdministrativeUserFromRoles } from "src/guilds/utils/is-administrative-user";
 import type {
   Socket,
   SocketUser,
@@ -591,7 +591,7 @@ export class PresenceService {
     const isOwner = guildData.guild.ownerId === viewer.data.discordId;
     return (
       isOwner ||
-      isOwnerOrAdminFromRoles(guildData.roles) ||
+      isAdministrativeUserFromRoles(guildData.roles) ||
       hasOnlinePlayersAccess(guildData.roles)
     );
   }

--- a/apps/gateway/src/gateway/utils/room-utils.ts
+++ b/apps/gateway/src/gateway/utils/room-utils.ts
@@ -5,7 +5,7 @@ import {
   type NpcRoutingTier,
 } from "@lootlog/types";
 import type { UserGuildData, GuildRole } from "src/guilds/types/guild.types";
-import { isOwnerOrAdminFromRoles } from "src/guilds/utils/is-administrative-user";
+import { isAdministrativeUserFromRoles } from "src/guilds/utils/is-administrative-user";
 import { Platform } from "src/gateway/enums/platform.enum";
 
 const FEATURE_ROOMS = {
@@ -95,7 +95,7 @@ export function calculateUserRooms(
   for (const { guild, roles } of guilds) {
     const guildRooms: string[] = [];
     const hasFullGuildAccess =
-      guild.ownerId === discordId || isOwnerOrAdminFromRoles(roles);
+      guild.ownerId === discordId || isAdministrativeUserFromRoles(roles);
 
     // Everyone gets presence and events rooms
     guildRooms.push(buildRoomName(guild.id, "presence"));

--- a/apps/gateway/src/guilds/utils/is-administrative-user.spec.ts
+++ b/apps/gateway/src/guilds/utils/is-administrative-user.spec.ts
@@ -1,8 +1,6 @@
 import {
   isAdministrativeUser,
   isAdministrativeUserFromRoles,
-  isOwnerOrAdmin,
-  isOwnerOrAdminFromRoles,
 } from "./is-administrative-user";
 import { Permission } from "@lootlog/types";
 import type { GuildRole } from "../types/guild.types";
@@ -129,129 +127,12 @@ describe("isAdministrativeUserFromRoles", () => {
 
     expect(isAdministrativeUserFromRoles(roles)).toBe(false);
   });
-});
-
-describe("isOwnerOrAdmin", () => {
-  it("should return true for OWNER permission", () => {
-    const permissions = [Permission.OWNER];
-
-    expect(isOwnerOrAdmin(permissions)).toBe(true);
-  });
-
-  it("should return true for ADMIN permission", () => {
-    const permissions = [Permission.ADMIN];
-
-    expect(isOwnerOrAdmin(permissions)).toBe(true);
-  });
-
-  it("should return false for LOOTLOG_MANAGE permission", () => {
-    const permissions = [Permission.LOOTLOG_MANAGE];
-
-    expect(isOwnerOrAdmin(permissions)).toBe(false);
-  });
-
-  it("should return false for non-administrative permissions", () => {
-    const permissions = [
-      Permission.LOOTLOG_LOOTS_READ,
-      Permission.LOOTLOG_LOOTS_WRITE,
-      Permission.LOOTLOG_CHAT_READ,
-    ];
-
-    expect(isOwnerOrAdmin(permissions)).toBe(false);
-  });
-
-  it("should return true when at least one owner/admin permission exists", () => {
-    const permissions = [
-      Permission.LOOTLOG_LOOTS_READ,
-      Permission.OWNER,
-      Permission.LOOTLOG_LOOTS_WRITE,
-    ];
-
-    expect(isOwnerOrAdmin(permissions)).toBe(true);
-  });
-
-  it("should return false for empty permissions array", () => {
-    expect(isOwnerOrAdmin([])).toBe(false);
-  });
-
-  it("should return true when both OWNER and ADMIN permissions exist", () => {
-    const permissions = [Permission.OWNER, Permission.ADMIN];
-
-    expect(isOwnerOrAdmin(permissions)).toBe(true);
-  });
-});
-
-describe("isOwnerOrAdminFromRoles", () => {
-  it("should return true when role has OWNER permission", () => {
-    const roles = [createRole([Permission.OWNER])];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(true);
-  });
-
-  it("should return true when role has ADMIN permission", () => {
-    const roles = [createRole([Permission.ADMIN])];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(true);
-  });
-
-  it("should return false when role has LOOTLOG_MANAGE permission", () => {
-    const roles = [createRole([Permission.LOOTLOG_MANAGE])];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(false);
-  });
-
-  it("should return false when no owner/admin permissions", () => {
-    const roles = [
-      createRole([
-        Permission.LOOTLOG_LOOTS_READ,
-        Permission.LOOTLOG_LOOTS_WRITE,
-        Permission.LOOTLOG_MANAGE,
-      ]),
-    ];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(false);
-  });
-
-  it("should flatten permissions from multiple roles", () => {
-    const roles = [
-      createRole([Permission.LOOTLOG_LOOTS_READ]),
-      createRole([Permission.OWNER]),
-      createRole([Permission.LOOTLOG_LOOTS_WRITE]),
-    ];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(true);
-  });
-
-  it("should return false for empty roles array", () => {
-    expect(isOwnerOrAdminFromRoles([])).toBe(false);
-  });
-
-  it("should handle roles with multiple permissions including admin", () => {
-    const roles = [
-      createRole([
-        Permission.LOOTLOG_LOOTS_READ,
-        Permission.LOOTLOG_LOOTS_WRITE,
-        Permission.ADMIN,
-      ]),
-    ];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(true);
-  });
-
-  it("should handle roles with empty permissions", () => {
-    const roles = [createRole([])];
-
-    expect(isOwnerOrAdminFromRoles(roles)).toBe(false);
-  });
 
   it("should treat LOOTLOG_MANAGE as non-administrative in gateway", () => {
     const rolesWithManage = [createRole([Permission.LOOTLOG_MANAGE])];
     const rolesWithAdmin = [createRole([Permission.ADMIN])];
 
     expect(isAdministrativeUserFromRoles(rolesWithManage)).toBe(false);
-    expect(isOwnerOrAdminFromRoles(rolesWithManage)).toBe(false);
-
     expect(isAdministrativeUserFromRoles(rolesWithAdmin)).toBe(true);
-    expect(isOwnerOrAdminFromRoles(rolesWithAdmin)).toBe(true);
   });
 });

--- a/apps/gateway/src/guilds/utils/is-administrative-user.ts
+++ b/apps/gateway/src/guilds/utils/is-administrative-user.ts
@@ -31,11 +31,3 @@ export const isAdministrativeUser = (permissions: Permission[]) => {
 export const isAdministrativeUserFromRoles = (roles: GuildRole[]) => {
   return hasAnyRolePermission(roles, ADMINISTRATIVE_PERMISSIONS);
 };
-
-export const isOwnerOrAdmin = (permissions: Permission[]) => {
-  return isAdministrativeUser(permissions);
-};
-
-export const isOwnerOrAdminFromRoles = (roles: GuildRole[]) => {
-  return isAdministrativeUserFromRoles(roles);
-};


### PR DESCRIPTION
## Summary

- Removed the `isOwnerOrAdmin` and `isOwnerOrAdminFromRoles` gateway aliases that only forwarded to the administrative permission helpers.
- Updated gateway room, message, and presence access checks to call `isAdministrativeUserFromRoles` directly.
- Trimmed duplicate tests that covered the deleted aliases while keeping coverage for administrative role behavior.

## Verification

- `pnpm --filter @lootlog/gateway exec vitest run --config ./vitest.config.ts src/guilds/utils/is-administrative-user.spec.ts src/gateway/utils/room-utils.spec.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway build`
- `pnpm --filter @lootlog/gateway test`
- `pnpm exec oxfmt --check apps/gateway/src/gateway/gateway.service.ts apps/gateway/src/gateway/services/presence.service.ts apps/gateway/src/gateway/utils/room-utils.ts apps/gateway/src/guilds/utils/is-administrative-user.spec.ts apps/gateway/src/guilds/utils/is-administrative-user.ts`
- `pnpm exec oxlint --no-error-on-unmatched-pattern apps/gateway/src/gateway/gateway.service.ts apps/gateway/src/gateway/services/presence.service.ts apps/gateway/src/gateway/utils/room-utils.ts apps/gateway/src/guilds/utils/is-administrative-user.spec.ts apps/gateway/src/guilds/utils/is-administrative-user.ts`
- `.husky/pre-commit`