### PR TITLE
refactor(nest-shared): remove validators wrapper

### DIFF
--- a/apps/api/src/kills/dto/get-kill-stats.dto.ts
+++ b/apps/api/src/kills/dto/get-kill-stats.dto.ts
@@ -3,7 +3,7 @@ import { createZodDto } from "nestjs-zod";
 import {
   commaSeparatedArray,
   intFromString,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 import { NpcType } from "src/generated/prisma/client";
 import { KillStatsPeriodSchema } from "../utils/kill-stats-period";
 

--- a/apps/api/src/kills/dto/get-member-kills.dto.ts
+++ b/apps/api/src/kills/dto/get-member-kills.dto.ts
@@ -4,7 +4,7 @@ import {
   commaSeparatedArray,
   intFromString,
   optionalFromQuery,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 import { NpcType } from "src/generated/prisma/client";
 import { KillStatsPeriodSchema } from "../utils/kill-stats-period";
 

--- a/apps/api/src/kills/dto/get-user-npc-kills.dto.ts
+++ b/apps/api/src/kills/dto/get-user-npc-kills.dto.ts
@@ -3,7 +3,7 @@ import { createZodDto } from "nestjs-zod";
 import {
   commaSeparatedArray,
   intFromString,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 import { NpcType } from "src/generated/prisma/client";
 import { KillStatsPeriodSchema } from "../utils/kill-stats-period";
 

--- a/apps/api/src/loots/dto/fetch-loots-params.dto.ts
+++ b/apps/api/src/loots/dto/fetch-loots-params.dto.ts
@@ -4,7 +4,7 @@ import {
   commaSeparatedArray,
   intFromString,
   optionalFromQuery,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 import { MAX_PAGE_LIMIT } from "../config/pagination";
 
 const FetchLootsParamsSchema = z.object({

--- a/apps/api/src/loots/dto/loot-stats.dto.ts
+++ b/apps/api/src/loots/dto/loot-stats.dto.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { createZodDto } from "nestjs-zod";
-import { booleanFromString } from "@lootlog/nest-shared/validators";
+import { booleanFromString } from "@lootlog/nest-shared/validators/query-helpers";
 import type { ItemRarity, NpcType } from "src/generated/prisma/client";
 
 export type Period =

--- a/apps/battlelog-service/src/battles/dto/query-battle-analytics.dto.ts
+++ b/apps/battlelog-service/src/battles/dto/query-battle-analytics.dto.ts
@@ -3,7 +3,7 @@ import { createZodDto } from "nestjs-zod";
 import {
   booleanFromString,
   intFromString,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 
 const QueryBattleAnalyticsSchema = z.object({
   characterId: z.string().optional(),

--- a/apps/battlelog-service/src/battles/dto/query-battle-statistics.dto.ts
+++ b/apps/battlelog-service/src/battles/dto/query-battle-statistics.dto.ts
@@ -3,7 +3,7 @@ import { createZodDto } from "nestjs-zod";
 import {
   booleanFromString,
   intFromString,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 
 const QueryBattleStatisticsSchema = z.object({
   characterId: z.string().optional(),

--- a/apps/battlelog-service/src/battles/dto/query-battles.dto.ts
+++ b/apps/battlelog-service/src/battles/dto/query-battles.dto.ts
@@ -3,7 +3,7 @@ import { createZodDto } from "nestjs-zod";
 import {
   booleanFromString,
   commaSeparatedArray,
-} from "@lootlog/nest-shared/validators";
+} from "@lootlog/nest-shared/validators/query-helpers";
 
 export type SortOrder = "asc" | "desc";
 

--- a/apps/battlelog-service/vitest.config.ts
+++ b/apps/battlelog-service/vitest.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
         "../../packages/nest-shared/src/decorators/index.ts",
       "@lootlog/nest-shared/redis":
         "../../packages/nest-shared/src/redis/index.ts",
-      "@lootlog/nest-shared/validators":
-        "../../packages/nest-shared/src/validators/index.ts",
+      "@lootlog/nest-shared/validators/query-helpers":
+        "../../packages/nest-shared/src/validators/query-helpers.ts",
     },
     setupFiles: ["./vitest.setup.ts"],
   }),

--- a/packages/nest-shared/package.json
+++ b/packages/nest-shared/package.json
@@ -31,9 +31,9 @@
       "types": "./dist/redis/index.d.ts",
       "default": "./dist/redis/index.js"
     },
-    "./validators": {
-      "types": "./dist/validators/index.d.ts",
-      "default": "./dist/validators/index.js"
+    "./validators/query-helpers": {
+      "types": "./dist/validators/query-helpers.d.ts",
+      "default": "./dist/validators/query-helpers.js"
     }
   },
   "scripts": {

--- a/packages/nest-shared/src/validators/index.ts
+++ b/packages/nest-shared/src/validators/index.ts
@@ -1,7 +1,0 @@
-export {
-  nonEmptyString,
-  booleanFromString,
-  optionalFromQuery,
-  intFromString,
-  commaSeparatedArray,
-} from "./query-helpers";


### PR DESCRIPTION
## Summary

- Removed the re-export-only `packages/nest-shared/src/validators/index.ts` wrapper.
- Pointed backend DTO imports and the battlelog-service Vitest alias at `@lootlog/nest-shared/validators/query-helpers` directly.
- Updated `@lootlog/nest-shared` package exports to expose the concrete query helper module.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt ...changed files...`
- `corepack pnpm turbo run build --filter=@lootlog/nest-shared --filter=@lootlog/api --filter=@lootlog/battlelog-service`
- `corepack pnpm turbo run lint --filter=@lootlog/api --filter=@lootlog/battlelog-service`
- `corepack pnpm turbo run test --filter=@lootlog/api --filter=@lootlog/battlelog-service`
- `corepack pnpm format:check`
- `git diff --check`
- `.husky/pre-commit`
- Commit hook on `git commit`

Notes: the first API build/test attempts exposed stale local linked package outputs in this fresh worktree; explicitly rebuilding `@lootlog/api-helpers` and `@lootlog/types` restored the local workspace artifacts and the targeted checks passed. The first commit-hook attempt hit a one-off timeout in `public-guild-stats-card.service.spec.ts`; the spec passed in isolation and the commit hook passed on retry.