### PR TITLE
refactor(battlelog): simplify timeline returns

### DIFF
--- a/apps/battlelog-service/src/battles/battles.service.ts
+++ b/apps/battlelog-service/src/battles/battles.service.ts
@@ -203,14 +203,14 @@ export class BattlesService implements IBattlesService {
     requestingUserId?: string,
   ): Promise<BattleTimelineResponseInput> {
     const battle = await this.getBattleFromDatabase(battleId, requestingUserId);
-    return await this.buildTimelineResponse(battle);
+    return this.buildTimelineResponse(battle);
   }
 
   async getPublicBattleTimeline(
     battleId: string,
   ): Promise<BattleTimelineResponseInput> {
     const battle = await this.getPublicBattle(battleId);
-    return await this.buildTimelineResponse(battle);
+    return this.buildTimelineResponse(battle);
   }
 
   async getBattleFromDatabase(


### PR DESCRIPTION
## Summary

- Simplifies `getBattleTimeline` and `getPublicBattleTimeline` by returning the timeline helper promise directly.
- Removes redundant `return await` where there is no local catch/finally behavior to preserve.

## Verification

- `pnpm --filter @lootlog/battlelog-service lint`
- `pnpm --filter @lootlog/battlelog-service test`
- `pnpm exec oxfmt --check apps/battlelog-service/src/battles/battles.service.ts`
- `pnpm --filter @lootlog/nest-shared build`
- `pnpm --filter @lootlog/instrumentation build`
- `pnpm --filter @lootlog/battle-processor build`
- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/battlelog-service build`
- Pre-commit hook passed during commit: lint-staged, filtered lint, filtered format check, filtered tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined battle timeline processing without changing the information or behavior available to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->