### PR TITLE
refactor(web): extract event points formatting

### DIFF
--- a/apps/web/src/features/guild/events/components/dialogs/manual-points-edit-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/manual-points-edit-dialog.tsx
@@ -12,6 +12,7 @@ import {
 import { Input } from "@lootlog/ui/components/input";
 import { Label } from "@lootlog/ui/components/label";
 import { Textarea } from "@lootlog/ui/components/textarea";
+import { formatPoints, formatSignedPoints } from "../../utils/format-points";
 import { parseEditablePoints } from "../../utils/parse-editable-points";
 
 interface ManualPointsEditDialogProps {
@@ -26,10 +27,6 @@ interface ManualPointsEditDialogProps {
     comment?: string;
   }) => Promise<void>;
 }
-
-const formatPoints = (points: number): string => {
-  return Number.isInteger(points) ? String(points) : points.toFixed(2);
-};
 
 export const ManualPointsEditDialog = ({
   open,
@@ -117,9 +114,7 @@ export const ManualPointsEditDialog = ({
               <p className="font-semibold">
                 {parsedPointsDelta === null
                   ? t("events.points.previewUnavailable")
-                  : parsedPointsDelta > 0
-                    ? `+${formatPoints(parsedPointsDelta)}`
-                    : formatPoints(parsedPointsDelta)}
+                  : formatSignedPoints(parsedPointsDelta)}
               </p>
             </div>
             <div className="rounded-md border border-border/60 bg-primary/5 px-3 py-2">

--- a/apps/web/src/features/guild/events/components/kills/kill-participants-card.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-participants-card.tsx
@@ -30,6 +30,7 @@ import { invalidateKillQueries } from "../../hooks/mutations/invalidate-kill-que
 import { ManualPointsEditDialog } from "../dialogs/manual-points-edit-dialog";
 import { aggregateMapData } from "../../utils/aggregate-map-data";
 import { formatDurationHuman } from "../../utils/format-duration";
+import { formatPoints, formatSignedPoints } from "../../utils/format-points";
 import { normalizeBonusBreakdown } from "../../utils/normalize-bonus-breakdown";
 
 interface KillParticipantsCardProps {
@@ -55,18 +56,6 @@ interface ParticipantRowProps {
   ) => Promise<void>;
   isEditPending?: boolean;
 }
-
-const formatPoints = (points: number): string => {
-  return Number.isInteger(points) ? String(points) : points.toFixed(2);
-};
-
-const formatSignedPoints = (points: number): string => {
-  if (points > 0) {
-    return `+${formatPoints(points)}`;
-  }
-
-  return formatPoints(points);
-};
 
 const ParticipantRow = ({
   participant,

--- a/apps/web/src/features/guild/events/components/ranking/event-ranking-table.tsx
+++ b/apps/web/src/features/guild/events/components/ranking/event-ranking-table.tsx
@@ -25,6 +25,7 @@ import {
   useUpdateRankingPoints,
 } from "@/lib/api/generated/main/events/events";
 import { invalidateRankingQueries } from "../../hooks/mutations/invalidate-ranking-queries";
+import { formatPoints, formatSignedPoints } from "../../utils/format-points";
 import { ManualPointsEditDialog } from "../dialogs/manual-points-edit-dialog";
 
 interface EventRankingTableProps {
@@ -47,18 +48,6 @@ interface RankingRowProps {
   guildId?: string;
   eventId?: string;
 }
-
-const formatPoints = (points: number): string => {
-  return Number.isInteger(points) ? String(points) : points.toFixed(2);
-};
-
-const formatSignedPoints = (points: number): string => {
-  if (points > 0) {
-    return `+${formatPoints(points)}`;
-  }
-
-  return formatPoints(points);
-};
 
 const RankingRow = ({
   ranking,

--- a/apps/web/src/features/guild/events/utils/format-points.spec.ts
+++ b/apps/web/src/features/guild/events/utils/format-points.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatPoints, formatSignedPoints } from "./format-points";
+
+describe("formatPoints", () => {
+  it("keeps whole numbers compact", () => {
+    expect(formatPoints(3)).toBe("3");
+    expect(formatPoints(-2)).toBe("-2");
+  });
+
+  it("formats decimal values with two fractional digits", () => {
+    expect(formatPoints(1.5)).toBe("1.50");
+    expect(formatPoints(0.25)).toBe("0.25");
+  });
+
+  it("rounds longer decimal values consistently", () => {
+    expect(formatPoints(1.234)).toBe("1.23");
+    expect(formatPoints(1.235)).toBe("1.24");
+  });
+});
+
+describe("formatSignedPoints", () => {
+  it("prefixes only positive values with a plus sign", () => {
+    expect(formatSignedPoints(1.5)).toBe("+1.50");
+    expect(formatSignedPoints(0)).toBe("0");
+    expect(formatSignedPoints(-0.25)).toBe("-0.25");
+  });
+});

--- a/apps/web/src/features/guild/events/utils/format-points.ts
+++ b/apps/web/src/features/guild/events/utils/format-points.ts
@@ -1,0 +1,11 @@
+export const formatPoints = (points: number): string => {
+  return Number.isInteger(points) ? String(points) : points.toFixed(2);
+};
+
+export const formatSignedPoints = (points: number): string => {
+  if (points > 0) {
+    return `+${formatPoints(points)}`;
+  }
+
+  return formatPoints(points);
+};


### PR DESCRIPTION
## Summary

- Extract shared event points formatting into `format-points` utilities.
- Replace duplicate local `formatPoints` / signed-points logic in ranking, kill participants, and manual edit UI.
- Add focused unit coverage for whole-number, decimal, rounding, and signed formatting behavior.

## Verification

- `pnpm --filter @lootlog/web exec vitest run src/features/guild/events/utils/format-points.spec.ts`
- `pnpm --filter @lootlog/web lint`
- `pnpm turbo run build --filter=@lootlog/web`
- Pre-commit hook via `git commit` (lint-staged formatting/lint, Turbo lint/test for changed packages)