### PR TITLE
[codex] Type final notification job statuses

### DIFF
--- a/apps/api/src/notifications/notification-job.service.ts
+++ b/apps/api/src/notifications/notification-job.service.ts
@@ -58,11 +58,11 @@ type TimerUpdatedEvent = {
   } | null;
 };
 
-const FINAL_JOB_STATUSES = [
+const FINAL_JOB_STATUSES: DbNotificationJobStatus[] = [
   DbNotificationJobStatus.SENT,
   DbNotificationJobStatus.FAILED,
   DbNotificationJobStatus.CANCELED,
-] as const;
+];
 
 @Injectable()
 export class NotificationJobService {
@@ -426,11 +426,7 @@ export class NotificationJobService {
       return;
     }
 
-    if (
-      (FINAL_JOB_STATUSES as readonly DbNotificationJobStatus[]).includes(
-        notificationJob.status,
-      )
-    ) {
+    if (FINAL_JOB_STATUSES.includes(notificationJob.status)) {
       return;
     }
 
@@ -797,12 +793,7 @@ export class NotificationJobService {
     });
 
     if (
-      currentCycleJobs.some(
-        (job) =>
-          !(FINAL_JOB_STATUSES as readonly DbNotificationJobStatus[]).includes(
-            job.status,
-          ),
-      )
+      currentCycleJobs.some((job) => !FINAL_JOB_STATUSES.includes(job.status))
     ) {
       return;
     }
@@ -974,7 +965,7 @@ export class NotificationJobService {
           ownerType: owner.ownerType,
           ownerId: owner.ownerId,
           status: {
-            in: FINAL_JOB_STATUSES as unknown as DbNotificationJobStatus[],
+            in: FINAL_JOB_STATUSES,
           },
         },
         include: {
@@ -995,7 +986,7 @@ export class NotificationJobService {
         ownerType: owner.ownerType,
         ownerId: owner.ownerId,
         status: {
-          in: FINAL_JOB_STATUSES as unknown as DbNotificationJobStatus[],
+          in: FINAL_JOB_STATUSES,
         },
       },
       orderBy: [{ updatedAt: "desc" }],


### PR DESCRIPTION
## Summary
- Type `FINAL_JOB_STATUSES` as `DbNotificationJobStatus[]`.
- Remove assertion casts from final-status checks and Prisma status filters in `NotificationJobService`.

## Verification
- `corepack pnpm --filter @lootlog/api exec oxfmt --check src/notifications/notification-job.service.ts`
- `corepack pnpm --filter @lootlog/api exec oxlint src/notifications/notification-job.service.ts`
- `corepack pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/notifications/notifications.service.spec.ts`
- `corepack pnpm turbo run build --filter=@lootlog/api`
- `corepack pnpm turbo run lint --filter=@lootlog/api` (passes with existing warnings)
- `corepack pnpm turbo run test --filter=@lootlog/api`
- `corepack pnpm --filter @lootlog/api exec tsc --noEmit -p tsconfig.build.json`
- `.husky/pre-commit` via Corepack pnpm shim

Note: fresh dependency setup required `corepack pnpm install --frozen-lockfile`, then a forced frozen reinstall after building workspace package outputs so pnpm's virtual-store copies included local `dist` files.