### PR TITLE
refactor(api): simplify notification NPC visibility checks

### DIFF
--- a/apps/api/src/notifications/notification-matching.service.spec.ts
+++ b/apps/api/src/notifications/notification-matching.service.spec.ts
@@ -7,7 +7,7 @@ describe("NotificationMatchingService", () => {
   beforeEach(() => {
     service = new NotificationMatchingService({
       member: {
-        findMany: vi.fn(),
+        findMany: vi.fn<() => Promise<unknown[]>>(),
       },
     } as never);
   });
@@ -90,6 +90,25 @@ describe("NotificationMatchingService", () => {
         ],
         NpcType.TITAN,
         300,
+      ),
+    ).toBe(true);
+  });
+
+  it("allows access for unknown npc levels when tier permissions match", () => {
+    expect(
+      service.canRolesViewNpc(
+        [
+          {
+            permissions: [
+              Permission.LOOTLOG_LOOTS_READ,
+              Permission.LOOTLOG_LOOTS_TITANS_READ,
+            ],
+            lvlRangeFrom: 250,
+            lvlRangeTo: 350,
+          },
+        ],
+        NpcType.TITAN,
+        null,
       ),
     ).toBe(true);
   });

--- a/apps/api/src/notifications/notification-matching.service.ts
+++ b/apps/api/src/notifications/notification-matching.service.ts
@@ -24,6 +24,53 @@ type MemberRoleInfo = {
   }[];
 };
 
+type MemberRolePermissions = MemberRoleInfo["roles"][number];
+
+const UNKNOWN_NPC_LEVEL = 0;
+const DEFAULT_NPC_LVL_RANGE_FROM = 0;
+const DEFAULT_NPC_LVL_RANGE_TO = 500;
+
+const roleCanViewNpcLevel = (
+  role: MemberRolePermissions,
+  npcLvl: number | null | undefined,
+) => {
+  const lvlFrom = role.lvlRangeFrom ?? DEFAULT_NPC_LVL_RANGE_FROM;
+  const lvlTo = role.lvlRangeTo ?? DEFAULT_NPC_LVL_RANGE_TO;
+
+  if (npcLvl === null || npcLvl === undefined) {
+    return lvlFrom <= UNKNOWN_NPC_LEVEL || lvlTo >= UNKNOWN_NPC_LEVEL;
+  }
+
+  return npcLvl >= lvlFrom && npcLvl <= lvlTo;
+};
+
+const roleCanViewNpcType = (
+  role: MemberRolePermissions,
+  npcType: NpcType | null | undefined,
+) => {
+  if (npcType === NpcType.TITAN) {
+    return role.permissions.includes(Permission.LOOTLOG_LOOTS_TITANS_READ);
+  }
+
+  if (npcType === NpcType.HERO || npcType === NpcType.EVENT_HERO) {
+    return role.permissions.includes(Permission.LOOTLOG_LOOTS_HEROES_READ);
+  }
+
+  return true;
+};
+
+const roleCanViewNpc = (
+  role: MemberRolePermissions,
+  npcType: NpcType | null | undefined,
+  npcLvl: number | null | undefined,
+) => {
+  return (
+    role.permissions.includes(Permission.LOOTLOG_LOOTS_READ) &&
+    roleCanViewNpcLevel(role, npcLvl) &&
+    roleCanViewNpcType(role, npcType)
+  );
+};
+
 @Injectable()
 export class NotificationMatchingService {
   constructor(private readonly prisma: PrismaService) {}
@@ -200,42 +247,6 @@ export class NotificationMatchingService {
       return true;
     }
 
-    const readableRoles = roles.filter((role) =>
-      role.permissions.includes(Permission.LOOTLOG_LOOTS_READ),
-    );
-
-    if (readableRoles.length === 0) {
-      return false;
-    }
-
-    return readableRoles.some((role) => {
-      const lvlFrom = role.lvlRangeFrom ?? 0;
-      const lvlTo = role.lvlRangeTo ?? 500;
-
-      const lvlOk =
-        npcLvl === null || npcLvl === undefined
-          ? lvlFrom <= 0 || lvlTo >= 0
-          : npcLvl >= lvlFrom && npcLvl <= lvlTo;
-
-      if (!lvlOk) {
-        return false;
-      }
-
-      if (
-        !role.permissions.includes(Permission.LOOTLOG_LOOTS_TITANS_READ) &&
-        npcType === NpcType.TITAN
-      ) {
-        return false;
-      }
-
-      if (
-        !role.permissions.includes(Permission.LOOTLOG_LOOTS_HEROES_READ) &&
-        (npcType === NpcType.HERO || npcType === NpcType.EVENT_HERO)
-      ) {
-        return false;
-      }
-
-      return true;
-    });
+    return roles.some((role) => roleCanViewNpc(role, npcType, npcLvl));
   }
 }


### PR DESCRIPTION
## Summary

- Extracted notification NPC visibility checks into small predicates for role level, NPC type, and complete role access.
- Kept `canRolesViewNpc` behavior unchanged while making the permission gates easier to read.
- Added coverage for unknown NPC levels with matching tier permissions and typed the mocked Prisma method in the spec.

## Verification

- `pnpm --dir apps/api exec vitest run --config ./vitest.config.ts src/notifications/notification-matching.service.spec.ts`
- `pnpm --dir apps/api exec oxlint src/notifications/notification-matching.service.ts src/notifications/notification-matching.service.spec.ts`
- `pnpm exec oxfmt --check apps/api/src/notifications/notification-matching.service.ts apps/api/src/notifications/notification-matching.service.spec.ts`
- `pnpm turbo run build --filter=@lootlog/api`
- `pnpm --dir apps/api exec tsc --noEmit -p tsconfig.build.json`
- `pnpm lint-staged`
- `pnpm turbo run lint '--filter=[HEAD]'` (passes with existing warnings outside touched files)
- `pnpm turbo run format:check '--filter=[HEAD]'` (no `format:check` task for API)
- `pnpm turbo run test '--filter=[HEAD]'` (86 files, 903 tests)
- pre-commit hook passed during commit