### PR TITLE
refactor(auth): tighten access token typing

### DIFF
--- a/apps/auth/src/auth/auth.service.spec.ts
+++ b/apps/auth/src/auth/auth.service.spec.ts
@@ -268,6 +268,26 @@ describe("AuthService", () => {
       );
     });
 
+    it("returns TOKEN_NOT_FOUND for empty tokens", async () => {
+      vi.mocked(auth.api.getAccessToken).mockResolvedValue({
+        accessToken: "",
+        accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+        scopes: ["guilds"],
+      } as never);
+
+      await expect(
+        service.getIdpTokenResponse({
+          userId: "user-1",
+          discordId: "discord-1",
+        }),
+      ).rejects.toSatisfy(
+        (error: unknown) =>
+          error instanceof BadRequestException &&
+          JSON.stringify(error.getResponse()) ===
+            JSON.stringify({ error: "TOKEN_NOT_FOUND" }),
+      );
+    });
+
     it("maps Better Auth API errors to account-not-found responses", async () => {
       vi.mocked(auth.api.getAccessToken).mockRejectedValue(
         new APIError("BAD_REQUEST", {

--- a/apps/auth/src/auth/auth.service.ts
+++ b/apps/auth/src/auth/auth.service.ts
@@ -32,6 +32,13 @@ type IdpTokenResponse = {
 };
 
 type AccessTokenPayload = Awaited<ReturnType<typeof auth.api.getAccessToken>>;
+type DiscordAccessTokenPayload = AccessTokenPayload & { accessToken: string };
+
+const hasDiscordAccessToken = (
+  token: AccessTokenPayload,
+): token is DiscordAccessTokenPayload => {
+  return typeof token?.accessToken === "string" && token.accessToken.length > 0;
+};
 
 @Injectable()
 export class AuthService {
@@ -247,10 +254,10 @@ export class AuthService {
       missingException: HttpException;
       expiredException: HttpException;
     },
-  ): Promise<AccessTokenPayload & { accessToken: string }> {
+  ): Promise<DiscordAccessTokenPayload> {
     const token = await this.getDiscordAccessToken(request);
 
-    if (!token?.accessToken) {
+    if (!hasDiscordAccessToken(token)) {
       throw missingException;
     }
 
@@ -258,7 +265,7 @@ export class AuthService {
       throw expiredException;
     }
 
-    return token as AccessTokenPayload & { accessToken: string };
+    return token;
   }
 
   private getHttpStatus(status: string | number | undefined, fallback: number) {


### PR DESCRIPTION
## Summary
- Replace the auth access-token assertion cast with a `hasDiscordAccessToken` type guard.
- Add a regression test covering the existing empty-token `TOKEN_NOT_FOUND` behavior.

## Verification
- `corepack pnpm --filter @lootlog/auth test`
- `corepack pnpm --filter @lootlog/auth lint`
- `corepack pnpm turbo run build --filter=@lootlog/auth... --force`
- `corepack pnpm turbo run lint --filter=@lootlog/auth...`
- `corepack pnpm turbo run check-types --filter=@lootlog/auth...` (no package exposes `check-types`, so Turbo ran 0 tasks)
- `corepack pnpm turbo run test --filter=@lootlog/auth`
- `corepack pnpm format:check -- apps/auth/src/auth/auth.service.ts apps/auth/src/auth/auth.service.spec.ts`
- pre-commit hook during `git commit`