### PR TITLE
refactor(web): remove route not-found alias

### DIFF
--- a/apps/web/src/lib/router/route-errors.ts
+++ b/apps/web/src/lib/router/route-errors.ts
@@ -66,5 +66,3 @@ export const rethrowNotFoundOrError = (error: unknown): never => {
 
   throw error;
 };
-
-export const throwNotFoundIfResponseMatches = rethrowNotFoundOrError;

--- a/apps/web/src/routes/_authenticated/$guildId.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId.tsx
@@ -14,8 +14,8 @@ import {
   getMembersControllerGetMeQueryOptions,
 } from "@/lib/api/generated/main/members/members";
 import {
+  rethrowNotFoundOrError,
   throwForbiddenRouteError,
-  throwNotFoundIfResponseMatches,
   withRouteLoaderCancellation,
 } from "@/lib/router/route-errors";
 import { ensureRouteQueryData } from "@/lib/router/route-prefetch";
@@ -89,7 +89,7 @@ export const Route = createFileRoute("/_authenticated/$guildId")({
           permissions,
         };
       } catch (error) {
-        throwNotFoundIfResponseMatches(error);
+        rethrowNotFoundOrError(error);
       }
     }),
   errorComponent: GuildRouteError,

--- a/apps/web/src/routes/_authenticated/$guildId/docs/$docId.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/docs/$docId.tsx
@@ -3,7 +3,7 @@ import { GuildDocEditorPage } from "@/features/guild/docs/guild-doc-editor-page"
 import { GuildDocEditorSkeleton } from "@/features/guild/docs/guild-doc-editor-skeleton";
 import { guildDocDetailQueryOptions } from "@/features/guild/docs/docs-api";
 import {
-  throwNotFoundIfResponseMatches,
+  rethrowNotFoundOrError,
   withRouteLoaderCancellation,
 } from "@/lib/router/route-errors";
 import { ensureRouteQueryData } from "@/lib/router/route-prefetch";
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/_authenticated/$guildId/docs/$docId")({
 
         return { document };
       } catch (error) {
-        throwNotFoundIfResponseMatches(error);
+        rethrowNotFoundOrError(error);
       }
     }),
   component: GuildDocEditorPage,

--- a/apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.coordination.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.coordination.tsx
@@ -3,7 +3,7 @@ import { EventCoordinationPage } from "@/features/guild/events/event-coordinatio
 import { EventCoordinationSkeleton } from "@/features/guild/events/event-coordination-skeleton";
 import { getEventsMonitoringControllerGetCoordinationQueryOptions } from "@/lib/api/generated/main/events/events";
 import {
-  throwNotFoundIfResponseMatches,
+  rethrowNotFoundOrError,
   withRouteLoaderCancellation,
 } from "@/lib/router/route-errors";
 
@@ -22,7 +22,7 @@ export const Route = createFileRoute(
           }),
         );
       } catch (error) {
-        throwNotFoundIfResponseMatches(error);
+        rethrowNotFoundOrError(error);
       }
     }),
 });

--- a/apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.tsx
+++ b/apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.tsx
@@ -5,7 +5,7 @@ import {
   getShowEventOverviewQueryOptions,
 } from "@/lib/api/generated/main/events/events";
 import {
-  throwNotFoundIfResponseMatches,
+  rethrowNotFoundOrError,
   withRouteLoaderCancellation,
 } from "@/lib/router/route-errors";
 
@@ -36,7 +36,7 @@ export const Route = createFileRoute(
           rankings,
         };
       } catch (error) {
-        throwNotFoundIfResponseMatches(error);
+        rethrowNotFoundOrError(error);
       }
     }),
 });

--- a/apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx
+++ b/apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx
@@ -7,7 +7,7 @@ import {
   getBattlesControllerGetBattleRawDataQueryOptions,
 } from "@/lib/api/generated/battlelog/battles/battles";
 import {
-  throwNotFoundIfResponseMatches,
+  rethrowNotFoundOrError,
   withRouteLoaderCancellation,
 } from "@/lib/router/route-errors";
 
@@ -37,7 +37,7 @@ export const Route = createFileRoute(
 
         return { battle };
       } catch (error) {
-        throwNotFoundIfResponseMatches(error);
+        rethrowNotFoundOrError(error);
       }
     }),
   component: BattlePanelSingleBattle,

--- a/apps/web/src/routes/battles.$id.tsx
+++ b/apps/web/src/routes/battles.$id.tsx
@@ -8,7 +8,7 @@ import {
   getPublicBattlesControllerGetPublicBattleTimelineQueryOptions,
 } from "@/lib/api/generated/battlelog/public-battles/public-battles";
 import {
-  throwNotFoundIfResponseMatches,
+  rethrowNotFoundOrError,
   withRouteLoaderCancellation,
 } from "@/lib/router/route-errors";
 
@@ -37,7 +37,7 @@ export const Route = createFileRoute("/battles/$id")({
 
         return null;
       } catch (error) {
-        throwNotFoundIfResponseMatches(error);
+        rethrowNotFoundOrError(error);
       }
     }),
   component: PublicBattle,


### PR DESCRIPTION
## Summary

- Removed the redundant `throwNotFoundIfResponseMatches` alias from the web route error helper.
- Updated route loaders to call the existing `rethrowNotFoundOrError` helper directly.
- Kept route not-found behavior unchanged while reducing duplicate helper surface area.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec oxfmt apps/web/src/lib/router/route-errors.ts 'apps/web/src/routes/battles.$id.tsx' 'apps/web/src/routes/_authenticated/$guildId.tsx' 'apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.tsx' 'apps/web/src/routes/_authenticated/$guildId/events_.$eventId_.coordination.tsx' 'apps/web/src/routes/_authenticated/$guildId/docs/$docId.tsx' 'apps/web/src/routes/_authenticated/@me/battle-panel/battles_.$battleId.tsx'`
- `git diff --check`
- `corepack pnpm turbo run build --filter=@lootlog/types --filter=@lootlog/socket-parser`
- `VITE_AUTH_SERVICE_URL=http://localhost/api/auth corepack pnpm --filter @lootlog/web exec vitest run src/lib/router/route-errors.spec.ts`
- `corepack pnpm turbo run lint --filter=@lootlog/web`
- `VITE_API_URL=http://localhost/api/lootlog VITE_SEARCH_API_URL=http://localhost/api/search VITE_AUTH_SERVICE_URL=http://localhost/api/auth VITE_GATEWAY_URL=http://localhost VITE_BATTLELOG_API_URL=http://localhost/api/battlelog VITE_ACTIVITY_API_URL=http://localhost/api/activity VITE_DISCORD_CLIENT_ID=1337108729753112697 VITE_DISCORD_BOT_PERMISSIONS=268553216 VITE_ADDON_INSTALL_URL=http://localhost/addon VITE_BATTLELOG_PUBLIC_URL=http://localhost/battlelog-client VITE_GATEWAY_SOCKET_PATH=/gateway corepack pnpm turbo run build --filter=@lootlog/web`
- `corepack pnpm turbo run test --filter=@lootlog/web`
- `corepack pnpm format:check`
- `.husky/pre-commit`
- commit hook pre-commit

Notes: `@lootlog/web` does not define a package `test` script, so the Turbo test filter only rebuilt dependency tasks; the focused route-error Vitest spec was run directly. Existing warnings observed: cached `@lootlog/ui` `no-img-element`, package `MODULE_TYPELESS_PACKAGE_JSON`, and third-party `lottie-web` direct-eval build warning.