### PR TITLE
refactor(search): tighten Meilisearch error code parsing

### DIFF
--- a/apps/search/src/meilisearch/meilisearch.utils.spec.ts
+++ b/apps/search/src/meilisearch/meilisearch.utils.spec.ts
@@ -18,6 +18,8 @@ describe("getMeilisearchErrorCode", () => {
   it("returns null when the cause code is missing or not a string", () => {
     expect(getMeilisearchErrorCode(new Error("boom"))).toBeNull();
     expect(getMeilisearchErrorCode({ cause: { code: 404 } })).toBeNull();
+    expect(getMeilisearchErrorCode({ cause: null })).toBeNull();
+    expect(getMeilisearchErrorCode("boom")).toBeNull();
     expect(getMeilisearchErrorCode(null)).toBeNull();
   });
 });

--- a/apps/search/src/meilisearch/meilisearch.utils.ts
+++ b/apps/search/src/meilisearch/meilisearch.utils.ts
@@ -1,12 +1,15 @@
-type MeilisearchErrorCause = {
-  cause?: {
-    code?: unknown;
-  };
-};
+type UnknownRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
 
 export function getMeilisearchErrorCode(error: unknown): string | null {
-  const code = (error as MeilisearchErrorCause | null)?.cause?.code;
+  if (!isRecord(error) || !isRecord(error.cause)) {
+    return null;
+  }
 
+  const { code } = error.cause;
   return typeof code === "string" ? code : null;
 }
 


### PR DESCRIPTION
## Summary
- Replaced the broad cast in `getMeilisearchErrorCode` with explicit object-shape guards before reading `cause.code`.
- Added malformed-input coverage for null causes and primitive thrown values.

## Validation
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --filter @lootlog/search test -- src/meilisearch/meilisearch.utils.spec.ts`
- `pnpm --filter @lootlog/search build`
- `pnpm exec oxlint --no-error-on-unmatched-pattern apps/search/src/meilisearch/meilisearch.utils.ts apps/search/src/meilisearch/meilisearch.utils.spec.ts`
- `pnpm exec oxfmt --check apps/search/src/meilisearch/meilisearch.utils.ts apps/search/src/meilisearch/meilisearch.utils.spec.ts`
- `.husky/pre-commit`

Note: the Turbo lint and format steps inside pre-commit had no package-level tasks for `@lootlog/search`; lint-staged still ran `oxlint` and `oxfmt` on the staged files.