### PR TITLE
refactor(api): simplify notification schedule time conversion

### DIFF
--- a/apps/api/src/notifications/utils/notification-schedule-time.util.spec.ts
+++ b/apps/api/src/notifications/utils/notification-schedule-time.util.spec.ts
@@ -1,0 +1,154 @@
+import { NotificationScheduleIntervalType } from "src/generated/prisma/client";
+import {
+  calculateFirstOccurrenceInTimeZone,
+  calculateNextOccurrenceInTimeZone,
+  isRecurringScheduleInterval,
+  isValidTimeZone,
+} from "./notification-schedule-time.util";
+
+describe("notification-schedule-time.util", () => {
+  const timeZone = "Europe/Warsaw";
+
+  describe("isValidTimeZone", () => {
+    it("recognizes supported IANA time zones", () => {
+      expect(isValidTimeZone(timeZone)).toBe(true);
+    });
+
+    it("rejects invalid time zones", () => {
+      expect(isValidTimeZone("Lootlog/Invalid")).toBe(false);
+    });
+  });
+
+  describe("isRecurringScheduleInterval", () => {
+    it("returns true for daily and weekly intervals", () => {
+      expect(
+        isRecurringScheduleInterval(NotificationScheduleIntervalType.DAILY),
+      ).toBe(true);
+      expect(
+        isRecurringScheduleInterval(NotificationScheduleIntervalType.WEEKLY),
+      ).toBe(true);
+    });
+
+    it("returns false for one-time and hourly intervals", () => {
+      expect(
+        isRecurringScheduleInterval(NotificationScheduleIntervalType.ONCE),
+      ).toBe(false);
+      expect(
+        isRecurringScheduleInterval(NotificationScheduleIntervalType.HOURLY),
+      ).toBe(false);
+    });
+  });
+
+  describe("calculateFirstOccurrenceInTimeZone", () => {
+    it("uses today's local date when a daily time is still upcoming", () => {
+      const scheduledAt = calculateFirstOccurrenceInTimeZone({
+        intervalType: NotificationScheduleIntervalType.DAILY,
+        timeOfDay: "09:00",
+        timeZone,
+        now: new Date("2026-01-15T07:30:00.000Z"),
+      });
+
+      expect(scheduledAt.toISOString()).toBe("2026-01-15T08:00:00.000Z");
+    });
+
+    it("moves daily schedules to tomorrow when today's time has passed", () => {
+      const scheduledAt = calculateFirstOccurrenceInTimeZone({
+        intervalType: NotificationScheduleIntervalType.DAILY,
+        timeOfDay: "08:00",
+        timeZone,
+        now: new Date("2026-01-15T07:30:00.000Z"),
+      });
+
+      expect(scheduledAt.toISOString()).toBe("2026-01-16T07:00:00.000Z");
+    });
+
+    it("moves weekly schedules to the requested local weekday", () => {
+      const scheduledAt = calculateFirstOccurrenceInTimeZone({
+        intervalType: NotificationScheduleIntervalType.WEEKLY,
+        timeOfDay: "09:00",
+        timeZone,
+        weekday: 5,
+        now: new Date("2026-01-15T07:30:00.000Z"),
+      });
+
+      expect(scheduledAt.toISOString()).toBe("2026-01-16T08:00:00.000Z");
+    });
+
+    it("moves weekly schedules by seven days when this week's time has passed", () => {
+      const scheduledAt = calculateFirstOccurrenceInTimeZone({
+        intervalType: NotificationScheduleIntervalType.WEEKLY,
+        timeOfDay: "09:00",
+        timeZone,
+        weekday: 5,
+        now: new Date("2026-01-16T10:00:00.000Z"),
+      });
+
+      expect(scheduledAt.toISOString()).toBe("2026-01-23T08:00:00.000Z");
+    });
+  });
+
+  describe("calculateNextOccurrenceInTimeZone", () => {
+    it("adds the configured amount of UTC hours for hourly schedules", () => {
+      const scheduledAt = calculateNextOccurrenceInTimeZone({
+        currentScheduledAt: new Date("2026-01-15T07:30:00.000Z"),
+        intervalType: NotificationScheduleIntervalType.HOURLY,
+        intervalValue: 3,
+        weekday: null,
+        timeOfDay: null,
+        timeZone,
+      });
+
+      expect(scheduledAt?.toISOString()).toBe("2026-01-15T10:30:00.000Z");
+    });
+
+    it("keeps daily schedules anchored to local time across DST", () => {
+      const scheduledAt = calculateNextOccurrenceInTimeZone({
+        currentScheduledAt: new Date("2026-03-28T08:00:00.000Z"),
+        intervalType: NotificationScheduleIntervalType.DAILY,
+        intervalValue: null,
+        weekday: null,
+        timeOfDay: "09:00",
+        timeZone,
+      });
+
+      expect(scheduledAt?.toISOString()).toBe("2026-03-29T07:00:00.000Z");
+    });
+
+    it("keeps weekly schedules anchored to local time", () => {
+      const scheduledAt = calculateNextOccurrenceInTimeZone({
+        currentScheduledAt: new Date("2026-03-28T08:00:00.000Z"),
+        intervalType: NotificationScheduleIntervalType.WEEKLY,
+        intervalValue: null,
+        weekday: 6,
+        timeOfDay: "09:00",
+        timeZone,
+      });
+
+      expect(scheduledAt?.toISOString()).toBe("2026-04-04T07:00:00.000Z");
+    });
+
+    it("returns null when recurring schedules are missing required timing fields", () => {
+      expect(
+        calculateNextOccurrenceInTimeZone({
+          currentScheduledAt: new Date("2026-01-15T07:30:00.000Z"),
+          intervalType: NotificationScheduleIntervalType.HOURLY,
+          intervalValue: 0,
+          weekday: null,
+          timeOfDay: null,
+          timeZone,
+        }),
+      ).toBeNull();
+
+      expect(
+        calculateNextOccurrenceInTimeZone({
+          currentScheduledAt: new Date("2026-01-15T07:30:00.000Z"),
+          intervalType: NotificationScheduleIntervalType.WEEKLY,
+          intervalValue: null,
+          weekday: null,
+          timeOfDay: "09:00",
+          timeZone,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/notifications/utils/notification-schedule-time.util.ts
+++ b/apps/api/src/notifications/utils/notification-schedule-time.util.ts
@@ -1,10 +1,16 @@
 import { NotificationScheduleIntervalType } from "src/generated/prisma/client";
 import {
+  type LocalDate,
   addDays,
   getDateFormatter,
   getLocalDate,
   toUtcDateFromLocal,
 } from "src/shared/utils/timezone.util";
+
+type TimeOfDayParts = {
+  hours: number;
+  minutes: number;
+};
 
 export function isValidTimeZone(timeZone: string): boolean {
   try {
@@ -24,6 +30,23 @@ export function isRecurringScheduleInterval(
   );
 }
 
+function parseTimeOfDay(timeOfDay: string): TimeOfDayParts {
+  const [hours, minutes] = timeOfDay.split(":").map(Number);
+  return {
+    hours: hours ?? 0,
+    minutes: minutes ?? 0,
+  };
+}
+
+function toUtcDateFromLocalTimeOfDay(
+  localDate: LocalDate,
+  timeOfDay: string,
+  timeZone: string,
+): Date {
+  const { hours, minutes } = parseTimeOfDay(timeOfDay);
+  return toUtcDateFromLocal(localDate, hours, minutes, timeZone);
+}
+
 export function calculateFirstOccurrenceInTimeZone(params: {
   intervalType: NotificationScheduleIntervalType;
   timeOfDay: string;
@@ -31,14 +54,12 @@ export function calculateFirstOccurrenceInTimeZone(params: {
   weekday?: number | null;
   now?: Date;
 }): Date {
-  const [hours, minutes] = params.timeOfDay.split(":").map(Number);
   const now = params.now ?? new Date();
   const currentLocalDate = getLocalDate(now, params.timeZone);
   let candidateLocalDate = currentLocalDate;
-  let candidate = toUtcDateFromLocal(
+  let candidate = toUtcDateFromLocalTimeOfDay(
     candidateLocalDate,
-    hours ?? 0,
-    minutes ?? 0,
+    params.timeOfDay,
     params.timeZone,
   );
 
@@ -61,19 +82,17 @@ export function calculateFirstOccurrenceInTimeZone(params: {
     }
 
     candidateLocalDate = addDays(currentLocalDate, daysUntil);
-    candidate = toUtcDateFromLocal(
+    candidate = toUtcDateFromLocalTimeOfDay(
       candidateLocalDate,
-      hours ?? 0,
-      minutes ?? 0,
+      params.timeOfDay,
       params.timeZone,
     );
 
     if (candidate.getTime() <= now.getTime()) {
       candidateLocalDate = addDays(candidateLocalDate, 7);
-      candidate = toUtcDateFromLocal(
+      candidate = toUtcDateFromLocalTimeOfDay(
         candidateLocalDate,
-        hours ?? 0,
-        minutes ?? 0,
+        params.timeOfDay,
         params.timeZone,
       );
     }
@@ -83,10 +102,9 @@ export function calculateFirstOccurrenceInTimeZone(params: {
 
   if (candidate.getTime() <= now.getTime()) {
     candidateLocalDate = addDays(candidateLocalDate, 1);
-    candidate = toUtcDateFromLocal(
+    candidate = toUtcDateFromLocalTimeOfDay(
       candidateLocalDate,
-      hours ?? 0,
-      minutes ?? 0,
+      params.timeOfDay,
       params.timeZone,
     );
   }
@@ -126,36 +144,24 @@ export function calculateNextOccurrenceInTimeZone(params: {
         return null;
       }
 
-      const [hours, minutes] = timeOfDay.split(":").map(Number);
       const nextLocalDate = addDays(
         getLocalDate(currentScheduledAt, timeZone),
         1,
       );
 
-      return toUtcDateFromLocal(
-        nextLocalDate,
-        hours ?? 0,
-        minutes ?? 0,
-        timeZone,
-      );
+      return toUtcDateFromLocalTimeOfDay(nextLocalDate, timeOfDay, timeZone);
     }
     case NotificationScheduleIntervalType.WEEKLY: {
       if (!timeOfDay || weekday === null) {
         return null;
       }
 
-      const [hours, minutes] = timeOfDay.split(":").map(Number);
       const nextLocalDate = addDays(
         getLocalDate(currentScheduledAt, timeZone),
         7,
       );
 
-      return toUtcDateFromLocal(
-        nextLocalDate,
-        hours ?? 0,
-        minutes ?? 0,
-        timeZone,
-      );
+      return toUtcDateFromLocalTimeOfDay(nextLocalDate, timeOfDay, timeZone);
     }
     default:
       return null;


### PR DESCRIPTION
## Summary
- Extracted a private helper for converting local notification schedule dates plus time-of-day strings into UTC dates.
- Reused that helper across first and next occurrence calculations to remove repeated parsing/conversion logic.
- Added focused coverage for daily, weekly, hourly, invalid schedule inputs, timezone validation, recurrence classification, and DST anchoring.

## Verification
- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/notifications/utils/notification-schedule-time.util.spec.ts`
- `pnpm --filter @lootlog/api build`
- `pnpm --filter @lootlog/api test`
- `pnpm turbo run lint '--filter=[HEAD]'`
- `pnpm turbo run format:check '--filter=[HEAD]'` (no matching configured task)
- `pnpm turbo run test '--filter=[HEAD]'`
- `sh .husky/pre-commit`

Note: Fresh install initially required direct builds of injected workspace packages (`@lootlog/types`, `@lootlog/api-helpers`, `@lootlog/nest-shared`) so their `dist` outputs were synced into pnpm's injected dependency copies.