### PR TITLE
feat(game-client): play sound for local map pings

### DIFF
--- a/apps/game-client/src/features/map-pings/use-map-pings.test.tsx
+++ b/apps/game-client/src/features/map-pings/use-map-pings.test.tsx
@@ -1,0 +1,200 @@
+import { act, renderHook } from "@testing-library/react";
+import type { MapPingAck, MapPingEvent } from "@lootlog/types";
+import { GatewayEvent } from "@/config/gateway";
+import { useMapPings } from "./use-map-pings";
+
+const testState = vi.hoisted(() => ({
+  connected: true,
+  joined: true,
+  pingsEnabled: true,
+}));
+const socketHandlers = vi.hoisted(
+  () => new Map<string, (payload: MapPingEvent) => void>(),
+);
+const socket = vi.hoisted(() => ({
+  emit: vi.fn(),
+  off: vi.fn(),
+  on: vi.fn(),
+  timeout: vi.fn(),
+}));
+const controller = vi.hoisted(() => ({
+  addOptimistic: vi.fn(() => "local-ping-1"),
+  addRemote: vi.fn(() => true),
+  clear: vi.fn(),
+  isTileValid: vi.fn(() => true),
+  register: vi.fn(() => true),
+  remove: vi.fn(),
+  resolveTile: vi.fn(() => ({ x: 12, y: 8 })),
+  unregister: vi.fn(),
+}));
+const playSound = vi.hoisted(() => vi.fn());
+
+vi.mock("@/contexts/socket-context", () => ({
+  useSocket: () => ({
+    socket,
+    connected: testState.connected,
+    joined: testState.joined,
+  }),
+}));
+
+vi.mock("@/hooks/use-current-game-account-preferences", () => ({
+  useCurrentGameAccountPreferences: () => ({
+    data: { pings: { enabled: testState.pingsEnabled } },
+  }),
+}));
+
+vi.mock("@/lib/game", () => ({
+  Game: {
+    getWorldName: () => "aether",
+    hero: { nick: "Sender" },
+    map: { id: 42 },
+  },
+}));
+
+vi.mock("@/lib/sound-playback", () => ({ playSound }));
+
+vi.mock("@/store/global.store", () => ({
+  useGlobalStore: (
+    selector: (state: { gameState: { gameInitialized: boolean } }) => unknown,
+  ) => selector({ gameState: { gameInitialized: true } }),
+}));
+
+vi.mock("./map-ping-controller", () => ({
+  isMapPingSurface: (target: EventTarget | null) =>
+    target instanceof HTMLCanvasElement && target.id === "GAME_CANVAS",
+  mapPingController: controller,
+}));
+
+const createMapMouseEvent = () => {
+  const canvas = document.createElement("canvas");
+  canvas.id = "GAME_CANVAS";
+  const event = new MouseEvent("mousedown", { button: 1 });
+  canvas.dispatchEvent(event);
+  return event;
+};
+
+const createOutsideMouseEvent = () => {
+  const element = document.createElement("div");
+  const event = new MouseEvent("mousedown", { button: 1 });
+  element.dispatchEvent(event);
+  return event;
+};
+
+describe("useMapPings", () => {
+  beforeEach(() => {
+    testState.connected = true;
+    testState.joined = true;
+    testState.pingsEnabled = true;
+    socketHandlers.clear();
+    vi.clearAllMocks();
+    socket.timeout.mockReturnValue(socket);
+    socket.on.mockImplementation((event, handler) => {
+      socketHandlers.set(event, handler);
+    });
+    controller.addRemote.mockReturnValue(true);
+    controller.register.mockReturnValue(true);
+    controller.resolveTile.mockReturnValue({ x: 12, y: 8 });
+  });
+
+  it("plays one sound immediately when a local ping is triggered", () => {
+    const { result } = renderHook(() => useMapPings());
+
+    act(() => {
+      expect(result.current(createMapMouseEvent())).toBe(true);
+    });
+
+    expect(controller.addOptimistic).toHaveBeenCalledWith(
+      { x: 12, y: 8 },
+      42,
+      "Sender",
+    );
+    expect(playSound).toHaveBeenCalledTimes(1);
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+    expect(socket.emit).toHaveBeenCalledWith(
+      GatewayEvent.MAP_PING_SEND,
+      { expectedMapId: 42, x: 12, y: 8 },
+      expect.any(Function),
+    );
+  });
+
+  it.each([
+    {
+      name: "pings are disabled",
+      configure: () => {
+        testState.pingsEnabled = false;
+      },
+      event: createMapMouseEvent,
+    },
+    {
+      name: "the socket is disconnected",
+      configure: () => {
+        testState.connected = false;
+      },
+      event: createMapMouseEvent,
+    },
+    {
+      name: "the socket has not joined",
+      configure: () => {
+        testState.joined = false;
+      },
+      event: createMapMouseEvent,
+    },
+    {
+      name: "the trigger is outside a map surface",
+      configure: () => undefined,
+      event: createOutsideMouseEvent,
+    },
+  ])("stays silent when $name", ({ configure, event }) => {
+    configure();
+    const { result } = renderHook(() => useMapPings());
+
+    act(() => {
+      expect(result.current(event())).toBe(false);
+    });
+
+    expect(playSound).not.toHaveBeenCalled();
+    expect(socket.emit).not.toHaveBeenCalled();
+  });
+
+  it("does not replay the local sound when the gateway rejects the ping", () => {
+    const { result } = renderHook(() => useMapPings());
+    act(() => {
+      result.current(createMapMouseEvent());
+    });
+    const acknowledgement = socket.emit.mock.calls[0]?.[2] as (
+      error: Error | null,
+      response?: MapPingAck,
+    ) => void;
+
+    act(() => {
+      acknowledgement(null, {
+        status: "rejected",
+        code: "invalid-context",
+      });
+    });
+
+    expect(controller.remove).toHaveBeenCalledWith("local-ping-1");
+    expect(playSound).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps playing one sound for a received remote ping", () => {
+    renderHook(() => useMapPings());
+    const event: MapPingEvent = {
+      pingId: "remote-ping-1",
+      world: "aether",
+      mapId: 42,
+      x: 12,
+      y: 8,
+      sender: { characterId: "123", name: "Other" },
+      createdAt: Date.now(),
+    };
+
+    act(() => {
+      socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);
+    });
+
+    expect(controller.addRemote).toHaveBeenCalledWith(event);
+    expect(playSound).toHaveBeenCalledTimes(1);
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+  });
+});

