### PR TITLE
[codex] Share search query parsing

### DIFF
--- a/apps/search/src/npcs/dto/get-npcs.dto.ts
+++ b/apps/search/src/npcs/dto/get-npcs.dto.ts
@@ -1,16 +1,9 @@
 import { createZodDto, type ZodDto } from "nestjs-zod";
+import {
+  parseCommaSeparatedQuery,
+  parseCommaSeparatedSearchQuery,
+} from "src/shared/query-helpers";
 import { z } from "zod";
-
-function parseCommaSeparatedQuery(value: unknown) {
-  if (typeof value !== "string") {
-    return value;
-  }
-
-  return value
-    .split(",")
-    .map((searchTerm) => searchTerm.trim())
-    .filter(Boolean);
-}
 
 export const getNpcsQuerySchema = z.object({
   ids: z
@@ -19,17 +12,7 @@ export const getNpcsQuerySchema = z.object({
   limit: z.coerce.number().optional().default(10),
   search: z
     .preprocess(
-      (value) => {
-        if (typeof value !== "string") {
-          return value;
-        }
-
-        if (!value.includes(",")) {
-          return value;
-        }
-
-        return parseCommaSeparatedQuery(value);
-      },
+      parseCommaSeparatedSearchQuery,
       z.union([z.string(), z.array(z.string())]),
     )
     .optional(),

--- a/apps/search/src/players/dto/get-players.dto.ts
+++ b/apps/search/src/players/dto/get-players.dto.ts
@@ -1,25 +1,14 @@
 import { createZodDto, type ZodDto } from "nestjs-zod";
+import { parseCommaSeparatedSearchQuery } from "src/shared/query-helpers";
 import { z } from "zod";
-
-function parseSearchQuery(value: unknown) {
-  if (typeof value !== "string") {
-    return value;
-  }
-
-  if (!value.includes(",")) {
-    return value;
-  }
-
-  return value
-    .split(",")
-    .map((searchTerm) => searchTerm.trim())
-    .filter(Boolean);
-}
 
 export const getPlayersQuerySchema = z.object({
   limit: z.coerce.number().optional().default(10),
   search: z
-    .preprocess(parseSearchQuery, z.union([z.string(), z.array(z.string())]))
+    .preprocess(
+      parseCommaSeparatedSearchQuery,
+      z.union([z.string(), z.array(z.string())]),
+    )
     .optional(),
   world: z.string().optional(),
 });

--- a/apps/search/src/shared/query-helpers.spec.ts
+++ b/apps/search/src/shared/query-helpers.spec.ts
@@ -1,0 +1,36 @@
+import {
+  parseCommaSeparatedQuery,
+  parseCommaSeparatedSearchQuery,
+} from "./query-helpers";
+
+describe("query helpers", () => {
+  describe("parseCommaSeparatedQuery", () => {
+    it("splits comma-separated strings into trimmed values", () => {
+      expect(parseCommaSeparatedQuery("tanroth, hero, , titan")).toEqual([
+        "tanroth",
+        "hero",
+        "titan",
+      ]);
+    });
+
+    it("passes non-string values through unchanged", () => {
+      const queryValues = ["1", "2"];
+
+      expect(parseCommaSeparatedQuery(queryValues)).toBe(queryValues);
+      expect(parseCommaSeparatedQuery(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("parseCommaSeparatedSearchQuery", () => {
+    it("keeps plain search strings unchanged", () => {
+      expect(parseCommaSeparatedSearchQuery("tanroth")).toBe("tanroth");
+    });
+
+    it("splits comma-separated search strings", () => {
+      expect(parseCommaSeparatedSearchQuery("tanroth, hero")).toEqual([
+        "tanroth",
+        "hero",
+      ]);
+    });
+  });
+});

--- a/apps/search/src/shared/query-helpers.ts
+++ b/apps/search/src/shared/query-helpers.ts
@@ -1,0 +1,25 @@
+const splitCommaSeparatedQuery = (value: string) =>
+  value
+    .split(",")
+    .map((searchTerm) => searchTerm.trim())
+    .filter((searchTerm) => searchTerm.length > 0);
+
+export function parseCommaSeparatedQuery(value: unknown) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return splitCommaSeparatedQuery(value);
+}
+
+export function parseCommaSeparatedSearchQuery(value: unknown) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  if (!value.includes(",")) {
+    return value;
+  }
+
+  return splitCommaSeparatedQuery(value);
+}


### PR DESCRIPTION
## Summary
- Extract shared search query parsing helpers for comma-separated values.
- Reuse them in NPC and player search DTO validation.
- Add focused coverage for the helper behavior.

## Verification
- `pnpm exec oxfmt --check apps/search/src/shared/query-helpers.ts apps/search/src/shared/query-helpers.spec.ts apps/search/src/npcs/dto/get-npcs.dto.ts apps/search/src/players/dto/get-players.dto.ts`
- `pnpm exec oxlint --no-error-on-unmatched-pattern apps/search/src/shared/query-helpers.ts apps/search/src/shared/query-helpers.spec.ts apps/search/src/npcs/dto/get-npcs.dto.ts apps/search/src/players/dto/get-players.dto.ts`
- `pnpm turbo run test --filter=@lootlog/search`
- `pnpm turbo run build --filter=@lootlog/search`
- pre-commit hook: lint-staged, changed-package lint/format/test