### PR TITLE
refactor(api): type final notification job statuses

### DIFF
--- a/apps/api/src/notifications/notification-job.service.ts
+++ b/apps/api/src/notifications/notification-job.service.ts
@@ -58,11 +58,11 @@ type TimerUpdatedEvent = {
   } | null;
 };
 
-const FINAL_JOB_STATUSES = [
+const FINAL_JOB_STATUSES: readonly DbNotificationJobStatus[] = [
   DbNotificationJobStatus.SENT,
   DbNotificationJobStatus.FAILED,
   DbNotificationJobStatus.CANCELED,
-] as const;
+];
 
 @Injectable()
 export class NotificationJobService {
@@ -426,11 +426,7 @@ export class NotificationJobService {
       return;
     }
 
-    if (
-      (FINAL_JOB_STATUSES as readonly DbNotificationJobStatus[]).includes(
-        notificationJob.status,
-      )
-    ) {
+    if (FINAL_JOB_STATUSES.includes(notificationJob.status)) {
       return;
     }
 
@@ -797,12 +793,7 @@ export class NotificationJobService {
     });
 
     if (
-      currentCycleJobs.some(
-        (job) =>
-          !(FINAL_JOB_STATUSES as readonly DbNotificationJobStatus[]).includes(
-            job.status,
-          ),
-      )
+      currentCycleJobs.some((job) => !FINAL_JOB_STATUSES.includes(job.status))
     ) {
       return;
     }
@@ -974,7 +965,7 @@ export class NotificationJobService {
           ownerType: owner.ownerType,
           ownerId: owner.ownerId,
           status: {
-            in: FINAL_JOB_STATUSES as unknown as DbNotificationJobStatus[],
+            in: [...FINAL_JOB_STATUSES],
           },
         },
         include: {
@@ -995,7 +986,7 @@ export class NotificationJobService {
         ownerType: owner.ownerType,
         ownerId: owner.ownerId,
         status: {
-          in: FINAL_JOB_STATUSES as unknown as DbNotificationJobStatus[],
+          in: [...FINAL_JOB_STATUSES],
         },
       },
       orderBy: [{ updatedAt: "desc" }],


### PR DESCRIPTION
## Summary

- Annotate the notification job final-status list as a readonly `DbNotificationJobStatus` array.
- Remove repeated status-list casts by using the typed list directly for `includes` and spreading it for Prisma `in` filters.

## Verification

- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/notifications/notifications.service.spec.ts`
- `pnpm --filter @lootlog/api lint`
- `pnpm turbo run build --filter=@lootlog/api...`
- `.husky/pre-commit`