### PR TITLE
fix(gateway): harden activity publish error logging

### DIFF
--- a/apps/gateway/src/gateway/services/activity.service.spec.ts
+++ b/apps/gateway/src/gateway/services/activity.service.spec.ts
@@ -3,6 +3,7 @@ import { ActivityType } from "src/gateway/enums/activity-type.enum";
 import { Platform } from "src/gateway/enums/platform.enum";
 import { RoutingKey } from "src/gateway/enums/routing-key.enum";
 import { DEFAULT_EXCHANGE_NAME } from "src/config/rabbitmq.config";
+import { Logger } from "@nestjs/common";
 import type { AmqpConnection } from "@golevelup/nestjs-rabbitmq";
 import type { Socket } from "src/gateway/types/socket-user.type";
 import type { UserGuildData } from "src/guilds/types/guild.types";
@@ -167,6 +168,27 @@ describe("ActivityService", () => {
     ]);
 
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("handles non-error publish rejections without failing the activity publish", async () => {
+    const loggerError = vi
+      .spyOn(Logger.prototype, "error")
+      .mockImplementation(() => undefined);
+    const client = createClient({ platform: Platform.WEB_APP });
+    publish.mockRejectedValueOnce(null);
+
+    await expect(
+      service.publishActivityEvent(ActivityType.CONNECT_EVENT, client, [
+        createGuild("guild-1"),
+      ]),
+    ).resolves.toBeUndefined();
+
+    expect(loggerError).toHaveBeenCalledWith(
+      "Failed to publish CONNECT_EVENT for discord-1 in guild guild-1: null",
+      undefined,
+    );
+
+    loggerError.mockRestore();
   });
 });
 

--- a/apps/gateway/src/gateway/services/activity.service.ts
+++ b/apps/gateway/src/gateway/services/activity.service.ts
@@ -16,6 +16,10 @@ import {
 type ActivityPlayer = NonNullable<Socket["data"]["player"]>;
 type ActivityClient = Pick<Socket, "data"> &
   Partial<Pick<Socket, "request" | "handshake">>;
+interface PublishErrorDetails {
+  message: string;
+  stack?: string;
+}
 
 @Injectable()
 export class ActivityService {
@@ -80,13 +84,28 @@ export class ActivityService {
             },
           );
         } catch (error) {
+          const publishError = this.getPublishErrorDetails(error);
+
           this.logger.error(
-            `Failed to publish ${type} for ${discordId} in guild ${guildId}: ${error.message}`,
-            error.stack,
+            `Failed to publish ${type} for ${discordId} in guild ${guildId}: ${publishError.message}`,
+            publishError.stack,
           );
         }
       }),
     );
+  }
+
+  private getPublishErrorDetails(error: unknown): PublishErrorDetails {
+    if (error instanceof Error) {
+      return {
+        message: error.message,
+        stack: error.stack,
+      };
+    }
+
+    return {
+      message: String(error),
+    };
   }
 
   private buildActivityPayload({


### PR DESCRIPTION
## Summary
- Narrow caught publish errors in `ActivityService` before logging message and stack details.
- Add coverage for non-`Error` AMQP publish rejections so handled publish failures do not reject the activity publish flow.

## Verification
- `pnpm exec oxfmt --check apps/gateway/src/gateway/services/activity.service.ts apps/gateway/src/gateway/services/activity.service.spec.ts`
- `pnpm --filter @lootlog/gateway exec vitest run --config ./vitest.config.ts src/gateway/services/activity.service.spec.ts`
- `pnpm --filter @lootlog/gateway lint`
- `pnpm --filter @lootlog/gateway build`
- `pnpm --filter @lootlog/gateway test`
- Pre-commit hook: lint-staged, gateway lint, changed-package test

Note: this fresh worktree had no `node_modules`; `pnpm install --frozen-lockfile` populated dependencies but exited nonzero because pnpm blocked package build scripts pending approval. The required workspace packages were then built explicitly for verification.