### PR TITLE
test(game-client): simplify preferences sync imports

### DIFF
--- a/apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx
+++ b/apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx
@@ -7,8 +7,7 @@ import {
   createNotificationsSettings,
 } from "@/lib/game-account-preferences";
 import { useGameAccountPreferencesSync } from "@/hooks/use-game-account-preferences-sync";
-import { getUsersControllerGetUserGameAccountPreferencesQueryKey } from "@/lib/api/generated/main/users/users";
-import type * as UsersApi from "@/lib/api/generated/main/users/users";
+import * as UsersApi from "@/lib/api/generated/main/users/users";
 
 const mockUseAccessibleGuilds = vi.fn();
 const mockUseUserGameAccountPreferences = vi.fn();
@@ -130,7 +129,7 @@ describe("useGameAccountPreferencesSync", () => {
 
     expect(
       queryClient.getQueryData(
-        getUsersControllerGetUserGameAccountPreferencesQueryKey({
+        UsersApi.getUsersControllerGetUserGameAccountPreferencesQueryKey({
           accountId: "202",
         }),
       ),
@@ -172,7 +171,7 @@ describe("useGameAccountPreferencesSync", () => {
     expect(mockMutate).not.toHaveBeenCalled();
     expect(
       queryClient.getQueryData(
-        getUsersControllerGetUserGameAccountPreferencesQueryKey({
+        UsersApi.getUsersControllerGetUserGameAccountPreferencesQueryKey({
           accountId: "202",
         }),
       ),
@@ -196,7 +195,7 @@ describe("useGameAccountPreferencesSync", () => {
     });
   });
 
-  it("resolves account id after game initialization before flushing queued detector events", async () => {
+  it("resolves account id after game initialization before flushing queued detector events", () => {
     vi.useFakeTimers();
 
     try {


### PR DESCRIPTION
## Summary

- Replace the split value/type imports from the generated users API module in the game-client preferences sync test with one namespace import.
- Reuse that namespace for the query key helper and remove an unnecessary `async` from a synchronous fake-timer test.

## Validation

- `corepack pnpm exec oxfmt --check apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx`
- `corepack pnpm exec oxlint apps/game-client/src/hooks/use-game-account-preferences-sync.test.tsx`
- `corepack pnpm exec vitest run src/hooks/use-game-account-preferences-sync.test.tsx` from `apps/game-client`
- `corepack pnpm --filter @lootlog/types build`
- `corepack pnpm --filter @lootlog/margonem --filter @lootlog/socket-parser build`
- `corepack pnpm --filter @lootlog/game-client build`
- `.husky/pre-commit`
- `git commit` hook rerun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated game account preference synchronization tests to use the current API query-key access pattern.
  - Refined timer-based test handling for game initialization and queued detector events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->