### PR TITLE
refactor(web): simplify sidebar navigation clicks

### DIFF
--- a/apps/web/src/components/layout/sidebar-nav/sidebar-nav-item.tsx
+++ b/apps/web/src/components/layout/sidebar-nav/sidebar-nav-item.tsx
@@ -8,7 +8,6 @@ import { ThemeInteractiveFrame } from "@/themes";
 
 export const SidebarNavItem = ({
   url,
-  path,
   available,
   isActive,
   icon,
@@ -20,7 +19,6 @@ export const SidebarNavItem = ({
   onItemClick,
 }: {
   url: string;
-  path: string;
   available: boolean;
   isActive: boolean;
   icon: ReactNode;
@@ -92,7 +90,6 @@ export const SidebarNavItem = ({
       ) : null}
       <Link
         to={url}
-        key={path}
         preload="intent"
         onClick={(e) => {
           if (!available) e.preventDefault();

--- a/apps/web/src/components/layout/sidebar-nav/sidebar-nav.tsx
+++ b/apps/web/src/components/layout/sidebar-nav/sidebar-nav.tsx
@@ -1,5 +1,5 @@
 import { Separator } from "@lootlog/ui/components/separator";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { useLocation } from "@tanstack/react-router";
 import type { MenuItem } from "./types";
 import { SidebarNavItem } from "./sidebar-nav-item";
@@ -15,7 +15,7 @@ interface SidebarNavProps {
   header?: ReactNode;
   beforeItems?: ReactNode;
   footer?: ReactNode;
-  onItemClick?: (item: MenuItem, event: React.MouseEvent) => void;
+  onItemClick?: (item: MenuItem, event: MouseEvent) => void;
 }
 
 export const SidebarNav = ({
@@ -39,8 +39,8 @@ export const SidebarNav = ({
       )}
       {beforeItems}
       <div key={basePath} className="flex flex-col gap-1.5">
-        {items.map(
-          ({
+        {items.map((item) => {
+          const {
             divided,
             icon,
             path,
@@ -50,49 +50,45 @@ export const SidebarNav = ({
             badge,
             highlight,
             childPaths,
-          }) => {
-            if (!enabled) return null;
+          } = item;
 
-            const url = `${basePath}${path}`;
-            const normalizedPathname = pathname.replace(/\/$/, "");
-            const normalizedUrl = url.replace(/\/$/, "");
-            const isActive =
-              path === ""
-                ? normalizedPathname === normalizedUrl ||
-                  (childPaths?.some(
-                    (cp) =>
-                      normalizedPathname === `${normalizedUrl}${cp}` ||
-                      pathname.startsWith(`${normalizedUrl}${cp}/`),
-                  ) ??
-                    false)
-                : normalizedPathname === normalizedUrl ||
-                  pathname.startsWith(`${normalizedUrl}/`);
+          if (!enabled) return null;
 
-            return (
-              <div key={path}>
-                {divided && <Separator className="mb-1.5" />}
-                <SidebarNavItem
-                  url={url}
-                  path={path}
-                  available={available}
-                  isActive={isActive}
-                  icon={icon}
-                  label={label}
-                  badge={badge}
-                  highlight={highlight}
-                  isRukiaTheme={isRukiaTheme}
-                  isCatTheme={isCatTheme}
-                  onItemClick={(e) => {
-                    const item = items.find((item) => item.path === path);
-                    if (item) {
-                      onItemClick?.(item, e);
-                    }
-                  }}
-                />
-              </div>
-            );
-          },
-        )}
+          const url = `${basePath}${path}`;
+          const normalizedPathname = pathname.replace(/\/$/, "");
+          const normalizedUrl = url.replace(/\/$/, "");
+          const isActive =
+            path === ""
+              ? normalizedPathname === normalizedUrl ||
+                (childPaths?.some(
+                  (cp) =>
+                    normalizedPathname === `${normalizedUrl}${cp}` ||
+                    pathname.startsWith(`${normalizedUrl}${cp}/`),
+                ) ??
+                  false)
+              : normalizedPathname === normalizedUrl ||
+                pathname.startsWith(`${normalizedUrl}/`);
+
+          return (
+            <div key={path}>
+              {divided && <Separator className="mb-1.5" />}
+              <SidebarNavItem
+                url={url}
+                available={available}
+                isActive={isActive}
+                icon={icon}
+                label={label}
+                badge={badge}
+                highlight={highlight}
+                isRukiaTheme={isRukiaTheme}
+                isCatTheme={isCatTheme}
+                onItemClick={(e) => {
+                  onItemClick?.(item, e);
+                }}
+              />
+            </div>
+          );
+        })}
       </div>
       {footer ? (
         <div className="relative mt-auto px-2 pb-2">{footer}</div>


### PR DESCRIPTION
## Summary
- Simplify `SidebarNav` item mapping so click handlers use the current `MenuItem` directly instead of searching `items` by path.
- Remove the `path` prop and internal `key` from `SidebarNavItem`, since the parent list wrapper already owns the React key.
- Keep behavior unchanged while trimming unnecessary prop flow in the sidebar nav components.

## Verification
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt apps/web/src/components/layout/sidebar-nav/sidebar-nav.tsx apps/web/src/components/layout/sidebar-nav/sidebar-nav-item.tsx`
- `git diff --check`
- `corepack pnpm turbo run lint --filter=@lootlog/web`
- `corepack pnpm turbo run build --filter=@lootlog/web`
- `corepack pnpm turbo run test --filter=@lootlog/web`
- `corepack pnpm format:check`
- `.husky/pre-commit`

Notes: `@lootlog/web` has no standalone test script, so the Turbo test command replayed required dependency builds. Existing warnings observed: cached `@lootlog/ui` `no-img-element`, dependency package `MODULE_TYPELESS_PACKAGE_JSON`, and third-party `lottie-web` direct-eval build warning.