### PR TITLE
fix(game-client): keep map pings active on NI

### DIFF
--- a/apps/game-client/src/features/map-pings/use-map-pings.test.tsx
+++ b/apps/game-client/src/features/map-pings/use-map-pings.test.tsx
@@ -5,6 +5,7 @@ import { useMapPings } from "./use-map-pings";
 
 const testState = vi.hoisted(() => ({
   connected: true,
+  gameInterface: "ni" as "ni" | "si",
   joined: true,
   pingsEnabled: true,
 }));
@@ -45,13 +46,23 @@ vi.mock("@/hooks/use-current-game-account-preferences", () => ({
 
 vi.mock("@/lib/game", () => ({
   Game: {
+    getAccountId: () => "account-1",
     getWorldName: () => "aether",
     hero: { nick: "Sender" },
+    get interface() {
+      return testState.gameInterface;
+    },
     map: { id: 42 },
   },
 }));
 
 vi.mock("@/lib/sound-playback", () => ({ playSound }));
+
+vi.mock("@/lib/query-client", () => ({
+  queryClient: {
+    getQueryData: () => ({ pings: { enabled: testState.pingsEnabled } }),
+  },
+}));
 
 vi.mock("@/store/global.store", () => ({
   useGlobalStore: (
@@ -83,6 +94,7 @@ const createOutsideMouseEvent = () => {
 describe("useMapPings", () => {
   beforeEach(() => {
     testState.connected = true;
+    testState.gameInterface = "ni";
     testState.joined = true;
     testState.pingsEnabled = true;
     socketHandlers.clear();
@@ -115,6 +127,36 @@ describe("useMapPings", () => {
       { expectedMapId: 42, x: 12, y: 8 },
       expect.any(Function),
     );
+  });
+
+  it("uses the latest cached preference for a local ping trigger", () => {
+    testState.pingsEnabled = false;
+    const { result } = renderHook(() => useMapPings());
+    testState.pingsEnabled = true;
+
+    act(() => {
+      expect(result.current(createMapMouseEvent())).toBe(true);
+    });
+
+    expect(socket.emit).toHaveBeenCalledWith(
+      GatewayEvent.MAP_PING_SEND,
+      { expectedMapId: 42, x: 12, y: 8 },
+      expect.any(Function),
+    );
+  });
+
+  it("does not trigger a local ping on the old interface", () => {
+    testState.gameInterface = "si";
+    const { result } = renderHook(() => useMapPings());
+
+    act(() => {
+      expect(result.current(createMapMouseEvent())).toBe(false);
+    });
+
+    expect(controller.register).not.toHaveBeenCalled();
+    expect(controller.addOptimistic).not.toHaveBeenCalled();
+    expect(playSound).not.toHaveBeenCalled();
+    expect(socket.emit).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -196,5 +238,48 @@ describe("useMapPings", () => {
     expect(controller.addRemote).toHaveBeenCalledWith(event);
     expect(playSound).toHaveBeenCalledTimes(1);
     expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+  });
+
+  it("uses the latest cached preference for a received ping", () => {
+    testState.pingsEnabled = false;
+    renderHook(() => useMapPings());
+    testState.pingsEnabled = true;
+    const event: MapPingEvent = {
+      pingId: "remote-ping-after-enable",
+      world: "aether",
+      mapId: 42,
+      x: 12,
+      y: 8,
+      sender: { characterId: "123", name: "Other" },
+      createdAt: Date.now(),
+    };
+
+    act(() => {
+      socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);
+    });
+
+    expect(controller.addRemote).toHaveBeenCalledWith(event);
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+  });
+
+  it("ignores a received ping on the old interface", () => {
+    testState.gameInterface = "si";
+    renderHook(() => useMapPings());
+    const event: MapPingEvent = {
+      pingId: "remote-ping-on-si",
+      world: "aether",
+      mapId: 42,
+      x: 12,
+      y: 8,
+      sender: { characterId: "123", name: "Other" },
+      createdAt: Date.now(),
+    };
+
+    act(() => {
+      socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);
+    });
+
+    expect(controller.addRemote).not.toHaveBeenCalled();
+    expect(playSound).not.toHaveBeenCalled();
   });
 });

--- a/apps/game-client/src/features/map-pings/use-map-pings.tsx
+++ b/apps/game-client/src/features/map-pings/use-map-pings.tsx
@@ -2,8 +2,11 @@ import { GatewayEvent } from "@/config/gateway";
 import { useSocket } from "@/contexts/socket-context";
 import { useCurrentGameAccountPreferences } from "@/hooks/use-current-game-account-preferences";
 import { Game } from "@/lib/game";
+import { queryClient } from "@/lib/query-client";
 import { playSound } from "@/lib/sound-playback";
 import { useGlobalStore } from "@/store/global.store";
+import { getUsersControllerGetUserGameAccountPreferencesQueryKey } from "@/lib/api/generated/main/users/users";
+import type { UserGameAccountPreferencesResponseDtoOutput } from "@/lib/api/generated/main/model";
 import type { MapPingAck, MapPingEvent } from "@lootlog/types";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -23,8 +26,23 @@ type PointerPosition = {
   clientY: number;
 };
 
+const areMapPingsEnabled = () => {
+  const accountId = Game.getAccountId();
+  if (!accountId) {
+    return false;
+  }
+
+  const preferences =
+    queryClient.getQueryData<UserGameAccountPreferencesResponseDtoOutput>(
+      getUsersControllerGetUserGameAccountPreferencesQueryKey({ accountId }),
+    );
+
+  return preferences?.pings.enabled ?? false;
+};
+
 export const useMapPings = () => {
   const { socket, connected, joined } = useSocket();
+  const isNewInterface = Game.interface === "ni";
   const gameInitialized = useGlobalStore(
     (state) => state.gameState.gameInitialized,
   );
@@ -35,7 +53,7 @@ export const useMapPings = () => {
   const { t } = useTranslation("settings");
 
   useEffect(() => {
-    if (!gameInitialized) {
+    if (!gameInitialized || !isNewInterface) {
       return;
     }
 
@@ -53,9 +71,13 @@ export const useMapPings = () => {
       window.clearInterval(retryInterval);
       mapPingController.unregister();
     };
-  }, [gameInitialized]);
+  }, [gameInitialized, isNewInterface]);
 
   useEffect(() => {
+    if (!isNewInterface) {
+      return;
+    }
+
     const handleMouseMove = (event: MouseEvent) => {
       if (!isMapPingSurface(event.target)) {
         pointerRef.current = null;
@@ -71,7 +93,7 @@ export const useMapPings = () => {
 
     window.addEventListener("mousemove", handleMouseMove);
     return () => window.removeEventListener("mousemove", handleMouseMove);
-  }, []);
+  }, [isNewInterface]);
 
   useEffect(() => {
     if (enabled) {
@@ -90,14 +112,14 @@ export const useMapPings = () => {
   }, [connected]);
 
   useEffect(() => {
-    if (!socket) {
+    if (!socket || !isNewInterface) {
       return;
     }
 
     const handleMapPing = (event: MapPingEvent) => {
       const tile = { x: event.x, y: event.y };
       if (
-        !enabled ||
+        !areMapPingsEnabled() ||
         event.world !== Game.getWorldName() ||
         event.mapId !== Game.map.id ||
         !mapPingController.isTileValid(tile)
@@ -114,7 +136,7 @@ export const useMapPings = () => {
     return () => {
       socket.off(GatewayEvent.MAP_PING_RECEIVE, handleMapPing);
     };
-  }, [enabled, socket]);
+  }, [enabled, isNewInterface, socket]);
 
   const showHint = (
     acknowledgement: Extract<MapPingAck, { status: "rejected" }>,
@@ -172,7 +194,13 @@ export const useMapPings = () => {
   };
 
   return (event: KeyboardEvent | MouseEvent) => {
-    if (!enabled || !socket || !connected || !joined) {
+    if (
+      !isNewInterface ||
+      !areMapPingsEnabled() ||
+      !socket ||
+      !connected ||
+      !joined
+    ) {
       return false;
     }
 

--- a/apps/game-client/src/features/settings/components/general/general-settings-tab.test.tsx
+++ b/apps/game-client/src/features/settings/components/general/general-settings-tab.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+import { GeneralSettingsTab } from "./general-settings-tab";
+
+const testState = vi.hoisted(() => ({
+  gameInterface: "si" as "ni" | "si",
+}));
+
+vi.mock("@/lib/game", () => ({
+  Game: {
+    get interface() {
+      return testState.gameInterface;
+    },
+  },
+}));
+
+vi.mock("@/store/settings.store", () => ({
+  useSettingsStore: () => ({
+    allowWorldSelection: false,
+    animationEffectsEnabled: true,
+    toggleAllowWorldSelection: vi.fn(),
+    toggleAnimationEffects: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-current-game-account-preferences", () => ({
+  useCurrentGameAccountPreferences: () => ({
+    accountId: "account-1",
+    data: { pings: { enabled: true } },
+  }),
+}));
+
+vi.mock("@/hooks/api/use-user-account-preferences", () => ({
+  useUpdateUserGameAccountPreferences: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+describe("GeneralSettingsTab", () => {
+  beforeEach(() => {
+    testState.gameInterface = "si";
+  });
+
+  it("hides map ping settings on the old interface", () => {
+    const { container } = render(<GeneralSettingsTab />);
+
+    expect(container.querySelector("#map-pings")).not.toBeInTheDocument();
+  });
+
+  it("shows map ping settings on the new interface", () => {
+    testState.gameInterface = "ni";
+    const { container } = render(<GeneralSettingsTab />);
+
+    expect(container.querySelector("#map-pings")).toBeInTheDocument();
+  });
+});

--- a/apps/game-client/src/features/settings/components/general/general-settings-tab.tsx
+++ b/apps/game-client/src/features/settings/components/general/general-settings-tab.tsx
@@ -7,6 +7,7 @@ import type { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { useCurrentGameAccountPreferences } from "@/hooks/use-current-game-account-preferences";
 import { useUpdateUserGameAccountPreferences } from "@/hooks/api/use-user-account-preferences";
+import { Game } from "@/lib/game";
 
 export const GeneralSettingsTab: FC = () => {
   const {
@@ -37,19 +38,23 @@ export const GeneralSettingsTab: FC = () => {
             id="allow-world-selection"
           />
         </SettingsControlRow>
-        <SettingsControlRow
-          label={t("settings.general.mapPingsLabel")}
-          description={t("settings.general.mapPingsDescription")}
-        >
-          <Switch
-            checked={accountPreferences?.pings.enabled ?? false}
-            disabled={!accountPreferences || updateAccountPreferences.isPending}
-            onCheckedChange={(enabled) =>
-              updateAccountPreferences.mutate({ pings: { enabled } })
-            }
-            id="map-pings"
-          />
-        </SettingsControlRow>
+        {Game.interface === "ni" ? (
+          <SettingsControlRow
+            label={t("settings.general.mapPingsLabel")}
+            description={t("settings.general.mapPingsDescription")}
+          >
+            <Switch
+              checked={accountPreferences?.pings.enabled ?? false}
+              disabled={
+                !accountPreferences || updateAccountPreferences.isPending
+              }
+              onCheckedChange={(enabled) =>
+                updateAccountPreferences.mutate({ pings: { enabled } })
+              }
+              id="map-pings"
+            />
+          </SettingsControlRow>
+        ) : null}
         <SettingsControlRow
           label={t("settings.general.animationEffectsLabel")}
           description={t("settings.general.animationEffectsDescription")}

--- a/apps/game-client/src/features/settings/components/hotkeys/hotkeys-settings-tab.test.tsx
+++ b/apps/game-client/src/features/settings/components/hotkeys/hotkeys-settings-tab.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { HotkeysSettingsTab } from "./hotkeys-settings-tab";
+
+const testState = vi.hoisted(() => ({
+  gameInterface: "si" as "ni" | "si",
+}));
+
+vi.mock("@/lib/game", () => ({
+  Game: {
+    get interface() {
+      return testState.gameInterface;
+    },
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("HotkeysSettingsTab", () => {
+  beforeEach(() => {
+    testState.gameInterface = "si";
+  });
+
+  it("hides the map ping hotkey on the old interface", () => {
+    render(<HotkeysSettingsTab />);
+
+    expect(
+      screen.queryByText("settings.hotkeys.actions.map-ping.label"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the map ping hotkey on the new interface", () => {
+    testState.gameInterface = "ni";
+    render(<HotkeysSettingsTab />);
+
+    expect(
+      screen.getByText("settings.hotkeys.actions.map-ping.label"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/game-client/src/features/settings/components/hotkeys/hotkeys-settings-tab.tsx
+++ b/apps/game-client/src/features/settings/components/hotkeys/hotkeys-settings-tab.tsx
@@ -2,6 +2,7 @@ import { SettingsControlRow } from "@/components/settings/settings-control-row";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { SettingsTabLayout } from "@/components/settings/settings-tab-layout";
 import { Button } from "@/components/ui/button";
+import { Game } from "@/lib/game";
 import {
   HOTKEY_ACTIONS,
   HOTKEY_CATEGORY_KEYS,
@@ -112,6 +113,10 @@ export const HotkeysSettingsTab = () => {
             title={t(HOTKEY_CATEGORY_KEYS[category])}
           >
             {actions.map((config) => {
+              if (config.action === "map-ping" && Game.interface !== "ni") {
+                return null;
+              }
+
               const binding = bindings[config.action];
               const isCapturing = capturingAction === config.action;
 

--- a/apps/game-client/src/features/settings/components/sounds/sounds-settings-tab.test.tsx
+++ b/apps/game-client/src/features/settings/components/sounds/sounds-settings-tab.test.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SoundSettingsResponseDto } from "@/lib/api/generated/main/model";
 
-const { mockUpdateSettings, mockPlaySoundTest, mockSoundSettings } = vi.hoisted(
-  () => ({
+const { mockUpdateSettings, mockPlaySoundTest, mockSoundSettings, testState } =
+  vi.hoisted(() => ({
     mockUpdateSettings: vi.fn(),
     mockPlaySoundTest: vi.fn(),
     mockSoundSettings: {
@@ -19,8 +19,18 @@ const { mockUpdateSettings, mockPlaySoundTest, mockSoundSettings } = vi.hoisted(
       createdAt: "2024-01-01T00:00:00.000Z",
       updatedAt: "2024-01-01T00:00:00.000Z",
     } as SoundSettingsResponseDto,
-  }),
-);
+    testState: {
+      gameInterface: "ni" as "ni" | "si",
+    },
+  }));
+
+vi.mock("@/lib/game", () => ({
+  Game: {
+    get interface() {
+      return testState.gameInterface;
+    },
+  },
+}));
 
 vi.mock("@/components/settings/settings-section", () => ({
   SettingsSection: ({
@@ -100,6 +110,7 @@ describe("SoundsSettingsTab", () => {
   beforeEach(() => {
     mockUpdateSettings.mockReset();
     mockPlaySoundTest.mockReset();
+    testState.gameInterface = "ni";
   });
 
   it("renders translated settings copy instead of raw settings keys", () => {
@@ -121,5 +132,22 @@ describe("SoundsSettingsTab", () => {
     expect(
       screen.queryByText("settings.sounds.categories.notifications.label"),
     ).not.toBeInTheDocument();
+  });
+
+  it("hides map ping sound settings on the old interface", () => {
+    testState.gameInterface = "si";
+    render(<SoundsSettingsTab />);
+
+    expect(
+      screen.queryByRole("heading", { name: "Pingi na mapie" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows map ping sound settings on the new interface", () => {
+    render(<SoundsSettingsTab />);
+
+    expect(
+      screen.getByRole("heading", { name: "Pingi na mapie" }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/game-client/src/features/settings/components/sounds/sounds-settings-tab.tsx
+++ b/apps/game-client/src/features/settings/components/sounds/sounds-settings-tab.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/hooks/api/use-sound-settings";
 import { useSoundPlayback } from "@/hooks/use-sound-playback";
 import { normalizeSoundSettings } from "@/lib/api/generated-helpers";
+import { Game } from "@/lib/game";
 import type { SoundCategory } from "@/features/settings/components/sounds/types";
 import { Bell, Clock, Crosshair, Loader2, MapPin, Play } from "lucide-react";
 import { useEffect, useState, type FC, type ReactNode } from "react";
@@ -150,73 +151,75 @@ export const SoundsSettingsTab: FC = () => {
           }}
         />
 
-        <SettingsSection
-          title={t("sounds.categories.pings.label")}
-          description={t("sounds.categories.pings.description")}
-        >
-          <div className="ll:flex ll:items-center ll:gap-2">
-            <CategoryVolumeControl
-              icon=<MapPin className="ll:size-4" />
-              label={t("sounds.categories.pings.label")}
-              volume={localVolumes.pings}
-              isMuted={mutedCategories.pings || localVolumes.pings === 0}
-              onVolumeChange={(value) => {
-                setLocalVolumes((previous) => ({
-                  ...previous,
-                  pings: value[0],
-                }));
-                if (value[0] > 0) {
+        {Game.interface === "ni" ? (
+          <SettingsSection
+            title={t("sounds.categories.pings.label")}
+            description={t("sounds.categories.pings.description")}
+          >
+            <div className="ll:flex ll:items-center ll:gap-2">
+              <CategoryVolumeControl
+                icon=<MapPin className="ll:size-4" />
+                label={t("sounds.categories.pings.label")}
+                volume={localVolumes.pings}
+                isMuted={mutedCategories.pings || localVolumes.pings === 0}
+                onVolumeChange={(value) => {
+                  setLocalVolumes((previous) => ({
+                    ...previous,
+                    pings: value[0],
+                  }));
+                  if (value[0] > 0) {
+                    setMutedCategories((previous) => ({
+                      ...previous,
+                      pings: false,
+                    }));
+                  }
+                }}
+                onVolumeCommit={(value) =>
+                  updateSettings({ pingsVolume: value[0] })
+                }
+                onMuteToggle={(event) => {
+                  event.stopPropagation();
+                  const nextVolume =
+                    mutedCategories.pings || localVolumes.pings === 0 ? 0.5 : 0;
+                  setLocalVolumes((previous) => ({
+                    ...previous,
+                    pings: nextVolume,
+                  }));
                   setMutedCategories((previous) => ({
                     ...previous,
-                    pings: false,
+                    pings: nextVolume === 0,
                   }));
-                }
-              }}
-              onVolumeCommit={(value) =>
-                updateSettings({ pingsVolume: value[0] })
-              }
-              onMuteToggle={(event) => {
-                event.stopPropagation();
-                const nextVolume =
-                  mutedCategories.pings || localVolumes.pings === 0 ? 0.5 : 0;
-                setLocalVolumes((previous) => ({
-                  ...previous,
-                  pings: nextVolume,
-                }));
-                setMutedCategories((previous) => ({
-                  ...previous,
-                  pings: nextVolume === 0,
-                }));
-                updateSettings({ pingsVolume: nextVolume });
-              }}
-              onMuteKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                event.preventDefault();
-                event.stopPropagation();
-                const nextVolume =
-                  mutedCategories.pings || localVolumes.pings === 0 ? 0.5 : 0;
-                setLocalVolumes((previous) => ({
-                  ...previous,
-                  pings: nextVolume,
-                }));
-                setMutedCategories((previous) => ({
-                  ...previous,
-                  pings: nextVolume === 0,
-                }));
-                updateSettings({ pingsVolume: nextVolume });
-              }}
-            />
-            <Button
-              aria-label={t("sounds.test")}
-              className="ll:size-7 ll:p-0"
-              onClick={() => playSoundTest("pings", "mapPing")}
-              type="button"
-              variant="ghost"
-            >
-              <Play className="ll:size-4" />
-            </Button>
-          </div>
-        </SettingsSection>
+                  updateSettings({ pingsVolume: nextVolume });
+                }}
+                onMuteKeyDown={(event) => {
+                  if (event.key !== "Enter" && event.key !== " ") return;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  const nextVolume =
+                    mutedCategories.pings || localVolumes.pings === 0 ? 0.5 : 0;
+                  setLocalVolumes((previous) => ({
+                    ...previous,
+                    pings: nextVolume,
+                  }));
+                  setMutedCategories((previous) => ({
+                    ...previous,
+                    pings: nextVolume === 0,
+                  }));
+                  updateSettings({ pingsVolume: nextVolume });
+                }}
+              />
+              <Button
+                aria-label={t("sounds.test")}
+                className="ll:size-7 ll:p-0"
+                onClick={() => playSoundTest("pings", "mapPing")}
+                type="button"
+                variant="ghost"
+              >
+                <Play className="ll:size-4" />
+              </Button>
+            </div>
+          </SettingsSection>
+        ) : null}
 
         <SettingsSection
           title={t("sounds.categoriesTitle")}

--- a/apps/game-client/src/hooks/use-hotkeys.test.tsx
+++ b/apps/game-client/src/hooks/use-hotkeys.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useHotkeys } from "@/hooks/use-hotkeys";
 import { useHotkeysStore } from "@/store/hotkeys.store";
 import { useWindowsStore } from "@/store/windows.store";
@@ -60,5 +60,30 @@ describe("useHotkeys", () => {
     });
 
     expect(useWindowsStore.getState()["quick-access"].open).toBe(false);
+  });
+
+  it("triggers a map ping when a text input still has focus", () => {
+    const input = document.createElement("input");
+    const canvas = document.createElement("canvas");
+    canvas.id = "GAME_CANVAS";
+    document.body.append(input, canvas);
+    input.focus();
+    const onMapPing = vi.fn(() => true);
+    renderHook(() => useHotkeys({ onMapPing }));
+
+    const event = new MouseEvent("mousedown", {
+      bubbles: true,
+      button: 1,
+      cancelable: true,
+    });
+    act(() => {
+      canvas.dispatchEvent(event);
+    });
+
+    input.remove();
+    canvas.remove();
+
+    expect(onMapPing).toHaveBeenCalledOnce();
+    expect(event.defaultPrevented).toBe(true);
   });
 });

--- a/apps/game-client/src/hooks/use-hotkeys.tsx
+++ b/apps/game-client/src/hooks/use-hotkeys.tsx
@@ -127,8 +127,6 @@ export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
     };
 
     const handleMouseDown = (event: MouseEvent) => {
-      if (isEditableElementActive()) return;
-
       const matchingAction = Object.entries(bindings).find(
         ([action, binding]) =>
           binding.type === "mouse" &&
@@ -136,7 +134,11 @@ export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
           (hotkeyScopes.get(action as HotkeyAction) === "global" ||
             hotkeyScopes.get(action as HotkeyAction) === "map-surface"),
       );
-      if (!matchingAction || !executeAction(event)) {
+      if (
+        !matchingAction ||
+        (isEditableElementActive() && matchingAction[0] !== "map-ping") ||
+        !executeAction(event)
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Summary

- read the current map ping preference from the active account cache when sending and receiving pings
- prevent an initially disabled preference from permanently blocking deployed ping callbacks
- allow middle mouse pings while a text input retains focus
- limit map ping runtime and settings to Margonem NI
- preserve stored preferences and hotkey bindings for accounts also used on SI

## Release scope

This branch is based directly on `main` and contains one targeted commit. It applies only the final map ping fixes already validated on `develop`; unrelated unreleased `develop` commits and the temporary markdown spec are excluded.

## Root cause of the replaced PR

`main` already contained three map ping commits under different SHAs, while `develop` retained their patch-equivalent originals plus unrelated unreleased work. A direct `develop` to `main` PR therefore showed duplicate history and conflicts.

## Verification

- branch applies cleanly to current `main` with no conflict
- changed game-client files match their validated `develop` versions
- `pnpm turbo run test --filter=@lootlog/game-client --force` (137 files, 647 tests)
- `pnpm --dir apps/game-client build`
- pre-commit lint and formatting checks passed