--- a/apps/game-client/src/features/map-pings/use-map-pings.tsx
+++ b/apps/game-client/src/features/map-pings/use-map-pings.tsx
@@ -187,6 +187,7 @@ export const useMapPings = () => {
       mapId,
       Game.hero.nick,
     );
+    playSound("pings", "mapPing");
     socket
       .timeout(ACK_TIMEOUT_MS)
       .emit(

--- a/apps/game-client/src/lib/sound-playback.test.ts
+++ b/apps/game-client/src/lib/sound-playback.test.ts
@@ -1,0 +1,70 @@
+import type { UserSoundSettings } from "@lootlog/types";
+import { getSoundSettingsControllerGetSettingsQueryKey } from "@/lib/api/generated/main/sound-settings/sound-settings";
+import { DEFAULT_SOUND_URLS } from "@/features/settings/config/default-sounds";
+import { queryClient } from "@/lib/query-client";
+import { playSound } from "./sound-playback";
+
+const audioInstances: AudioMock[] = [];
+
+class AudioMock {
+  volume = 1;
+  onended: (() => void) | null = null;
+  readonly pause = vi.fn();
+  readonly play = vi.fn<() => Promise<void>>().mockResolvedValue();
+
+  constructor(readonly src: string) {
+    audioInstances.push(this);
+  }
+}
+
+const createSoundSettings = (
+  overrides: Partial<UserSoundSettings> = {},
+): UserSoundSettings => ({
+  userId: "user-1",
+  masterVolume: 0.5,
+  notificationsVolume: 0.5,
+  detectorVolume: 0.5,
+  timersVolume: 0.5,
+  pingsVolume: 0.8,
+  notificationsConfig: {},
+  detectorConfig: {},
+  timersConfig: {},
+  ...overrides,
+});
+
+describe("playSound", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    audioInstances.length = 0;
+    vi.stubGlobal("Audio", AudioMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("plays a map ping using settings from the generated query cache", () => {
+    queryClient.setQueryData(
+      getSoundSettingsControllerGetSettingsQueryKey(),
+      createSoundSettings(),
+    );
+
+    playSound("pings", "mapPing");
+
+    expect(audioInstances).toHaveLength(1);
+    expect(audioInstances[0]?.src).toBe(DEFAULT_SOUND_URLS.mapPing);
+    expect(audioInstances[0]?.volume).toBe(0.4);
+    expect(audioInstances[0]?.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when ping sounds are muted", () => {
+    queryClient.setQueryData(
+      getSoundSettingsControllerGetSettingsQueryKey(),
+      createSoundSettings({ pingsVolume: 0 }),
+    );
+
+    playSound("pings", "mapPing");
+
+    expect(audioInstances).toHaveLength(0);
+  });
+});

--- a/apps/game-client/src/lib/sound-playback.ts
+++ b/apps/game-client/src/lib/sound-playback.ts
@@ -1,16 +1,19 @@
 import { queryClient } from "@/lib/query-client";
 import { DEFAULT_SOUND_URLS } from "@/features/settings/config/default-sounds";
+import { getSoundSettingsControllerGetSettingsQueryKey } from "@/lib/api/generated/main/sound-settings/sound-settings";
 import type { UserSoundSettings } from "@lootlog/types";
 
 type SoundCategory = "notifications" | "detector" | "timers" | "pings";
 type ConfigurableSoundCategory = Exclude<SoundCategory, "pings">;
 
 let currentAudio: HTMLAudioElement | null = null;
+const SOUND_SETTINGS_QUERY_KEY =
+  getSoundSettingsControllerGetSettingsQueryKey();
 
 function getSettings(): UserSoundSettings | undefined {
   const cached = queryClient.getQueryData<
     UserSoundSettings | { data: UserSoundSettings }
-  >(["sound-settings"]);
+  >(SOUND_SETTINGS_QUERY_KEY);
 
   if (cached && "masterVolume" in cached) {
     return cached;


### PR DESCRIPTION
## Summary

- play the existing map ping sound immediately after a valid local optimistic ping is created
- read sound settings through the generated React Query cache key used by the settings hook
- respect the existing master and ping volume settings without changing API, gateway, or database contracts
- keep invalid or locally blocked triggers silent
- preserve the existing single sound for received remote pings

## Root cause

The local trigger called `playSound` correctly, but the shared playback helper looked up settings under `["sound-settings"]` while Orval stores them under `["/sound-settings"]`. The lookup returned no settings, so playback exited before creating `Audio`. The helper now uses the generated query-key function.

## Behavior

The sound is local action feedback, so it plays before the Socket.IO ACK. A later timeout or rejection removes the optimistic marker as before but does not replay or undo the sound.

## Validation

- focused map ping and playback tests: 9 passed
- full game client suite: 636 tests passed
- game client production build passed
- staged-file lint and formatting passed in pre-commit