### PR TITLE
fix(game-client): strip request-only config fields

### DIFF
--- a/apps/game-client/src/lib/api-client.test.ts
+++ b/apps/game-client/src/lib/api-client.test.ts
@@ -211,6 +211,37 @@ describe("api-client", () => {
     expect(new Headers(requestInit.headers).has("Content-Type")).toBe(false);
   });
 
+  it("strips client-only config fields from request init", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+        },
+      }),
+    );
+
+    const client = getApiClient("default");
+    await client.get<{ ok: boolean }>("/timers", {
+      params: {
+        world: "pandora",
+      },
+      withCredentials: false,
+    });
+
+    const [requestUrl, requestInit] = mockFetch.mock.calls[0] as [
+      URL,
+      RequestInit,
+    ];
+
+    expect(requestUrl.toString()).toBe(
+      "http://localhost/api/lootlog/timers?world=pandora",
+    );
+    expect("params" in requestInit).toBe(false);
+    expect("withCredentials" in requestInit).toBe(false);
+    expect(requestInit.credentials).toBe("omit");
+  });
+
   it("caches clients per api type", () => {
     expect(getApiClient("default")).toBe(getApiClient("default"));
     expect(getApiClient("default")).not.toBe(getApiClient("public"));

--- a/apps/game-client/src/lib/api-client.ts
+++ b/apps/game-client/src/lib/api-client.ts
@@ -248,7 +248,14 @@ const createRequestInit = (
   config: ApiRequestConfig | undefined,
   withCredentials: boolean,
 ) => {
-  const headers = new Headers(config?.headers);
+  const {
+    params: _params,
+    withCredentials: configuredWithCredentials,
+    headers: headerInit,
+    credentials,
+    ...requestInit
+  } = config ?? {};
+  const headers = new Headers(headerInit);
   applyDevPermissionOverrideHeader(headers);
 
   let requestBody: BodyInit | undefined;
@@ -266,11 +273,11 @@ const createRequestInit = (
   }
 
   return {
-    ...config,
+    ...requestInit,
     body: requestBody,
     credentials:
-      config?.credentials ??
-      ((config?.withCredentials ?? withCredentials) ? "include" : "omit"),
+      credentials ??
+      ((configuredWithCredentials ?? withCredentials) ? "include" : "omit"),
     headers,
     method,
   } satisfies RequestInit;


### PR DESCRIPTION
## Summary

- Strip game-client-only API request config fields before building `RequestInit`.
- Keep query params flowing only into URL construction and preserve the existing `withCredentials` override behavior.
- Add a regression test to ensure `params` and `withCredentials` are not passed through to `fetch`.

## Validation

- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/game-client exec vitest run src/lib/api-client.test.ts`
- `pnpm exec oxfmt --check apps/game-client/src/lib/api-client.ts apps/game-client/src/lib/api-client.test.ts`
- `pnpm exec oxlint apps/game-client/src/lib/api-client.ts apps/game-client/src/lib/api-client.test.ts`
- `pnpm exec turbo run build --filter=@lootlog/game-client --ui=stream`
- Pre-commit hook via `VITEST_MAX_WORKERS=1 git commit ...`, including lint-staged and `pnpm turbo run test --filter=[HEAD]`.

Note: the default full game-client test fanout hit unrelated Vitest worker startup timeouts locally. Re-running the same hook with `VITEST_MAX_WORKERS=1` completed successfully: 130 test files and 620 tests passed.