### PR TITLE
refactor(ui): simplify item stat parsing

### DIFF
--- a/packages/ui/src/components/item-stat-utils.ts
+++ b/packages/ui/src/components/item-stat-utils.ts
@@ -25,11 +25,15 @@ function isString(value: unknown): value is string {
 }
 
 const parseItemStat = (stat: string): ItemStat => {
-  const [key = "undefined", ...rawValueParts] = stat.split("=");
+  const separatorIndex = stat.indexOf("=");
+
+  if (separatorIndex === -1) {
+    return { key: stat, value: true };
+  }
 
   return {
-    key,
-    value: rawValueParts.length === 0 ? true : rawValueParts.join("="),
+    key: stat.slice(0, separatorIndex),
+    value: stat.slice(separatorIndex + 1),
   };
 };
 


### PR DESCRIPTION
## Summary
- Simplify item stat segment parsing to split on the first `=` instead of splitting and joining the remainder.
- Preserve existing flag stat behavior and values containing additional equals signs.

## Verification
- `pnpm --filter @lootlog/web exec vitest run src/utils/item-tips/parse-item-stats.spec.ts`
- `pnpm --filter @lootlog/ui lint`
- `pnpm exec oxfmt --check packages/ui/src/components/item-stat-utils.ts`
- `pnpm turbo run build --filter=@lootlog/web`
- `.husky/pre-commit` / commit hook

Note: `pnpm install` populated dependencies but exited on pnpm's ignored-builds policy for native package scripts; the listed checks completed after dependency installation. UI lint reports an existing warning for `packages/ui/src/components/npc-tile.tsx` using `<img>`, with no errors.