### PR TITLE
feat(game-client): add contextual map pings

### DIFF
--- a/apps/game-client/src/App.tsx
+++ b/apps/game-client/src/App.tsx
@@ -1,40 +1,12 @@
-import { Timers } from "@/features/timers/timers";
-import { Settings } from "@/features/settings/settings";
-import { Chat } from "@/features/chat/chat";
-import { useGlobalStore } from "@/store/global.store";
-import { OnlinePlayers } from "@/features/online-players/online-players";
-import { AddTimer } from "@/features/timers/add-timer";
-import { NpcDetector } from "@/features/npc-detector/npc-detector";
-import { Notifications } from "@/features/notifications/notifications";
-import { QuickAccess } from "@/features/quick-access/quick-access";
-import { useHotkeys } from "@/hooks/use-hotkeys";
-import { Toaster } from "@/components/ui/toaster";
-import { useTimerSettingsSync } from "@/hooks/use-timer-settings-sync";
-import { useTimerSettingsMutationsRegistry } from "@/hooks/use-timer-settings-mutations-registry";
-import { CatchingWhitelistWarning } from "@/features/catching-whitelist-warning/catching-whitelist-warning";
-import { useGameEventHandlers } from "@/hooks/game-events/use-game-event-handlers";
-import { useInit } from "@/hooks/use-init";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
 import { storageKey } from "@/lib/storage-key";
 import { ThemeProvider } from "@/components/theme-provider";
-import { CommandWindow } from "./features/command/command";
 import { SocketProvider } from "@/contexts/socket-context";
 import { ErrorBoundary } from "react-error-boundary";
-import { PartyFinder } from "@/features/party-finder/party-finder";
-import { CreatePartyGathering } from "@/features/party-finder/create-party-gathering";
-import { useNotificationVolunteersSocket } from "@/features/party-finder/hooks/use-notification-volunteers-socket";
-import { usePartyGatheringSocket } from "@/features/party-finder/hooks/use-party-gathering-socket";
 import { bootstrapPublicApi } from "@/features/public-api";
-import { useGameAccountPreferencesSync } from "@/hooks/use-game-account-preferences-sync";
 import { AppErrorBoundaryFallback } from "@/features/error-boundary/app-error-boundary-fallback";
-import { BackendPreferencesWarning } from "@/features/backend-preferences-warning/backend-preferences-warning";
-import { AnimationEffectsRootClass } from "@/components/animation-effects-root-class";
-import { useMapPings } from "@/features/map-pings/use-map-pings";
-import { usePartyReadyRoomSocket } from "@/features/party-finder/hooks/use-party-ready-room-socket";
-import { usePartyReadyRoomSync } from "@/features/party-finder/hooks/use-party-ready-room-sync";
-import { usePartyReadyRoomExpiry } from "@/features/party-finder/hooks/use-party-ready-room-expiry";
-import { usePartyReadyRoomObserver } from "@/features/party-finder/hooks/use-party-ready-room-observer";
+import { AppContent } from "@/app-content";
 
 const THEME_STORAGE_KEY = storageKey("lootlog-theme");
 
@@ -47,47 +19,6 @@ if (lootlogApiWindow.__lootlogApiTeardown) {
   lootlogApiWindow.__lootlogApiTeardown();
 }
 lootlogApiWindow.__lootlogApiTeardown = bootstrapPublicApi(queryClient);
-
-function AppContent() {
-  useGameEventHandlers();
-  useInit();
-  useGameAccountPreferencesSync();
-  const triggerMapPing = useMapPings();
-  useHotkeys({ onMapPing: triggerMapPing });
-  useTimerSettingsMutationsRegistry();
-  useNotificationVolunteersSocket();
-  usePartyGatheringSocket();
-  usePartyReadyRoomSocket();
-  usePartyReadyRoomSync();
-  usePartyReadyRoomExpiry();
-  usePartyReadyRoomObserver();
-
-  const { ConflictDialog } = useTimerSettingsSync();
-  const gameInitialized = useGlobalStore((s) => s.gameState.gameInitialized);
-
-  return (
-    gameInitialized && (
-      <>
-        <AnimationEffectsRootClass />
-        <Timers />
-        <AddTimer />
-        <Settings />
-        <Chat />
-        <CommandWindow />
-        <OnlinePlayers />
-        <NpcDetector />
-        <Notifications />
-        <QuickAccess />
-        <CatchingWhitelistWarning />
-        <BackendPreferencesWarning />
-        <Toaster />
-        <PartyFinder />
-        <CreatePartyGathering />
-        {ConflictDialog}
-      </>
-    )
-  );
-}
 
 function App() {
   return (

--- a/apps/game-client/src/app-content.test.tsx
+++ b/apps/game-client/src/app-content.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import { AppContent } from "@/app-content";
+
+const mapPingHotkeyHandlers = vi.hoisted(() => ({
+  onMapPingCancel: vi.fn(),
+  onMapPingEnd: vi.fn(),
+  onMapPingStart: vi.fn(),
+}));
+const useHotkeys = vi.hoisted(() => vi.fn());
+
+vi.mock("@/features/map-pings/use-map-pings", () => ({
+  useMapPings: () => mapPingHotkeyHandlers,
+}));
+vi.mock("@/hooks/use-hotkeys", () => ({ useHotkeys }));
+vi.mock("@/features/map-pings/map-ping-wheel", () => ({
+  MapPingWheel: () => <div data-testid="map-ping-wheel" />,
+}));
+
+vi.mock("@/store/global.store", () => ({
+  useGlobalStore: (
+    selector: (state: { gameState: { gameInitialized: boolean } }) => unknown,
+  ) => selector({ gameState: { gameInitialized: true } }),
+}));
+vi.mock("@/hooks/use-timer-settings-sync", () => ({
+  useTimerSettingsSync: () => ({ ConflictDialog: null }),
+}));
+
+vi.mock("@/components/animation-effects-root-class", () => ({
+  AnimationEffectsRootClass: () => null,
+}));
+vi.mock("@/components/ui/toaster", () => ({ Toaster: () => null }));
+vi.mock(
+  "@/features/backend-preferences-warning/backend-preferences-warning",
+  () => ({ BackendPreferencesWarning: () => null }),
+);
+vi.mock(
+  "@/features/catching-whitelist-warning/catching-whitelist-warning",
+  () => ({ CatchingWhitelistWarning: () => null }),
+);
+vi.mock("@/features/chat/chat", () => ({ Chat: () => null }));
+vi.mock("@/features/command/command", () => ({
+  CommandWindow: () => null,
+}));
+vi.mock("@/features/notifications/notifications", () => ({
+  Notifications: () => null,
+}));
+vi.mock("@/features/npc-detector/npc-detector", () => ({
+  NpcDetector: () => null,
+}));
+vi.mock("@/features/online-players/online-players", () => ({
+  OnlinePlayers: () => null,
+}));
+vi.mock("@/features/party-finder/create-party-gathering", () => ({
+  CreatePartyGathering: () => null,
+}));
+vi.mock("@/features/party-finder/party-finder", () => ({
+  PartyFinder: () => null,
+}));
+vi.mock("@/features/quick-access/quick-access", () => ({
+  QuickAccess: () => null,
+}));
+vi.mock("@/features/settings/settings", () => ({ Settings: () => null }));
+vi.mock("@/features/timers/add-timer", () => ({ AddTimer: () => null }));
+vi.mock("@/features/timers/timers", () => ({ Timers: () => null }));
+
+vi.mock("@/hooks/game-events/use-game-event-handlers", () => ({
+  useGameEventHandlers: () => undefined,
+}));
+vi.mock("@/hooks/use-game-account-preferences-sync", () => ({
+  useGameAccountPreferencesSync: () => undefined,
+}));
+vi.mock("@/hooks/use-init", () => ({ useInit: () => undefined }));
+vi.mock("@/hooks/use-timer-settings-mutations-registry", () => ({
+  useTimerSettingsMutationsRegistry: () => undefined,
+}));
+vi.mock(
+  "@/features/party-finder/hooks/use-notification-volunteers-socket",
+  () => ({ useNotificationVolunteersSocket: () => undefined }),
+);
+vi.mock("@/features/party-finder/hooks/use-party-gathering-socket", () => ({
+  usePartyGatheringSocket: () => undefined,
+}));
+vi.mock("@/features/party-finder/hooks/use-party-ready-room-expiry", () => ({
+  usePartyReadyRoomExpiry: () => undefined,
+}));
+vi.mock("@/features/party-finder/hooks/use-party-ready-room-observer", () => ({
+  usePartyReadyRoomObserver: () => undefined,
+}));
+vi.mock("@/features/party-finder/hooks/use-party-ready-room-socket", () => ({
+  usePartyReadyRoomSocket: () => undefined,
+}));
+vi.mock("@/features/party-finder/hooks/use-party-ready-room-sync", () => ({
+  usePartyReadyRoomSync: () => undefined,
+}));
+
+describe("AppContent map ping integration", () => {
+  it("wires the map ping lifecycle into hotkeys and mounts the wheel", () => {
+    render(<AppContent />);
+
+    expect(useHotkeys).toHaveBeenCalledWith(mapPingHotkeyHandlers);
+    expect(screen.getByTestId("map-ping-wheel")).toBeInTheDocument();
+  });
+});

--- a/apps/game-client/src/app-content.tsx
+++ b/apps/game-client/src/app-content.tsx
@@ -1,0 +1,76 @@
+import { AddTimer } from "@/features/timers/add-timer";
+import { AnimationEffectsRootClass } from "@/components/animation-effects-root-class";
+import { BackendPreferencesWarning } from "@/features/backend-preferences-warning/backend-preferences-warning";
+import { CatchingWhitelistWarning } from "@/features/catching-whitelist-warning/catching-whitelist-warning";
+import { Chat } from "@/features/chat/chat";
+import { CommandWindow } from "@/features/command/command";
+import { CreatePartyGathering } from "@/features/party-finder/create-party-gathering";
+import { MapPingWheel } from "@/features/map-pings/map-ping-wheel";
+import { Notifications } from "@/features/notifications/notifications";
+import { NpcDetector } from "@/features/npc-detector/npc-detector";
+import { OnlinePlayers } from "@/features/online-players/online-players";
+import { PartyFinder } from "@/features/party-finder/party-finder";
+import { QuickAccess } from "@/features/quick-access/quick-access";
+import { Settings } from "@/features/settings/settings";
+import { Timers } from "@/features/timers/timers";
+import { Toaster } from "@/components/ui/toaster";
+import { useGameAccountPreferencesSync } from "@/hooks/use-game-account-preferences-sync";
+import { useGameEventHandlers } from "@/hooks/game-events/use-game-event-handlers";
+import { useGlobalStore } from "@/store/global.store";
+import { useHotkeys } from "@/hooks/use-hotkeys";
+import { useInit } from "@/hooks/use-init";
+import { useMapPings } from "@/features/map-pings/use-map-pings";
+import { useNotificationVolunteersSocket } from "@/features/party-finder/hooks/use-notification-volunteers-socket";
+import { usePartyGatheringSocket } from "@/features/party-finder/hooks/use-party-gathering-socket";
+import { usePartyReadyRoomExpiry } from "@/features/party-finder/hooks/use-party-ready-room-expiry";
+import { usePartyReadyRoomObserver } from "@/features/party-finder/hooks/use-party-ready-room-observer";
+import { usePartyReadyRoomSocket } from "@/features/party-finder/hooks/use-party-ready-room-socket";
+import { usePartyReadyRoomSync } from "@/features/party-finder/hooks/use-party-ready-room-sync";
+import { useTimerSettingsMutationsRegistry } from "@/hooks/use-timer-settings-mutations-registry";
+import { useTimerSettingsSync } from "@/hooks/use-timer-settings-sync";
+
+export const AppContent = () => {
+  useGameEventHandlers();
+  useInit();
+  useGameAccountPreferencesSync();
+  const mapPingHotkeyHandlers = useMapPings();
+  useHotkeys(mapPingHotkeyHandlers);
+  useTimerSettingsMutationsRegistry();
+  useNotificationVolunteersSocket();
+  usePartyGatheringSocket();
+  usePartyReadyRoomSocket();
+  usePartyReadyRoomSync();
+  usePartyReadyRoomExpiry();
+  usePartyReadyRoomObserver();
+
+  const { ConflictDialog } = useTimerSettingsSync();
+  const gameInitialized = useGlobalStore((state) =>
+    Boolean(state.gameState.gameInitialized),
+  );
+
+  if (!gameInitialized) {
+    return null;
+  }
+
+  return (
+    <>
+      <AnimationEffectsRootClass />
+      <Timers />
+      <AddTimer />
+      <Settings />
+      <Chat />
+      <CommandWindow />
+      <OnlinePlayers />
+      <NpcDetector />
+      <Notifications />
+      <QuickAccess />
+      <CatchingWhitelistWarning />
+      <BackendPreferencesWarning />
+      <Toaster />
+      <PartyFinder />
+      <CreatePartyGathering />
+      <MapPingWheel />
+      {ConflictDialog}
+    </>
+  );
+};

--- a/apps/game-client/src/features/map-pings/map-ping-controller.test.ts
+++ b/apps/game-client/src/features/map-pings/map-ping-controller.test.ts
@@ -116,6 +116,7 @@ describe("map ping coordinates", () => {
       pingId: "ping-1",
       world: "aether",
       mapId: 42,
+      type: "attention" as const,
       x: 10,
       y: 20,
       sender: { characterId: "123", name: "Sender" },
@@ -123,8 +124,8 @@ describe("map ping coordinates", () => {
     };
 
     expect(controller.register()).toBe(true);
-    expect(controller.addRemote(event)).toBe(true);
-    expect(controller.addRemote(event)).toBe(false);
+    expect(controller.addRemote(event, "Uwaga")).toBe(true);
+    expect(controller.addRemote(event, "Uwaga")).toBe(false);
     drawFrame();
     expect(renderer.add).toHaveBeenCalledTimes(1);
 

--- a/apps/game-client/src/features/map-pings/map-ping-controller.ts
+++ b/apps/game-client/src/features/map-pings/map-ping-controller.ts
@@ -1,10 +1,12 @@
-import type { MapPingEvent } from "@lootlog/types";
+import type { MapPingEvent, MapPingType } from "@lootlog/types";
+import {
+  getMapPingPresentation,
+  type MapPingSymbol,
+} from "./map-ping-presentation";
 
-export const MAP_PING_DURATION_MS = 2_500;
 const MAIN_MAP_CANVAS_ID = "GAME_CANVAS";
 const HANDHELD_MINI_MAP_CANVAS_CLASS = "handheld-mini-map-canvas";
 const DEFAULT_TILE_SIZE = 32;
-const PING_COLOR = "#f59e0b";
 const MAX_NETWORK_COORDINATE = 65_535;
 
 export type MapTile = { x: number; y: number };
@@ -59,6 +61,8 @@ type ActiveMapPing = {
   y: number;
   senderName: string;
   startedAt: number;
+  type: MapPingType;
+  typeLabel: string;
 };
 
 type MainMapGeometry = {
@@ -197,7 +201,13 @@ export class MapPingController {
     this.clear();
   }
 
-  addOptimistic(tile: MapTile, mapId: number, senderName: string) {
+  addOptimistic(
+    tile: MapTile,
+    mapId: number,
+    senderName: string,
+    type: MapPingType,
+    typeLabel: string,
+  ) {
     const id = `local-${crypto.randomUUID()}`;
     this.activePings.set(id, {
       id,
@@ -206,11 +216,13 @@ export class MapPingController {
       y: tile.y,
       senderName,
       startedAt: this.now(),
+      type,
+      typeLabel,
     });
     return id;
   }
 
-  addRemote(event: MapPingEvent) {
+  addRemote(event: MapPingEvent, typeLabel: string) {
     if (this.activePings.has(event.pingId)) {
       return false;
     }
@@ -222,6 +234,8 @@ export class MapPingController {
       y: event.y,
       senderName: event.sender.name,
       startedAt: this.now(),
+      type: event.type,
+      typeLabel,
     });
     return true;
   }
@@ -349,30 +363,88 @@ export class MapPingController {
     showSender: boolean,
   ) {
     const elapsed = this.now() - ping.startedAt;
-    const progress = Math.min(1, elapsed / MAP_PING_DURATION_MS);
+    const presentation = getMapPingPresentation(ping.type);
+    const progress = Math.min(1, elapsed / presentation.durationMs);
     const pulse = 1 + Math.sin(elapsed / 120) * 0.18;
 
     context.save();
     context.globalAlpha = 1 - progress;
-    context.strokeStyle = PING_COLOR;
-    context.fillStyle = PING_COLOR;
+    context.strokeStyle = presentation.color;
+    context.fillStyle = presentation.color;
     context.lineWidth = 2;
     context.beginPath();
     context.arc(x, y, baseRadius * pulse, 0, Math.PI * 2);
     context.stroke();
-    context.beginPath();
-    context.arc(x, y, 3, 0, Math.PI * 2);
-    context.fill();
+    this.drawSymbol(
+      context,
+      presentation.symbol,
+      x,
+      y,
+      Math.max(4, baseRadius * 0.55),
+    );
 
     if (showSender) {
-      context.font = "bold 11px Arial";
       context.textAlign = "center";
       context.textBaseline = "bottom";
       context.lineWidth = 3;
       context.strokeStyle = "rgba(0, 0, 0, 0.85)";
-      context.strokeText(ping.senderName, x, y - baseRadius - 5);
-      context.fillStyle = "#fff7d6";
-      context.fillText(ping.senderName, x, y - baseRadius - 5);
+      context.font = "bold 10px Arial";
+      context.strokeText(ping.typeLabel, x, y - baseRadius - 17);
+      context.fillStyle = presentation.color;
+      context.fillText(ping.typeLabel, x, y - baseRadius - 17);
+      context.font = "bold 11px Arial";
+      context.strokeText(ping.senderName, x, y - baseRadius - 4);
+      context.fillStyle = "#ffffff";
+      context.fillText(ping.senderName, x, y - baseRadius - 4);
+    }
+
+    context.restore();
+  }
+
+  private drawSymbol(
+    context: CanvasRenderingContext2D,
+    symbol: MapPingSymbol,
+    x: number,
+    y: number,
+    size: number,
+  ) {
+    context.save();
+    context.strokeStyle = "#ffffff";
+    context.fillStyle = "#ffffff";
+    context.lineCap = "round";
+    context.lineWidth = Math.max(1.5, size * 0.22);
+
+    if (symbol === "exclamation") {
+      context.font = `bold ${Math.max(10, size * 2)}px Arial`;
+      context.textAlign = "center";
+      context.textBaseline = "middle";
+      context.fillText("!", x, y + 1);
+    } else if (symbol === "crosshair") {
+      const radius = size * 0.62;
+      context.beginPath();
+      context.arc(x, y, radius, 0, Math.PI * 2);
+      context.moveTo(x - size, y);
+      context.lineTo(x - radius * 0.45, y);
+      context.moveTo(x + radius * 0.45, y);
+      context.lineTo(x + size, y);
+      context.moveTo(x, y - size);
+      context.lineTo(x, y - radius * 0.45);
+      context.moveTo(x, y + radius * 0.45);
+      context.lineTo(x, y + size);
+      context.stroke();
+    } else if (symbol === "regroup") {
+      context.beginPath();
+      context.arc(x, y, size * 0.72, 0, Math.PI * 2);
+      context.arc(x, y, size * 0.3, 0, Math.PI * 2);
+      context.stroke();
+    } else {
+      const extent = size * 0.72;
+      context.beginPath();
+      context.moveTo(x - extent, y - extent);
+      context.lineTo(x + extent, y + extent);
+      context.moveTo(x + extent, y - extent);
+      context.lineTo(x - extent, y + extent);
+      context.stroke();
     }
 
     context.restore();
@@ -381,7 +453,8 @@ export class MapPingController {
   private pruneExpired() {
     const now = this.now();
     for (const [id, ping] of this.activePings) {
-      if (now - ping.startedAt >= MAP_PING_DURATION_MS) {
+      const durationMs = getMapPingPresentation(ping.type).durationMs;
+      if (now - ping.startedAt >= durationMs) {
         this.activePings.delete(id);
       }
     }

--- a/apps/game-client/src/features/map-pings/map-ping-interaction-controller.test.ts
+++ b/apps/game-client/src/features/map-pings/map-ping-interaction-controller.test.ts
@@ -1,0 +1,149 @@
+import {
+  MAP_PING_HOLD_DELAY_MS,
+  MAP_PING_WHEEL_DEAD_ZONE_PX,
+  MapPingInteractionController,
+  clampMapPingWheelCenter,
+  resolveMapPingTypeFromPointer,
+  type MapPingPressIdentity,
+} from "./map-ping-interaction-controller";
+
+const mouseIdentity = (button = 1): MapPingPressIdentity => ({
+  kind: "mouse",
+  button,
+});
+
+const startInteraction = (
+  controller: MapPingInteractionController,
+  identity = mouseIdentity(),
+) =>
+  controller.begin({
+    identity,
+    mapId: 42,
+    origin: { x: 100, y: 100 },
+    tile: { x: 12, y: 8 },
+  });
+
+describe("MapPingInteractionController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns an attention submission for a tap", () => {
+    const controller = new MapPingInteractionController();
+
+    expect(startInteraction(controller)).toBe(true);
+    expect(controller.complete(mouseIdentity())).toEqual({
+      mapId: 42,
+      tile: { x: 12, y: 8 },
+      type: "attention",
+    });
+    expect(controller.isActive()).toBe(false);
+    expect(controller.getSnapshot()).toBeNull();
+  });
+
+  it("opens the wheel after the hold delay with a stable snapshot", () => {
+    const controller = new MapPingInteractionController({
+      getViewport: () => ({ height: 600, width: 800 }),
+    });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    startInteraction(controller);
+    expect(controller.getSnapshot()).toBeNull();
+
+    vi.advanceTimersByTime(MAP_PING_HOLD_DELAY_MS);
+
+    const snapshot = controller.getSnapshot();
+    expect(snapshot).toEqual({
+      selectedType: null,
+      visualCenter: { x: 100, y: 100 },
+    });
+    expect(controller.getSnapshot()).toBe(snapshot);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["attention", { x: 100, y: 60 }],
+    ["enemy", { x: 140, y: 100 }],
+    ["avoid", { x: 100, y: 140 }],
+    ["regroup", { x: 60, y: 100 }],
+  ] as const)("submits the %s wheel segment", (type, pointer) => {
+    const controller = new MapPingInteractionController();
+    startInteraction(controller);
+    vi.advanceTimersByTime(MAP_PING_HOLD_DELAY_MS);
+
+    controller.updatePointer(pointer);
+
+    expect(controller.getSnapshot()?.selectedType).toBe(type);
+    expect(controller.complete(mouseIdentity())).toEqual({
+      mapId: 42,
+      tile: { x: 12, y: 8 },
+      type,
+    });
+  });
+
+  it("leaves state unchanged for an identity mismatch and cancels a dead-zone completion", () => {
+    const controller = new MapPingInteractionController();
+    startInteraction(controller);
+
+    expect(controller.complete(mouseIdentity(3))).toBeNull();
+    expect(controller.isActive()).toBe(true);
+
+    vi.advanceTimersByTime(MAP_PING_HOLD_DELAY_MS);
+    expect(controller.complete(mouseIdentity())).toBeNull();
+    expect(controller.isActive()).toBe(false);
+  });
+
+  it("rejects a duplicate interaction until the current one is cancelled", () => {
+    const controller = new MapPingInteractionController();
+
+    expect(startInteraction(controller)).toBe(true);
+    expect(startInteraction(controller, mouseIdentity(3))).toBe(false);
+    controller.cancel();
+    expect(startInteraction(controller, mouseIdentity(3))).toBe(true);
+  });
+});
+
+describe("map ping wheel geometry", () => {
+  it.each([
+    ["attention", -135],
+    ["attention", -90],
+    ["enemy", -45],
+    ["enemy", 0],
+    ["avoid", 45],
+    ["avoid", 90],
+    ["regroup", 135],
+    ["regroup", 180],
+  ] as const)("maps the %s segment boundary at %s degrees", (type, angle) => {
+    const radians = (angle * Math.PI) / 180;
+    const origin = { x: 100, y: 100 };
+    const pointer = {
+      x: origin.x + Math.cos(radians) * 40,
+      y: origin.y + Math.sin(radians) * 40,
+    };
+
+    expect(resolveMapPingTypeFromPointer(origin, pointer)).toBe(type);
+  });
+
+  it("keeps the dead-zone boundary unselected", () => {
+    expect(
+      resolveMapPingTypeFromPointer(
+        { x: 100, y: 100 },
+        { x: 100 + MAP_PING_WHEEL_DEAD_ZONE_PX, y: 100 },
+      ),
+    ).toBeNull();
+  });
+
+  it("clamps the visual centre independently on normal and tiny viewports", () => {
+    expect(
+      clampMapPingWheelCenter({ x: 10, y: 590 }, { width: 800, height: 600 }),
+    ).toEqual({ x: 100, y: 500 });
+    expect(
+      clampMapPingWheelCenter({ x: 10, y: 20 }, { width: 160, height: 180 }),
+    ).toEqual({ x: 80, y: 90 });
+  });
+});

--- a/apps/game-client/src/features/map-pings/map-ping-interaction-controller.ts
+++ b/apps/game-client/src/features/map-pings/map-ping-interaction-controller.ts
@@ -1,0 +1,277 @@
+import type { MapPingType } from "@lootlog/types";
+import type { MapTile } from "./map-ping-controller";
+
+export const MAP_PING_HOLD_DELAY_MS = 300;
+export const MAP_PING_WHEEL_RADIUS_PX = 88;
+export const MAP_PING_WHEEL_DEAD_ZONE_PX = 24;
+export const MAP_PING_WHEEL_MARGIN_PX = 12;
+
+export type ClientPoint = {
+  x: number;
+  y: number;
+};
+
+export type MapPingPressIdentity =
+  | { kind: "keyboard"; code: string }
+  | { kind: "mouse"; button: number };
+
+export type MapPingInteractionStart = {
+  identity: MapPingPressIdentity;
+  mapId: number;
+  origin: ClientPoint;
+  tile: MapTile;
+};
+
+export type MapPingSubmission = {
+  mapId: number;
+  tile: MapTile;
+  type: MapPingType;
+};
+
+export type MapPingWheelSnapshot = {
+  selectedType: MapPingType | null;
+  visualCenter: ClientPoint;
+};
+
+type ViewportSize = {
+  height: number;
+  width: number;
+};
+
+type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
+
+type ControllerDependencies = {
+  clearTimer: (timer: TimerHandle) => void;
+  getViewport: () => ViewportSize;
+  setTimer: (callback: () => void, delayMs: number) => TimerHandle;
+};
+
+type InteractionState = {
+  identity: MapPingPressIdentity;
+  mapId: number;
+  origin: ClientPoint;
+  phase: "pending" | "wheel-open";
+  selectedType: MapPingType | null;
+  tile: MapTile;
+  timer: TimerHandle | null;
+  visualCenter: ClientPoint | null;
+};
+
+const defaultDependencies: ControllerDependencies = {
+  clearTimer: (timer) => globalThis.clearTimeout(timer),
+  getViewport: () => ({ height: window.innerHeight, width: window.innerWidth }),
+  setTimer: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+};
+
+export const createMapPingPressIdentity = (
+  event: KeyboardEvent | MouseEvent,
+): MapPingPressIdentity => {
+  if (event instanceof KeyboardEvent) {
+    return { kind: "keyboard", code: event.code };
+  }
+
+  return { kind: "mouse", button: event.button };
+};
+
+export const isSameMapPingPressIdentity = (
+  first: MapPingPressIdentity,
+  second: MapPingPressIdentity,
+) => {
+  if (first.kind !== second.kind) {
+    return false;
+  }
+
+  if (first.kind === "keyboard" && second.kind === "keyboard") {
+    return first.code === second.code;
+  }
+
+  return (
+    first.kind === "mouse" &&
+    second.kind === "mouse" &&
+    first.button === second.button
+  );
+};
+
+export const clampMapPingWheelCenter = (
+  origin: ClientPoint,
+  viewport: ViewportSize,
+): ClientPoint => {
+  const minimumCenter = MAP_PING_WHEEL_RADIUS_PX + MAP_PING_WHEEL_MARGIN_PX;
+  const clampAxis = (coordinate: number, viewportSize: number) => {
+    if (viewportSize < minimumCenter * 2) {
+      return viewportSize / 2;
+    }
+
+    return Math.min(
+      Math.max(coordinate, minimumCenter),
+      viewportSize - minimumCenter,
+    );
+  };
+
+  return {
+    x: clampAxis(origin.x, viewport.width),
+    y: clampAxis(origin.y, viewport.height),
+  };
+};
+
+export const resolveMapPingTypeFromPointer = (
+  origin: ClientPoint,
+  pointer: ClientPoint,
+): MapPingType | null => {
+  const deltaX = pointer.x - origin.x;
+  const deltaY = pointer.y - origin.y;
+  if (Math.hypot(deltaX, deltaY) <= MAP_PING_WHEEL_DEAD_ZONE_PX) {
+    return null;
+  }
+
+  const angle = (Math.atan2(deltaY, deltaX) * 180) / Math.PI;
+  if (angle >= -135 && angle < -45) {
+    return "attention";
+  }
+  if (angle >= -45 && angle < 45) {
+    return "enemy";
+  }
+  if (angle >= 45 && angle < 135) {
+    return "avoid";
+  }
+
+  return "regroup";
+};
+
+export class MapPingInteractionController {
+  private readonly dependencies: ControllerDependencies;
+  private readonly listeners = new Set<() => void>();
+  private snapshot: MapPingWheelSnapshot | null = null;
+  private state: InteractionState | null = null;
+
+  constructor(dependencies: Partial<ControllerDependencies> = {}) {
+    this.dependencies = { ...defaultDependencies, ...dependencies };
+  }
+
+  begin(input: MapPingInteractionStart): boolean {
+    if (this.state) {
+      return false;
+    }
+
+    const timer = this.dependencies.setTimer(
+      () => this.openWheel(input.identity),
+      MAP_PING_HOLD_DELAY_MS,
+    );
+    this.state = {
+      ...input,
+      phase: "pending",
+      selectedType: null,
+      timer,
+      visualCenter: null,
+    };
+    return true;
+  }
+
+  updatePointer(position: ClientPoint): void {
+    if (!this.state || this.state.phase !== "wheel-open") {
+      return;
+    }
+
+    const visualCenter = this.state.visualCenter;
+    if (!visualCenter) {
+      return;
+    }
+
+    const selectedType = resolveMapPingTypeFromPointer(
+      this.state.origin,
+      position,
+    );
+    if (selectedType === this.state.selectedType) {
+      return;
+    }
+
+    this.state = { ...this.state, selectedType };
+    this.setSnapshot({
+      selectedType,
+      visualCenter,
+    });
+  }
+
+  complete(identity: MapPingPressIdentity): MapPingSubmission | null {
+    const state = this.state;
+    if (!state || !isSameMapPingPressIdentity(state.identity, identity)) {
+      return null;
+    }
+
+    this.reset();
+    if (state.phase === "pending") {
+      return { mapId: state.mapId, tile: state.tile, type: "attention" };
+    }
+    if (!state.selectedType) {
+      return null;
+    }
+
+    return {
+      mapId: state.mapId,
+      tile: state.tile,
+      type: state.selectedType,
+    };
+  }
+
+  cancel(): void {
+    this.reset();
+  }
+
+  isActive(): boolean {
+    return this.state !== null;
+  }
+
+  readonly getSnapshot = (): MapPingWheelSnapshot | null => this.snapshot;
+
+  readonly subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  private openWheel(identity: MapPingPressIdentity): void {
+    if (
+      !this.state ||
+      this.state.phase !== "pending" ||
+      !isSameMapPingPressIdentity(this.state.identity, identity)
+    ) {
+      return;
+    }
+
+    const visualCenter = clampMapPingWheelCenter(
+      this.state.origin,
+      this.dependencies.getViewport(),
+    );
+    this.state = {
+      ...this.state,
+      phase: "wheel-open",
+      timer: null,
+      visualCenter,
+    };
+    this.setSnapshot({ selectedType: null, visualCenter });
+  }
+
+  private reset(): void {
+    if (!this.state) {
+      return;
+    }
+
+    if (this.state.timer) {
+      this.dependencies.clearTimer(this.state.timer);
+    }
+    this.state = null;
+    this.setSnapshot(null);
+  }
+
+  private setSnapshot(snapshot: MapPingWheelSnapshot | null): void {
+    if (this.snapshot === snapshot) {
+      return;
+    }
+
+    this.snapshot = snapshot;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+export const mapPingInteractionController = new MapPingInteractionController();

--- a/apps/game-client/src/features/map-pings/map-ping-presentation.ts
+++ b/apps/game-client/src/features/map-pings/map-ping-presentation.ts
@@ -1,0 +1,56 @@
+import type { MapPingType } from "@lootlog/types";
+
+export type MapPingSymbol = "exclamation" | "crosshair" | "regroup" | "avoid";
+
+type MapPingPresentation = {
+  color: string;
+  durationMs: number;
+  sound: {
+    key: "mapPing";
+    playbackRate: number;
+    preservesPitch: false;
+  };
+  symbol: MapPingSymbol;
+  translationKey: `mapPings.types.${MapPingType}`;
+};
+
+export const MAP_PING_PRESENTATION = {
+  attention: {
+    color: "#f59e0b",
+    durationMs: 2_500,
+    sound: { key: "mapPing", playbackRate: 1, preservesPitch: false },
+    symbol: "exclamation",
+    translationKey: "mapPings.types.attention",
+  },
+  enemy: {
+    color: "#ef4444",
+    durationMs: 4_000,
+    sound: { key: "mapPing", playbackRate: 1.35, preservesPitch: false },
+    symbol: "crosshair",
+    translationKey: "mapPings.types.enemy",
+  },
+  regroup: {
+    color: "#3b82f6",
+    durationMs: 5_000,
+    sound: { key: "mapPing", playbackRate: 0.82, preservesPitch: false },
+    symbol: "regroup",
+    translationKey: "mapPings.types.regroup",
+  },
+  avoid: {
+    color: "#a855f7",
+    durationMs: 5_000,
+    sound: { key: "mapPing", playbackRate: 0.62, preservesPitch: false },
+    symbol: "avoid",
+    translationKey: "mapPings.types.avoid",
+  },
+} as const satisfies Record<MapPingType, MapPingPresentation>;
+
+export const MAP_PING_WHEEL_SEGMENTS = [
+  { type: "attention", angle: -90 },
+  { type: "enemy", angle: 0 },
+  { type: "avoid", angle: 90 },
+  { type: "regroup", angle: 180 },
+] as const satisfies ReadonlyArray<{ type: MapPingType; angle: number }>;
+
+export const getMapPingPresentation = (type: MapPingType) =>
+  MAP_PING_PRESENTATION[type];

--- a/apps/game-client/src/features/map-pings/map-ping-wheel.test.tsx
+++ b/apps/game-client/src/features/map-pings/map-ping-wheel.test.tsx
@@ -1,0 +1,53 @@
+import { act, render, screen } from "@testing-library/react";
+import { MapPingWheel } from "./map-ping-wheel";
+import {
+  MAP_PING_HOLD_DELAY_MS,
+  mapPingInteractionController,
+} from "./map-ping-interaction-controller";
+
+describe("MapPingWheel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mapPingInteractionController.cancel();
+  });
+
+  afterEach(() => {
+    mapPingInteractionController.cancel();
+    vi.useRealTimers();
+  });
+
+  it("renders the clamped wheel and highlights the selected translated type", () => {
+    mapPingInteractionController.begin({
+      identity: { kind: "mouse", button: 1 },
+      mapId: 42,
+      origin: { x: 200, y: 200 },
+      tile: { x: 12, y: 8 },
+    });
+    vi.advanceTimersByTime(MAP_PING_HOLD_DELAY_MS);
+
+    render(<MapPingWheel />);
+
+    const wheel = screen.getByRole("status");
+    expect(wheel).toHaveStyle({
+      left: "112px",
+      pointerEvents: "none",
+      top: "112px",
+    });
+    expect(screen.getByText("Anuluj")).toBeInTheDocument();
+
+    act(() => {
+      mapPingInteractionController.updatePointer({ x: 240, y: 200 });
+    });
+
+    expect(screen.getByText("Wróg")).toBeInTheDocument();
+    expect(screen.getByTestId("map-ping-segment-enemy")).toHaveAttribute(
+      "data-selected",
+      "true",
+    );
+
+    act(() => {
+      mapPingInteractionController.cancel();
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/apps/game-client/src/features/map-pings/map-ping-wheel.tsx
+++ b/apps/game-client/src/features/map-pings/map-ping-wheel.tsx
@@ -1,0 +1,174 @@
+import { useSyncExternalStore } from "react";
+import { useTranslation } from "react-i18next";
+import type { MapPingType } from "@lootlog/types";
+import {
+  MAP_PING_WHEEL_RADIUS_PX,
+  mapPingInteractionController,
+} from "./map-ping-interaction-controller";
+import {
+  getMapPingPresentation,
+  MAP_PING_WHEEL_SEGMENTS,
+} from "./map-ping-presentation";
+
+const WHEEL_SIZE_PX = MAP_PING_WHEEL_RADIUS_PX * 2;
+const WHEEL_CENTER_PX = MAP_PING_WHEEL_RADIUS_PX;
+const WHEEL_INNER_RADIUS_PX = 24;
+const SYMBOL_DISTANCE_PX = 56;
+const SYMBOL_SIZE_PX = 9;
+
+const getPointOnWheel = (radius: number, angle: number) => {
+  const radians = (angle * Math.PI) / 180;
+  return {
+    x: WHEEL_CENTER_PX + Math.cos(radians) * radius,
+    y: WHEEL_CENTER_PX + Math.sin(radians) * radius,
+  };
+};
+
+const getSegmentPath = (centerAngle: number) => {
+  const outerStart = getPointOnWheel(
+    MAP_PING_WHEEL_RADIUS_PX,
+    centerAngle - 45,
+  );
+  const outerEnd = getPointOnWheel(MAP_PING_WHEEL_RADIUS_PX, centerAngle + 45);
+  const innerEnd = getPointOnWheel(WHEEL_INNER_RADIUS_PX, centerAngle + 45);
+  const innerStart = getPointOnWheel(WHEEL_INNER_RADIUS_PX, centerAngle - 45);
+
+  return [
+    `M ${outerStart.x} ${outerStart.y}`,
+    `A ${MAP_PING_WHEEL_RADIUS_PX} ${MAP_PING_WHEEL_RADIUS_PX} 0 0 1 ${outerEnd.x} ${outerEnd.y}`,
+    `L ${innerEnd.x} ${innerEnd.y}`,
+    `A ${WHEEL_INNER_RADIUS_PX} ${WHEEL_INNER_RADIUS_PX} 0 0 0 ${innerStart.x} ${innerStart.y}`,
+    "Z",
+  ].join(" ");
+};
+
+const getTypeTranslationKey = (type: MapPingType) =>
+  getMapPingPresentation(type).translationKey;
+
+export const MapPingWheel = () => {
+  const snapshot = useSyncExternalStore(
+    mapPingInteractionController.subscribe,
+    mapPingInteractionController.getSnapshot,
+  );
+  const { t } = useTranslation("settings");
+
+  if (!snapshot) {
+    return null;
+  }
+
+  const selectedLabel = snapshot.selectedType
+    ? t(getTypeTranslationKey(snapshot.selectedType))
+    : t("mapPings.wheel.cancelHint");
+
+  return (
+    <div
+      aria-label={t("mapPings.wheel.ariaLabel", {
+        selection: selectedLabel,
+      })}
+      aria-live="polite"
+      className="ll:fixed ll:h-[176px] ll:w-[176px] ll:select-none ll:animate-in ll:fade-in-0 ll:zoom-in-95 ll:duration-100"
+      role="status"
+      style={{
+        left: snapshot.visualCenter.x - MAP_PING_WHEEL_RADIUS_PX,
+        pointerEvents: "none",
+        top: snapshot.visualCenter.y - MAP_PING_WHEEL_RADIUS_PX,
+        zIndex: 2_147_483_000,
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        className="ll:h-full ll:w-full ll:overflow-visible ll:drop-shadow-[0_8px_20px_rgba(0,0,0,0.65)]"
+        viewBox={`0 0 ${WHEEL_SIZE_PX} ${WHEEL_SIZE_PX}`}
+      >
+        {MAP_PING_WHEEL_SEGMENTS.map(({ angle, type }) => {
+          const presentation = getMapPingPresentation(type);
+          const selected = snapshot.selectedType === type;
+          const symbolPoint = getPointOnWheel(SYMBOL_DISTANCE_PX, angle);
+
+          return (
+            <g
+              data-selected={selected ? "true" : "false"}
+              data-testid={`map-ping-segment-${type}`}
+              key={type}
+              style={{
+                transform: selected ? "scale(1.08)" : "scale(1)",
+                transformOrigin: `${WHEEL_CENTER_PX}px ${WHEEL_CENTER_PX}px`,
+                transition: "opacity 100ms ease, transform 100ms ease",
+              }}
+            >
+              <path
+                d={getSegmentPath(angle)}
+                fill={presentation.color}
+                fillOpacity={selected ? 1 : 0.7}
+                stroke={selected ? "#ffffff" : "rgba(0, 0, 0, 0.7)"}
+                strokeWidth={selected ? 2 : 1}
+              />
+              <g
+                fill="none"
+                stroke="#ffffff"
+                strokeLinecap="round"
+                strokeWidth="3"
+              >
+                {type === "attention" ? (
+                  <text
+                    fill="#ffffff"
+                    fontFamily="Arial"
+                    fontSize="22"
+                    fontWeight="700"
+                    stroke="none"
+                    textAnchor="middle"
+                    x={symbolPoint.x}
+                    y={symbolPoint.y + 7}
+                  >
+                    !
+                  </text>
+                ) : null}
+                {type === "enemy" ? (
+                  <>
+                    <circle
+                      cx={symbolPoint.x}
+                      cy={symbolPoint.y}
+                      r={SYMBOL_SIZE_PX - 3}
+                    />
+                    <path
+                      d={`M ${symbolPoint.x - SYMBOL_SIZE_PX} ${symbolPoint.y} H ${symbolPoint.x + SYMBOL_SIZE_PX} M ${symbolPoint.x} ${symbolPoint.y - SYMBOL_SIZE_PX} V ${symbolPoint.y + SYMBOL_SIZE_PX}`}
+                    />
+                  </>
+                ) : null}
+                {type === "regroup" ? (
+                  <>
+                    <circle
+                      cx={symbolPoint.x}
+                      cy={symbolPoint.y}
+                      r={SYMBOL_SIZE_PX}
+                    />
+                    <circle
+                      cx={symbolPoint.x}
+                      cy={symbolPoint.y}
+                      r={SYMBOL_SIZE_PX / 2}
+                    />
+                  </>
+                ) : null}
+                {type === "avoid" ? (
+                  <path
+                    d={`M ${symbolPoint.x - SYMBOL_SIZE_PX} ${symbolPoint.y - SYMBOL_SIZE_PX} L ${symbolPoint.x + SYMBOL_SIZE_PX} ${symbolPoint.y + SYMBOL_SIZE_PX} M ${symbolPoint.x + SYMBOL_SIZE_PX} ${symbolPoint.y - SYMBOL_SIZE_PX} L ${symbolPoint.x - SYMBOL_SIZE_PX} ${symbolPoint.y + SYMBOL_SIZE_PX}`}
+                  />
+                ) : null}
+              </g>
+            </g>
+          );
+        })}
+        <circle
+          cx={WHEEL_CENTER_PX}
+          cy={WHEEL_CENTER_PX}
+          fill="rgba(9, 9, 11, 0.94)"
+          r={WHEEL_INNER_RADIUS_PX}
+          stroke="rgba(255, 255, 255, 0.35)"
+        />
+      </svg>
+      <div className="ll:absolute ll:left-1/2 ll:top-1/2 ll:flex ll:h-12 ll:w-12 ll:-translate-x-1/2 ll:-translate-y-1/2 ll:items-center ll:justify-center ll:px-1 ll:text-center ll:text-[8px] ll:font-bold ll:leading-tight ll:text-white">
+        {selectedLabel}
+      </div>
+    </div>
+  );
+};

--- a/apps/game-client/src/features/map-pings/use-map-pings.test.tsx
+++ b/apps/game-client/src/features/map-pings/use-map-pings.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import type { MapPingAck, MapPingEvent } from "@lootlog/types";
+import type { MapPingAck, MapPingEvent, MapPingType } from "@lootlog/types";
 import { GatewayEvent } from "@/config/gateway";
 import { useMapPings } from "./use-map-pings";
 
@@ -27,6 +27,16 @@ const controller = vi.hoisted(() => ({
   remove: vi.fn(),
   resolveTile: vi.fn(() => ({ x: 12, y: 8 })),
   unregister: vi.fn(),
+}));
+const interactionController = vi.hoisted(() => ({
+  begin: vi.fn(() => true),
+  cancel: vi.fn(),
+  complete: vi.fn(() => ({
+    mapId: 42,
+    tile: { x: 12, y: 8 },
+    type: "attention" as MapPingType,
+  })),
+  updatePointer: vi.fn(),
 }));
 const playSound = vi.hoisted(() => vi.fn());
 
@@ -76,6 +86,14 @@ vi.mock("./map-ping-controller", () => ({
   mapPingController: controller,
 }));
 
+vi.mock("./map-ping-interaction-controller", () => ({
+  createMapPingPressIdentity: (event: KeyboardEvent | MouseEvent) =>
+    event instanceof KeyboardEvent
+      ? { kind: "keyboard", code: event.code }
+      : { kind: "mouse", button: event.button },
+  mapPingInteractionController: interactionController,
+}));
+
 const createMapMouseEvent = () => {
   const canvas = document.createElement("canvas");
   canvas.id = "GAME_CANVAS";
@@ -89,6 +107,12 @@ const createOutsideMouseEvent = () => {
   const event = new MouseEvent("mousedown", { button: 1 });
   element.dispatchEvent(event);
   return event;
+};
+
+const triggerMapPingTap = (handlers: ReturnType<typeof useMapPings>) => {
+  const started = handlers.onMapPingStart(createMapMouseEvent());
+  handlers.onMapPingEnd(new MouseEvent("mouseup", { button: 1 }));
+  return started;
 };
 
 describe("useMapPings", () => {
@@ -106,25 +130,72 @@ describe("useMapPings", () => {
     controller.addRemote.mockReturnValue(true);
     controller.register.mockReturnValue(true);
     controller.resolveTile.mockReturnValue({ x: 12, y: 8 });
+    interactionController.begin.mockReturnValue(true);
+    interactionController.complete.mockReturnValue({
+      mapId: 42,
+      tile: { x: 12, y: 8 },
+      type: "attention",
+    });
   });
 
   it("plays one sound immediately when a local ping is triggered", () => {
     const { result } = renderHook(() => useMapPings());
 
     act(() => {
-      expect(result.current(createMapMouseEvent())).toBe(true);
+      expect(triggerMapPingTap(result.current)).toBe(true);
     });
 
     expect(controller.addOptimistic).toHaveBeenCalledWith(
       { x: 12, y: 8 },
       42,
       "Sender",
+      "attention",
+      "Uwaga",
     );
+    expect(interactionController.begin).toHaveBeenCalledWith({
+      identity: { kind: "mouse", button: 1 },
+      mapId: 42,
+      origin: { x: 0, y: 0 },
+      tile: { x: 12, y: 8 },
+    });
     expect(playSound).toHaveBeenCalledTimes(1);
-    expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing", {
+      playbackRate: 1,
+      preservesPitch: false,
+    });
     expect(socket.emit).toHaveBeenCalledWith(
       GatewayEvent.MAP_PING_SEND,
-      { expectedMapId: 42, x: 12, y: 8 },
+      { expectedMapId: 42, type: "attention", x: 12, y: 8 },
+      expect.any(Function),
+    );
+  });
+
+  it("propagates a selected contextual type to rendering, sound, and socket", () => {
+    interactionController.complete.mockReturnValueOnce({
+      mapId: 42,
+      tile: { x: 12, y: 8 },
+      type: "enemy",
+    });
+    const { result } = renderHook(() => useMapPings());
+
+    act(() => {
+      triggerMapPingTap(result.current);
+    });
+
+    expect(controller.addOptimistic).toHaveBeenCalledWith(
+      { x: 12, y: 8 },
+      42,
+      "Sender",
+      "enemy",
+      "Wróg",
+    );
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing", {
+      playbackRate: 1.35,
+      preservesPitch: false,
+    });
+    expect(socket.emit).toHaveBeenCalledWith(
+      GatewayEvent.MAP_PING_SEND,
+      { expectedMapId: 42, type: "enemy", x: 12, y: 8 },
       expect.any(Function),
     );
   });
@@ -135,12 +206,12 @@ describe("useMapPings", () => {
     testState.pingsEnabled = true;
 
     act(() => {
-      expect(result.current(createMapMouseEvent())).toBe(true);
+      expect(triggerMapPingTap(result.current)).toBe(true);
     });
 
     expect(socket.emit).toHaveBeenCalledWith(
       GatewayEvent.MAP_PING_SEND,
-      { expectedMapId: 42, x: 12, y: 8 },
+      { expectedMapId: 42, type: "attention", x: 12, y: 8 },
       expect.any(Function),
     );
   });
@@ -150,7 +221,7 @@ describe("useMapPings", () => {
     const { result } = renderHook(() => useMapPings());
 
     act(() => {
-      expect(result.current(createMapMouseEvent())).toBe(false);
+      expect(result.current.onMapPingStart(createMapMouseEvent())).toBe(false);
     });
 
     expect(controller.register).not.toHaveBeenCalled();
@@ -191,7 +262,7 @@ describe("useMapPings", () => {
     const { result } = renderHook(() => useMapPings());
 
     act(() => {
-      expect(result.current(event())).toBe(false);
+      expect(result.current.onMapPingStart(event())).toBe(false);
     });
 
     expect(playSound).not.toHaveBeenCalled();
@@ -201,7 +272,7 @@ describe("useMapPings", () => {
   it("does not replay the local sound when the gateway rejects the ping", () => {
     const { result } = renderHook(() => useMapPings());
     act(() => {
-      result.current(createMapMouseEvent());
+      triggerMapPingTap(result.current);
     });
     const acknowledgement = socket.emit.mock.calls[0]?.[2] as (
       error: Error | null,
@@ -225,6 +296,7 @@ describe("useMapPings", () => {
       pingId: "remote-ping-1",
       world: "aether",
       mapId: 42,
+      type: "attention",
       x: 12,
       y: 8,
       sender: { characterId: "123", name: "Other" },
@@ -235,9 +307,12 @@ describe("useMapPings", () => {
       socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);
     });
 
-    expect(controller.addRemote).toHaveBeenCalledWith(event);
+    expect(controller.addRemote).toHaveBeenCalledWith(event, "Uwaga");
     expect(playSound).toHaveBeenCalledTimes(1);
-    expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing", {
+      playbackRate: 1,
+      preservesPitch: false,
+    });
   });
 
   it("uses the latest cached preference for a received ping", () => {
@@ -248,6 +323,7 @@ describe("useMapPings", () => {
       pingId: "remote-ping-after-enable",
       world: "aether",
       mapId: 42,
+      type: "attention",
       x: 12,
       y: 8,
       sender: { characterId: "123", name: "Other" },
@@ -258,8 +334,11 @@ describe("useMapPings", () => {
       socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);
     });
 
-    expect(controller.addRemote).toHaveBeenCalledWith(event);
-    expect(playSound).toHaveBeenCalledWith("pings", "mapPing");
+    expect(controller.addRemote).toHaveBeenCalledWith(event, "Uwaga");
+    expect(playSound).toHaveBeenCalledWith("pings", "mapPing", {
+      playbackRate: 1,
+      preservesPitch: false,
+    });
   });
 
   it("ignores a received ping on the old interface", () => {
@@ -269,11 +348,33 @@ describe("useMapPings", () => {
       pingId: "remote-ping-on-si",
       world: "aether",
       mapId: 42,
+      type: "attention",
       x: 12,
       y: 8,
       sender: { characterId: "123", name: "Other" },
       createdAt: Date.now(),
     };
+
+    act(() => {
+      socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);
+    });
+
+    expect(controller.addRemote).not.toHaveBeenCalled();
+    expect(playSound).not.toHaveBeenCalled();
+  });
+
+  it("drops an unknown runtime ping type before presentation lookup", () => {
+    renderHook(() => useMapPings());
+    const event = {
+      pingId: "remote-unsupported-ping",
+      world: "aether",
+      mapId: 42,
+      type: "unsupported",
+      x: 12,
+      y: 8,
+      sender: { characterId: "123", name: "Other" },
+      createdAt: Date.now(),
+    } as unknown as MapPingEvent;
 
     act(() => {
       socketHandlers.get(GatewayEvent.MAP_PING_RECEIVE)?.(event);

--- a/apps/game-client/src/features/map-pings/use-map-pings.tsx
+++ b/apps/game-client/src/features/map-pings/use-map-pings.tsx
@@ -7,7 +7,11 @@ import { playSound } from "@/lib/sound-playback";
 import { useGlobalStore } from "@/store/global.store";
 import { getUsersControllerGetUserGameAccountPreferencesQueryKey } from "@/lib/api/generated/main/users/users";
 import type { UserGameAccountPreferencesResponseDtoOutput } from "@/lib/api/generated/main/model";
-import type { MapPingAck, MapPingEvent } from "@lootlog/types";
+import {
+  isMapPingType,
+  type MapPingAck,
+  type MapPingEvent,
+} from "@lootlog/types";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -15,6 +19,13 @@ import {
   mapPingController,
   type MapTile,
 } from "./map-ping-controller";
+import {
+  createMapPingPressIdentity,
+  mapPingInteractionController,
+  type ClientPoint,
+  type MapPingSubmission,
+} from "./map-ping-interaction-controller";
+import { getMapPingPresentation } from "./map-ping-presentation";
 
 const ACK_TIMEOUT_MS = 1_500;
 const HINT_THROTTLE_MS = 2_000;
@@ -24,6 +35,11 @@ type PointerPosition = {
   canvas: HTMLCanvasElement;
   clientX: number;
   clientY: number;
+};
+
+type ResolvedTrigger = {
+  origin: ClientPoint;
+  tile: MapTile;
 };
 
 const areMapPingsEnabled = () => {
@@ -79,6 +95,10 @@ export const useMapPings = () => {
     }
 
     const handleMouseMove = (event: MouseEvent) => {
+      mapPingInteractionController.updatePointer({
+        x: event.clientX,
+        y: event.clientY,
+      });
       if (!isMapPingSurface(event.target)) {
         pointerRef.current = null;
         return;
@@ -96,20 +116,20 @@ export const useMapPings = () => {
   }, [isNewInterface]);
 
   useEffect(() => {
-    if (enabled) {
+    if (enabled && connected && joined) {
       return;
     }
 
+    mapPingInteractionController.cancel();
     mapPingController.clear();
-  }, [enabled]);
+  }, [connected, enabled, joined]);
 
-  useEffect(() => {
-    if (connected) {
-      return;
-    }
-
-    mapPingController.clear();
-  }, [connected]);
+  useEffect(
+    () => () => {
+      mapPingInteractionController.cancel();
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!socket || !isNewInterface) {
@@ -119,6 +139,7 @@ export const useMapPings = () => {
     const handleMapPing = (event: MapPingEvent) => {
       const tile = { x: event.x, y: event.y };
       if (
+        !isMapPingType(event.type) ||
         !areMapPingsEnabled() ||
         event.world !== Game.getWorldName() ||
         event.mapId !== Game.map.id ||
@@ -127,8 +148,11 @@ export const useMapPings = () => {
         return;
       }
 
-      if (mapPingController.addRemote(event)) {
-        playSound("pings", "mapPing");
+      const presentation = getMapPingPresentation(event.type);
+      const typeLabel = t(presentation.translationKey);
+      if (mapPingController.addRemote(event, typeLabel)) {
+        const { key, ...soundProfile } = presentation.sound;
+        playSound("pings", key, soundProfile);
       }
     };
 
@@ -136,7 +160,7 @@ export const useMapPings = () => {
     return () => {
       socket.off(GatewayEvent.MAP_PING_RECEIVE, handleMapPing);
     };
-  }, [enabled, isNewInterface, socket]);
+  }, [enabled, isNewInterface, socket, t]);
 
   const showHint = (
     acknowledgement: Extract<MapPingAck, { status: "rejected" }>,
@@ -166,19 +190,22 @@ export const useMapPings = () => {
     window.message?.(message);
   };
 
-  const resolveTriggerTile = (
+  const resolveTrigger = (
     event: KeyboardEvent | MouseEvent,
-  ): MapTile | null => {
+  ): ResolvedTrigger | null => {
     if (event instanceof MouseEvent) {
       if (!isMapPingSurface(event.target)) {
         return null;
       }
 
-      return mapPingController.resolveTile(
+      const tile = mapPingController.resolveTile(
         event.target,
         event.clientX,
         event.clientY,
       );
+      return tile
+        ? { origin: { x: event.clientX, y: event.clientY }, tile }
+        : null;
     }
 
     const pointer = pointerRef.current;
@@ -186,14 +213,64 @@ export const useMapPings = () => {
       return null;
     }
 
-    return mapPingController.resolveTile(
+    const tile = mapPingController.resolveTile(
       pointer.canvas,
       pointer.clientX,
       pointer.clientY,
     );
+    return tile
+      ? {
+          origin: { x: pointer.clientX, y: pointer.clientY },
+          tile,
+        }
+      : null;
   };
 
-  return (event: KeyboardEvent | MouseEvent) => {
+  const sendMapPing = (submission: MapPingSubmission) => {
+    if (
+      !socket ||
+      !connected ||
+      !joined ||
+      !areMapPingsEnabled() ||
+      Game.map.id !== submission.mapId ||
+      !mapPingController.isTileValid(submission.tile)
+    ) {
+      return;
+    }
+
+    const presentation = getMapPingPresentation(submission.type);
+    const typeLabel = t(presentation.translationKey);
+    const localPingId = mapPingController.addOptimistic(
+      submission.tile,
+      submission.mapId,
+      Game.hero.nick,
+      submission.type,
+      typeLabel,
+    );
+    const { key, ...soundProfile } = presentation.sound;
+    playSound("pings", key, soundProfile);
+    socket.timeout(ACK_TIMEOUT_MS).emit(
+      GatewayEvent.MAP_PING_SEND,
+      {
+        expectedMapId: submission.mapId,
+        type: submission.type,
+        x: submission.tile.x,
+        y: submission.tile.y,
+      },
+      (error: Error | null, acknowledgement?: MapPingAck) => {
+        if (error || !acknowledgement) {
+          return;
+        }
+
+        if (acknowledgement.status === "rejected") {
+          mapPingController.remove(localPingId);
+          showHint(acknowledgement);
+        }
+      },
+    );
+  };
+
+  const onMapPingStart = (event: KeyboardEvent | MouseEvent) => {
     if (
       !isNewInterface ||
       !areMapPingsEnabled() ||
@@ -204,35 +281,36 @@ export const useMapPings = () => {
       return false;
     }
 
-    const tile = resolveTriggerTile(event);
+    const trigger = resolveTrigger(event);
     const mapId = Game.map.id;
-    if (!tile || !Number.isInteger(mapId)) {
+    if (!trigger || !Number.isInteger(mapId)) {
       return false;
     }
 
-    const localPingId = mapPingController.addOptimistic(
-      tile,
+    return mapPingInteractionController.begin({
+      identity: createMapPingPressIdentity(event),
       mapId,
-      Game.hero.nick,
+      origin: trigger.origin,
+      tile: trigger.tile,
+    });
+  };
+
+  const onMapPingEnd = (event: KeyboardEvent | MouseEvent) => {
+    const submission = mapPingInteractionController.complete(
+      createMapPingPressIdentity(event),
     );
-    playSound("pings", "mapPing");
-    socket
-      .timeout(ACK_TIMEOUT_MS)
-      .emit(
-        GatewayEvent.MAP_PING_SEND,
-        { expectedMapId: mapId, x: tile.x, y: tile.y },
-        (error: Error | null, acknowledgement?: MapPingAck) => {
-          if (error || !acknowledgement) {
-            return;
-          }
+    if (submission) {
+      sendMapPing(submission);
+    }
+  };
 
-          if (acknowledgement.status === "rejected") {
-            mapPingController.remove(localPingId);
-            showHint(acknowledgement);
-          }
-        },
-      );
+  const onMapPingCancel = () => {
+    mapPingInteractionController.cancel();
+  };
 
-    return true;
+  return {
+    onMapPingCancel,
+    onMapPingEnd,
+    onMapPingStart,
   };
 };

--- a/apps/game-client/src/hooks/use-hotkeys.test.tsx
+++ b/apps/game-client/src/hooks/use-hotkeys.test.tsx
@@ -76,8 +76,8 @@ describe("useHotkeys", () => {
     canvas.id = "GAME_CANVAS";
     document.body.append(input, canvas);
     input.focus();
-    const onMapPing = vi.fn(() => true);
-    renderHook(() => useHotkeys({ onMapPing }));
+    const onMapPingStart = vi.fn(() => true);
+    renderHook(() => useHotkeys({ onMapPingStart }));
 
     const event = new MouseEvent("mousedown", {
       bubbles: true,
@@ -91,8 +91,107 @@ describe("useHotkeys", () => {
     input.remove();
     canvas.remove();
 
-    expect(onMapPing).toHaveBeenCalledOnce();
+    expect(onMapPingStart).toHaveBeenCalledOnce();
     expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("finishes a mouse map ping on the matching button release", () => {
+    const canvas = document.createElement("canvas");
+    canvas.id = "GAME_CANVAS";
+    document.body.append(canvas);
+    const onMapPingStart = vi.fn(() => true);
+    const onMapPingEnd = vi.fn();
+    renderHook(() => useHotkeys({ onMapPingStart, onMapPingEnd }));
+
+    act(() => {
+      canvas.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 1,
+          cancelable: true,
+        }),
+      );
+      window.dispatchEvent(
+        new MouseEvent("mouseup", {
+          button: 1,
+          shiftKey: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    canvas.remove();
+    expect(onMapPingStart).toHaveBeenCalledOnce();
+    expect(onMapPingEnd).toHaveBeenCalledOnce();
+  });
+
+  it("matches keyboard release by code after a modifier is released", () => {
+    useHotkeysStore.getState().setBinding("map-ping", {
+      type: "keyboard",
+      key: "!",
+      shift: true,
+      ctrl: false,
+      alt: false,
+    });
+    const onMapPingStart = vi.fn(() => true);
+    const onMapPingEnd = vi.fn();
+    renderHook(() => useHotkeys({ onMapPingStart, onMapPingEnd }));
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "Digit1",
+          key: "!",
+          shiftKey: true,
+          cancelable: true,
+        }),
+      );
+      window.dispatchEvent(
+        new KeyboardEvent("keyup", {
+          code: "Digit1",
+          key: "1",
+          shiftKey: false,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(onMapPingStart).toHaveBeenCalledOnce();
+    expect(onMapPingEnd).toHaveBeenCalledOnce();
+  });
+
+  it("ignores key repeat and cancels an active ping with Escape", () => {
+    useHotkeysStore.getState().setBinding("map-ping", {
+      type: "keyboard",
+      key: "P",
+      shift: false,
+      ctrl: false,
+      alt: false,
+    });
+    const onMapPingStart = vi.fn(() => true);
+    const onMapPingCancel = vi.fn();
+    renderHook(() => useHotkeys({ onMapPingStart, onMapPingCancel }));
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "KeyP",
+          key: "P",
+          repeat: false,
+        }),
+      );
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "KeyP",
+          key: "P",
+          repeat: true,
+        }),
+      );
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(onMapPingStart).toHaveBeenCalledOnce();
+    expect(onMapPingCancel).toHaveBeenCalledOnce();
   });
 
   it("enqueues every explicit rapid invite-all hotkey activation", () => {

--- a/apps/game-client/src/hooks/use-hotkeys.tsx
+++ b/apps/game-client/src/hooks/use-hotkeys.tsx
@@ -10,10 +10,17 @@ import {
   canEnqueueReadyRoomInvitations,
   enqueueReadyRoomInvitations,
 } from "@/features/party-finder/ready-room-invitation-coordinator";
+import {
+  createMapPingPressIdentity,
+  isSameMapPingPressIdentity,
+  type MapPingPressIdentity,
+} from "@/features/map-pings/map-ping-interaction-controller";
 
 type HotkeyEvent = KeyboardEvent | MouseEvent;
 type UseHotkeysOptions = {
-  onMapPing?: (event: HotkeyEvent) => boolean;
+  onMapPingCancel?: () => void;
+  onMapPingEnd?: (event: HotkeyEvent) => void;
+  onMapPingStart?: (event: HotkeyEvent) => boolean;
 };
 
 const ACTION_TO_WINDOW: Partial<Record<HotkeyAction, WindowId>> = {
@@ -59,17 +66,49 @@ const hotkeyScopes = new Map(
   HOTKEY_ACTIONS.map(({ action, scope }) => [action, scope]),
 );
 
-export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
+export const useHotkeys = ({
+  onMapPingCancel,
+  onMapPingEnd,
+  onMapPingStart,
+}: UseHotkeysOptions = {}) => {
   const toggleOpen = useWindowsStore((state) => state.toggleOpen);
   const bindings = useHotkeysStore((s) => s.bindings);
+  const activeMapPingIdentityRef = useRef<MapPingPressIdentity | null>(null);
   const handledMouseRef = useRef<{
     button: number;
     ctrl: boolean;
     alt: boolean;
     shift: boolean;
   } | null>(null);
+  const handledMouseTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
+    const rememberHandledMouse = (event: MouseEvent) => {
+      if (handledMouseTimeoutRef.current !== null) {
+        window.clearTimeout(handledMouseTimeoutRef.current);
+      }
+      handledMouseRef.current = {
+        button: event.button,
+        ctrl: event.ctrlKey,
+        alt: event.altKey,
+        shift: event.shiftKey,
+      };
+      handledMouseTimeoutRef.current = window.setTimeout(() => {
+        handledMouseRef.current = null;
+        handledMouseTimeoutRef.current = null;
+      }, 1_000);
+    };
+
+    const cancelActiveMapPing = () => {
+      if (!activeMapPingIdentityRef.current) {
+        return false;
+      }
+
+      activeMapPingIdentityRef.current = null;
+      onMapPingCancel?.();
+      return true;
+    };
+
     const executeAction = (event: HotkeyEvent) => {
       for (const [action, binding] of Object.entries(bindings)) {
         if (!matchesBinding(event, binding)) {
@@ -91,7 +130,16 @@ export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
         }
 
         if (hotkeyAction === "map-ping") {
-          return onMapPing?.(event) ?? false;
+          if (event instanceof KeyboardEvent && event.repeat) {
+            return activeMapPingIdentityRef.current !== null;
+          }
+
+          const handled = onMapPingStart?.(event) ?? false;
+          if (handled) {
+            activeMapPingIdentityRef.current =
+              createMapPingPressIdentity(event);
+          }
+          return handled || activeMapPingIdentityRef.current !== null;
         }
 
         return false;
@@ -101,10 +149,32 @@ export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && cancelActiveMapPing()) {
+        event.preventDefault();
+        return;
+      }
       if (isEditableElementActive()) return;
       if (executeAction(event)) {
         event.preventDefault();
       }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      const activeIdentity = activeMapPingIdentityRef.current;
+      if (
+        !activeIdentity ||
+        activeIdentity.kind !== "keyboard" ||
+        !isSameMapPingPressIdentity(
+          activeIdentity,
+          createMapPingPressIdentity(event),
+        )
+      ) {
+        return;
+      }
+
+      activeMapPingIdentityRef.current = null;
+      onMapPingEnd?.(event);
+      event.preventDefault();
     };
 
     const handleMouseDown = (event: MouseEvent) => {
@@ -124,15 +194,28 @@ export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
       }
 
       event.preventDefault();
-      handledMouseRef.current = {
-        button: event.button,
-        ctrl: event.ctrlKey,
-        alt: event.altKey,
-        shift: event.shiftKey,
-      };
-      window.setTimeout(() => {
-        handledMouseRef.current = null;
-      }, 1_000);
+      if (matchingAction[0] !== "map-ping") {
+        rememberHandledMouse(event);
+      }
+    };
+
+    const handleMouseUp = (event: MouseEvent) => {
+      const activeIdentity = activeMapPingIdentityRef.current;
+      if (
+        !activeIdentity ||
+        activeIdentity.kind !== "mouse" ||
+        !isSameMapPingPressIdentity(
+          activeIdentity,
+          createMapPingPressIdentity(event),
+        )
+      ) {
+        return;
+      }
+
+      activeMapPingIdentityRef.current = null;
+      onMapPingEnd?.(event);
+      event.preventDefault();
+      rememberHandledMouse(event);
     };
 
     const suppressHandledMouseEvent = (event: MouseEvent) => {
@@ -149,16 +232,25 @@ export const useHotkeys = ({ onMapPing }: UseHotkeysOptions = {}) => {
     };
 
     window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
     window.addEventListener("mousedown", handleMouseDown);
-    window.addEventListener("mouseup", suppressHandledMouseEvent);
+    window.addEventListener("mouseup", handleMouseUp);
     window.addEventListener("auxclick", suppressHandledMouseEvent);
+    window.addEventListener("blur", cancelActiveMapPing);
     return () => {
+      cancelActiveMapPing();
       window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("mousedown", handleMouseDown);
-      window.removeEventListener("mouseup", suppressHandledMouseEvent);
+      window.removeEventListener("mouseup", handleMouseUp);
       window.removeEventListener("auxclick", suppressHandledMouseEvent);
+      window.removeEventListener("blur", cancelActiveMapPing);
+      if (handledMouseTimeoutRef.current !== null) {
+        window.clearTimeout(handledMouseTimeoutRef.current);
+        handledMouseTimeoutRef.current = null;
+      }
     };
-  }, [bindings, toggleOpen, onMapPing]);
+  }, [bindings, onMapPingCancel, onMapPingEnd, onMapPingStart, toggleOpen]);
 
   return null;
 };

--- a/apps/game-client/src/i18n/translations/settings.json
+++ b/apps/game-client/src/i18n/translations/settings.json
@@ -30,7 +30,17 @@
   },
   "mapPings": {
     "rateLimited": "Poczekaj {{seconds}} s przed kolejnym pingiem.",
-    "temporarilyUnavailable": "Pingi są chwilowo niedostępne."
+    "temporarilyUnavailable": "Pingi są chwilowo niedostępne.",
+    "types": {
+      "attention": "Uwaga",
+      "enemy": "Wróg",
+      "regroup": "Zbiórka",
+      "avoid": "Unikaj"
+    },
+    "wheel": {
+      "cancelHint": "Anuluj",
+      "ariaLabel": "Koło pingów. Wybrano: {{selection}}"
+    }
   },
   "battlePanel": {
     "title": "Ustawienia panelu walk",

--- a/apps/game-client/src/lib/sound-playback.test.ts
+++ b/apps/game-client/src/lib/sound-playback.test.ts
@@ -8,6 +8,8 @@ const audioInstances: AudioMock[] = [];
 
 class AudioMock {
   volume = 1;
+  playbackRate = 1;
+  preservesPitch = true;
   onended: (() => void) | null = null;
   readonly pause = vi.fn();
   readonly play = vi.fn<() => Promise<void>>().mockResolvedValue();
@@ -66,5 +68,20 @@ describe("playSound", () => {
     playSound("pings", "mapPing");
 
     expect(audioInstances).toHaveLength(0);
+  });
+
+  it("applies a contextual ping playback profile", () => {
+    queryClient.setQueryData(
+      getSoundSettingsControllerGetSettingsQueryKey(),
+      createSoundSettings(),
+    );
+
+    playSound("pings", "mapPing", {
+      playbackRate: 1.35,
+      preservesPitch: false,
+    });
+
+    expect(audioInstances[0]?.playbackRate).toBe(1.35);
+    expect(audioInstances[0]?.preservesPitch).toBe(false);
   });
 });

--- a/apps/game-client/src/lib/sound-playback.ts
+++ b/apps/game-client/src/lib/sound-playback.ts
@@ -6,6 +6,11 @@ import type { UserSoundSettings } from "@lootlog/types";
 type SoundCategory = "notifications" | "detector" | "timers" | "pings";
 type ConfigurableSoundCategory = Exclude<SoundCategory, "pings">;
 
+export type SoundPlaybackProfile = {
+  playbackRate?: number;
+  preservesPitch?: boolean;
+};
+
 let currentAudio: HTMLAudioElement | null = null;
 const SOUND_SETTINGS_QUERY_KEY =
   getSoundSettingsControllerGetSettingsQueryKey();
@@ -26,7 +31,11 @@ function getSettings(): UserSoundSettings | undefined {
   return undefined;
 }
 
-export function playSound(category: SoundCategory, key: string): void {
+export function playSound(
+  category: SoundCategory,
+  key: string,
+  profile: SoundPlaybackProfile = {},
+): void {
   const settings = getSettings();
   if (!settings) return;
 
@@ -53,6 +62,12 @@ export function playSound(category: SoundCategory, key: string): void {
 
   const audio = new Audio(soundUrl);
   audio.volume = categoryVolume * masterVolume;
+  if (profile.playbackRate !== undefined) {
+    audio.playbackRate = profile.playbackRate;
+  }
+  if (profile.preservesPitch !== undefined) {
+    audio.preservesPitch = profile.preservesPitch;
+  }
   currentAudio = audio;
 
   audio.play().catch(() => {});

--- a/apps/game-client/src/processors/map-change-processor.test.ts
+++ b/apps/game-client/src/processors/map-change-processor.test.ts
@@ -5,11 +5,21 @@ import { MapChangeProcessor } from "./map-change-processor";
 import type { GameEvent } from "@lootlog/margonem/game-events";
 
 const mockEmit = vi.fn();
+const cancelMapPingInteraction = vi.hoisted(() => vi.fn());
+const clearMapPings = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/socket", () => ({
   getSocket: () => ({
     emit: mockEmit,
   }),
+}));
+
+vi.mock("@/features/map-pings/map-ping-controller", () => ({
+  mapPingController: { clear: clearMapPings },
+}));
+
+vi.mock("@/features/map-pings/map-ping-interaction-controller", () => ({
+  mapPingInteractionController: { cancel: cancelMapPingInteraction },
 }));
 
 const createMapChangeEvent = (id: number, name: string): GameEvent =>
@@ -87,6 +97,8 @@ describe("MapChangeProcessor", () => {
     processor.handle(createMapChangeEvent(12, "Torneg"));
 
     expect(mockEmit).toHaveBeenCalledTimes(1);
+    expect(cancelMapPingInteraction).toHaveBeenCalledTimes(1);
+    expect(clearMapPings).toHaveBeenCalledTimes(1);
   });
 
   it("emits again when map id changes", () => {
@@ -109,5 +121,7 @@ describe("MapChangeProcessor", () => {
         mapName: "Nithal",
       },
     );
+    expect(cancelMapPingInteraction).toHaveBeenCalledTimes(2);
+    expect(clearMapPings).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/game-client/src/processors/map-change-processor.ts
+++ b/apps/game-client/src/processors/map-change-processor.ts
@@ -3,6 +3,7 @@ import { useGlobalStore } from "@/store/global.store";
 import { GatewayEvent } from "@/config/gateway";
 import type { GameEvent } from "@lootlog/margonem/game-events";
 import { mapPingController } from "@/features/map-pings/map-ping-controller";
+import { mapPingInteractionController } from "@/features/map-pings/map-ping-interaction-controller";
 
 export class MapChangeProcessor {
   private previousMapId: number | null = null;
@@ -16,6 +17,7 @@ export class MapChangeProcessor {
     if (this.previousMapId === mapId) return;
 
     this.previousMapId = mapId;
+    mapPingInteractionController.cancel();
     mapPingController.clear();
 
     const { connected, joinedGuilds } = useGlobalStore.getState().socketState;

--- a/apps/gateway/src/gateway/dto/map-ping-send.dto.ts
+++ b/apps/gateway/src/gateway/dto/map-ping-send.dto.ts
@@ -1,8 +1,10 @@
 import { createZodDto } from "nestjs-zod";
 import { z } from "zod";
+import { MAP_PING_TYPES } from "@lootlog/types";
 
 const MapPingSendSchema = z.object({
   expectedMapId: z.number().int().nonnegative(),
+  type: z.enum(MAP_PING_TYPES),
   x: z.number().int().min(0).max(65_535),
   y: z.number().int().min(0).max(65_535),
 });

--- a/apps/gateway/src/gateway/services/map-ping.service.spec.ts
+++ b/apps/gateway/src/gateway/services/map-ping.service.spec.ts
@@ -1,4 +1,4 @@
-import { Permission } from "@lootlog/types";
+import { MAP_PING_TYPES, Permission } from "@lootlog/types";
 import { Platform } from "src/gateway/enums/platform.enum";
 import { GatewayEvent } from "src/gateway/enums/gateway-event.enum";
 import { MapPingService } from "./map-ping.service";
@@ -16,67 +16,72 @@ describe("MapPingService", () => {
     ],
   });
 
-  it("broadcasts an accepted ping once to an eligible socket on the same map", async () => {
-    const recipient = {
-      id: "recipient-socket",
-      data: {
-        discordId: "recipient-discord",
-        platform: Platform.GAME,
-        guilds: [createGuild("guild-1"), createGuild("guild-2")],
-        playerPresence: { world: "aether", mapId: 42 },
-      },
-      emit: vi.fn(),
-    };
-    const server = {
-      in: vi.fn().mockReturnThis(),
-      fetchSockets: vi.fn().mockResolvedValue([recipient, recipient]),
-    };
-    const redis = {
-      eval: vi.fn().mockResolvedValue([1, 1_700_000_000_000, 0]),
-    };
-    const sender = {
-      id: "sender-socket",
-      data: {
-        userId: "user-1",
-        discordId: "sender-discord",
-        platform: Platform.GAME,
-        guilds: [createGuild("guild-1"), createGuild("guild-2")],
-        playerPresence: {
-          world: "aether",
-          mapId: 42,
-          name: "Sender",
-          characterId: "123",
+  it.each(MAP_PING_TYPES)(
+    "broadcasts an accepted %s ping once to an eligible socket on the same map",
+    async (type) => {
+      const recipient = {
+        id: "recipient-socket",
+        data: {
+          discordId: "recipient-discord",
+          platform: Platform.GAME,
+          guilds: [createGuild("guild-1"), createGuild("guild-2")],
+          playerPresence: { world: "aether", mapId: 42 },
         },
-      },
-    };
-    const service = new MapPingService(redis as never);
+        emit: vi.fn(),
+      };
+      const server = {
+        in: vi.fn().mockReturnThis(),
+        fetchSockets: vi.fn().mockResolvedValue([recipient, recipient]),
+      };
+      const redis = {
+        eval: vi.fn().mockResolvedValue([1, 1_700_000_000_000, 0]),
+      };
+      const sender = {
+        id: "sender-socket",
+        data: {
+          userId: "user-1",
+          discordId: "sender-discord",
+          platform: Platform.GAME,
+          guilds: [createGuild("guild-1"), createGuild("guild-2")],
+          playerPresence: {
+            world: "aether",
+            mapId: 42,
+            name: "Sender",
+            characterId: "123",
+          },
+        },
+      };
+      const service = new MapPingService(redis as never);
 
-    const result = await service.send(server as never, sender as never, {
-      expectedMapId: 42,
-      x: 12,
-      y: 8,
-    });
-
-    expect(result).toEqual({
-      status: "accepted",
-      pingId: expect.any(String),
-    });
-    expect(server.in).toHaveBeenCalledWith([
-      "guild-1:online-players",
-      "guild-2:online-players",
-    ]);
-    expect(recipient.emit).toHaveBeenCalledTimes(1);
-    expect(recipient.emit).toHaveBeenCalledWith(
-      GatewayEvent.MAP_PING_RECEIVE,
-      expect.objectContaining({
-        world: "aether",
-        mapId: 42,
+      const result = await service.send(server as never, sender as never, {
+        expectedMapId: 42,
+        type,
         x: 12,
         y: 8,
-        sender: { characterId: "123", name: "Sender" },
-      }),
-    );
-  });
+      });
+
+      expect(result).toEqual({
+        status: "accepted",
+        pingId: expect.any(String),
+      });
+      expect(server.in).toHaveBeenCalledWith([
+        "guild-1:online-players",
+        "guild-2:online-players",
+      ]);
+      expect(recipient.emit).toHaveBeenCalledTimes(1);
+      expect(recipient.emit).toHaveBeenCalledWith(
+        GatewayEvent.MAP_PING_RECEIVE,
+        expect.objectContaining({
+          world: "aether",
+          mapId: 42,
+          type,
+          x: 12,
+          y: 8,
+          sender: { characterId: "123", name: "Sender" },
+        }),
+      );
+    },
+  );
 
   it("excludes the source but emits to another eligible game session", async () => {
     const createRecipient = (
@@ -126,6 +131,7 @@ describe("MapPingService", () => {
     await expect(
       service.send(server as never, source as never, {
         expectedMapId: 42,
+        type: "attention",
         x: 12,
         y: 8,
       }),
@@ -163,6 +169,7 @@ describe("MapPingService", () => {
     await expect(
       service.send(server as never, sender as never, {
         expectedMapId: 99,
+        type: "attention",
         x: 12,
         y: 8,
       }),
@@ -210,6 +217,7 @@ describe("MapPingService", () => {
     await expect(
       service.send(server as never, sender as never, {
         expectedMapId: 42,
+        type: "attention",
         x: 12,
         y: 8,
       }),
@@ -245,6 +253,7 @@ describe("MapPingService", () => {
     await expect(
       service.send(server as never, sender as never, {
         expectedMapId: 42,
+        type: "attention",
         x: 12,
         y: 8,
       }),
@@ -263,10 +272,38 @@ describe("MapPingService", () => {
     await expect(
       service.send({} as never, { data: {} } as never, {
         expectedMapId: 42,
+        type: "attention",
         x: -1,
         y: 8,
       }),
     ).resolves.toEqual({ status: "rejected", code: "invalid-payload" });
     expect(redis.eval).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      name: "missing",
+      payload: { expectedMapId: 42, x: 12, y: 8 },
+    },
+    {
+      name: "unsupported",
+      payload: {
+        expectedMapId: 42,
+        type: "unsupported",
+        x: 12,
+        y: 8,
+      },
+    },
+  ])(
+    "rejects a $name ping type before consuming the rate limit",
+    async ({ payload }) => {
+      const redis = { eval: vi.fn() };
+      const service = new MapPingService(redis as never);
+
+      await expect(
+        service.send({} as never, { data: {} } as never, payload as never),
+      ).resolves.toEqual({ status: "rejected", code: "invalid-payload" });
+      expect(redis.eval).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/gateway/src/gateway/services/map-ping.service.ts
+++ b/apps/gateway/src/gateway/services/map-ping.service.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { Injectable, Logger } from "@nestjs/common";
 import { RedisService } from "@lootlog/nest-shared/redis";
-import type {
-  MapPingAck,
-  MapPingEvent,
-  MapPingSendPayload,
+import {
+  isMapPingType,
+  type MapPingAck,
+  type MapPingEvent,
+  type MapPingSendPayload,
 } from "@lootlog/types";
 import type { Server } from "socket.io";
 import { GatewayEvent } from "src/gateway/enums/gateway-event.enum";
@@ -51,7 +52,7 @@ export class MapPingService {
     client: Socket,
     payload: MapPingSendPayload,
   ): Promise<MapPingAck> {
-    if (!this.hasValidCoordinates(payload)) {
+    if (!this.hasValidPayload(payload)) {
       return { status: "rejected", code: "invalid-payload" };
     }
 
@@ -92,6 +93,7 @@ export class MapPingService {
       pingId,
       world: context.world,
       mapId: context.mapId,
+      type: payload.type,
       x: payload.x,
       y: payload.y,
       sender: {
@@ -138,10 +140,15 @@ export class MapPingService {
     };
   }
 
-  private hasValidCoordinates({ x, y }: MapPingSendPayload) {
-    return [x, y].every(
-      (coordinate) =>
-        Number.isInteger(coordinate) && coordinate >= 0 && coordinate <= 65_535,
+  private hasValidPayload({ type, x, y }: MapPingSendPayload) {
+    return (
+      isMapPingType(type) &&
+      [x, y].every(
+        (coordinate) =>
+          Number.isInteger(coordinate) &&
+          coordinate >= 0 &&
+          coordinate <= 65_535,
+      )
     );
   }
 

--- a/docs/superpowers/specs/2026-07-13-contextual-map-pings-design.md
+++ b/docs/superpowers/specs/2026-07-13-contextual-map-pings-design.md
@@ -1,0 +1,237 @@
+# Contextual Map Pings Design
+
+## Summary
+
+Contextual map pings extend the existing NI-only map ping into a small shared vocabulary. A quick activation keeps the current fast path and sends an `attention` ping. Holding the same configured hotkey for 300 ms opens a radial wheel with four ping types: `attention`, `enemy`, `regroup`, and `avoid`.
+
+The feature reuses the current game-client renderer, Socket.IO events, gateway authorization, guild scoping, map scoping, rate limiting, preferences, and sound volume. It does not introduce a second realtime channel or persistent storage.
+
+## Goals
+
+- Preserve the speed of the existing default map ping.
+- Let a player communicate one of four common tactical meanings without chat or voice.
+- Render the selected meaning consistently on the main canvas and handheld minimap.
+- Keep all existing authorization, guild, world, and map boundaries.
+- Make the interaction deterministic for keyboard and mouse hotkey bindings.
+- Keep the feature entirely ephemeral.
+
+## Non-goals
+
+- Object-aware pings for players, NPCs, transitions, or loot.
+- Ping reactions, acknowledgements, cancellation after sending, or lifecycle state.
+- Additional ping-wheel levels or user-defined ping types.
+- SI support.
+- Persistent ping history or analytics.
+- Changes to rate-limit policy or ping recipients.
+
+## Product behavior
+
+### Ping types
+
+The shared contract exposes a closed `MapPingType` union:
+
+| Type        | User-facing label | Meaning                   | Color     | Symbol           | Duration | Sound rate |
+| ----------- | ----------------- | ------------------------- | --------- | ---------------- | -------- | ---------- |
+| `attention` | Uwaga             | General point of interest | `#f59e0b` | exclamation mark | 2.5 s    | `1.0`      |
+| `enemy`     | Wróg              | Enemy or immediate danger | `#ef4444` | crosshair        | 4 s      | `1.35`     |
+| `regroup`   | Zbiórka           | Group meeting point       | `#3b82f6` | concentric rings | 5 s      | `0.82`     |
+| `avoid`     | Unikaj            | Area to avoid             | `#a855f7` | diagonal cross   | 5 s      | `0.62`     |
+
+Each type has a distinct canvas/minimap symbol and sound cue. Labels are translated through the game-client i18n resources. Colors are not the only discriminator.
+
+### Tap interaction
+
+1. The player presses the configured `map-ping` keyboard key or mouse button while the pointer is over the main map or handheld minimap.
+2. The client captures the target tile and pointer position at press time.
+3. If the binding is released before 300 ms, the client sends one `attention` ping at the captured tile.
+4. The local optimistic marker and sound appear immediately on release.
+
+Capturing the tile on press prevents the target from changing if the pointer moves while the binding is held.
+
+### Hold interaction
+
+1. After 300 ms, the client opens a radial wheel centred near the captured pointer position.
+2. The wheel has an 88 px outer radius, a 24 px central dead zone, and four equal directional segments centred on the cardinal directions.
+3. Pointer movement selects a segment by angle. Top selects `attention`, right selects `enemy`, bottom selects `avoid`, and left selects `regroup`. Exact half-open ranges are `[-135°, -45°)` for top, `[-45°, 45°)` for right, `[45°, 135°)` for bottom, and the remaining range for left, using the screen coordinate system where positive Y points down.
+4. The selected segment receives a strong visual highlight and its translated label is shown in the centre.
+5. Releasing the original binding sends the selected type at the captured tile.
+6. Releasing inside the dead zone cancels without sending. This avoids accidental pings when a hold was unintentional.
+
+Selection uses a logical vector from the pointer position captured on press to the latest pointer position. The visual wheel centre is independently clamped to stay at least 100 px from every viewport edge: 88 px for the wheel and 12 px of margin. If either viewport dimension is smaller than 200 px, that axis uses the viewport midpoint and permits visual clipping. Consequently, an edge-adjacent wheel may be drawn inward while its segment selection still reflects movement away from the original press point. Opening the wheel does not select a segment until a post-open pointer movement leaves the 24 px dead zone. The wheel does not intercept pointer events from Margonem.
+
+### Cancellation and cleanup
+
+An open or pending interaction is cancelled without sending when any of the following occurs:
+
+- the player presses `Escape`;
+- the game window loses focus;
+- the active map changes;
+- the gateway disconnects or the socket leaves its authenticated/joined state;
+- map pings are disabled;
+- the component unmounts.
+
+Repeated keyboard `keydown` events never create additional interactions. A second press while one interaction is active is ignored.
+
+## Architecture
+
+### Shared contract
+
+`packages/types/src/common/map-ping.types.ts` defines the runtime list of supported types and derives `MapPingType` from it. Both `MapPingSendPayload` and `MapPingEvent` require a `type` field.
+
+No compatibility fallback is added for payloads without `type`. Game-client and gateway are released from the same monorepo and the project does not require backwards compatibility for this change.
+
+### Hotkey lifecycle
+
+The existing `useHotkeys` hook currently handles only activation on `keydown` or `mousedown`. It will expose the map-ping binding as a lifecycle:
+
+- `onMapPingStart(event)` on the matching initial press;
+- `onMapPingEnd(event)` on the matching release;
+- `onMapPingCancel()` for loss of focus and cleanup.
+
+Other hotkey actions keep their current one-shot behavior. Binding matching at press time continues to use the configured key or mouse button and configured modifiers. Once accepted, the hook captures a stable press identity:
+
+- keyboard: `{ kind: "keyboard", code: event.code }`;
+- mouse: `{ kind: "mouse", button: event.button }`.
+
+Keyboard release matches only the captured `event.code`; mouse release matches only the captured `event.button`. Release modifiers and `event.key` are deliberately ignored, so releasing Shift before a shifted character key cannot strand the interaction. A release with a different kind, code, or button is ignored. Repeated keyboard events do not call `onMapPingStart`. The hook continues suppressing the corresponding browser/game events when the map-ping action consumed them.
+
+### Interaction state
+
+`MapPingInteractionController` is a non-React singleton that owns the small state machine:
+
+```text
+idle -> pending -> sent -> idle
+               -> wheel-open -> sent -> idle
+                             -> cancelled -> idle
+```
+
+The controller has the following public interface:
+
+```typescript
+begin(input: MapPingInteractionStart): boolean;
+updatePointer(position: ClientPoint): void;
+complete(identity: MapPingPressIdentity): MapPingSubmission | null;
+cancel(): void;
+getSnapshot(): MapPingWheelSnapshot | null;
+subscribe(listener: () => void): () => void;
+```
+
+`begin` rejects a second interaction while one is active. `complete` returns an `attention` submission for a tap, the selected submission for a wheel release, or `null` for an identity mismatch or dead-zone cancellation. It never performs networking. The state contains the captured tile, map ID, logical pointer origin, visual wheel centre, press identity, start time, and selected type. A single timer transitions `pending` to `wheel-open`. Cleanup always clears this timer.
+
+Pure geometry functions resolve the selected type from the pointer angle and dead-zone radius. They are independent of React and the Margonem runtime.
+
+`useMapPings` translates hotkey events into controller calls, turns a returned `MapPingSubmission` into an optimistic marker and socket emission, and installs global pointer-move and cancellation listeners while an interaction is active. `MapPingWheel` subscribes through `getSnapshot` and `subscribe`. `AppContent` wires the lifecycle returned by `useMapPings` into `useHotkeys` and renders one `<MapPingWheel />` beside the other application roots.
+
+`MapChangeProcessor` calls `mapPingInteractionController.cancel()` immediately before `mapPingController.clear()` when `event.town.id` changes. This explicit processor integration is the authoritative map-change cancellation path; no reactive map ID is added to the global store.
+
+### Radial wheel UI
+
+`MapPingWheel` is the only component in its file. It renders through the game-client React tree as a fixed 176 px square overlay with `pointer-events: none`, a z-index consistent with other Lootlog overlays, and semantic styling based on the four-type presentation registry. Four 90-degree segments follow the top/right/bottom/left mapping defined above; each symbol is positioned 56 px from the visual centre. The inactive segment opacity is 70%, while the selected segment uses full opacity, a 2 px white inner outline, and a 1.08 scale. The centre is a 48 px disc that displays the selected translated label or the translated cancellation hint while no segment is selected.
+
+The wheel receives display state and does not send socket events. The interaction controller owns selection and submission. This keeps rendering separate from hotkey and networking behavior.
+
+Static labels and accessibility text use i18n. Although the wheel is primarily pointer-driven, it exposes an appropriate status description in the DOM for assistive tooling and does not rely solely on color.
+
+### Sending and receiving
+
+The existing `useMapPings` flow remains responsible for local validation, optimistic rendering, audio, socket acknowledgement, rejection cleanup, and received events. It resolves the translated type label at insertion time and passes `{ type, typeLabel }` to both `addOptimistic` and `addRemote`.
+
+Sending adds the selected `type` to `MAP_PING_SEND`. Receiving passes the event type to the renderer and selects the matching sound. The sender does not receive its own server event, so optimistic markers remain the sender path.
+
+### Gateway validation
+
+`MapPingService` validates the type against the shared runtime list in addition to validating coordinates. Unsupported or missing types return the existing `invalid-payload` rejection.
+
+The gateway copies the validated type to `MapPingEvent`. Existing permission checks, presence checks, rate limiting, guild eligibility, world filtering, map filtering, sender exclusion, and delivery deduplication remain unchanged.
+
+### Rendering and presentation
+
+A single exhaustive presentation registry maps every `MapPingType` to:
+
+- main color and contrasting text color;
+- canvas/minimap symbol drawing strategy;
+- duration;
+- sound key;
+- translation key.
+
+`MapPingController` stores `type` and the already-localized `typeLabel` with each active ping. It does not import or call i18n. Existing active pings retain their insertion-time label if the player changes language during their maximum five-second lifetime; subsequent pings use the new language. This keeps the singleton renderer independent and makes its input fully testable.
+
+Expiry is calculated from the type's duration. The main map renders a pulse, the exact symbol from the product table, the localized type label, and the sender name. The handheld minimap renders the color and symbol without text to avoid clutter.
+
+The registry must be exhaustive at compile time so adding a future type cannot silently fall back to the wrong presentation.
+
+### Sounds
+
+The existing `pings` sound category, `mapPing` URL, and volume controls remain authoritative. No new file or external URL is introduced. The four distinct cues are deterministic playback profiles of the existing short `mapPing` sample, using the rates in the product table with `HTMLMediaElement.preservesPitch = false`.
+
+`playSound` receives an optional playback profile containing `playbackRate` and `preservesPitch`; existing callers keep the current defaults. The contextual-ping presentation registry maps every type to `{ key: "mapPing", playbackRate, preservesPitch: false }`. Tests assert the selected profile and resulting `Audio` properties, so distinctness does not depend on an unspecified asset.
+
+No new settings category or per-type toggle is introduced in this feature.
+
+## Data flow
+
+```text
+configured binding pressed over map surface
+  -> capture tile and start 300 ms timer
+  -> release early: choose attention
+  -> hold: show wheel and update angular selection
+  -> release with selection
+  -> optimistic typed marker + typed sound
+  -> MAP_PING_SEND { expectedMapId, x, y, type }
+  -> gateway validates context, coordinates, type, permission and rate limit
+  -> gateway emits typed MapPingEvent to eligible same-map guild clients
+  -> receiver validates world, map, tile and local preference
+  -> receiver renders typed marker + typed sound
+```
+
+## Error handling
+
+- Invalid target surfaces or tiles never start an interaction.
+- A missing socket, disconnected socket, unjoined socket, disabled preference, or non-NI client prevents interaction start.
+- A gateway rejection removes the optimistic marker exactly as today.
+- Rate-limit and temporary-unavailability hints keep their current throttling.
+- A timed-out acknowledgement leaves the already displayed short-lived optimistic marker, matching current behavior.
+- Unknown received types are prevented by the shared TypeScript contract; defensive runtime handling drops them rather than rendering a fallback.
+- UI timers and global listeners are always removed during cancellation and unmount.
+
+## Testing strategy
+
+### Shared types and gateway
+
+- Gateway accepts all four supported types and includes the type in emitted events.
+- Gateway rejects missing and unsupported types as `invalid-payload`.
+- Existing context, permission, routing, deduplication, and rate-limit tests continue to pass.
+
+### Hotkeys and interaction
+
+- Keyboard and mouse bindings emit start and matching end phases using captured `code` or `button`, even when modifiers change before release.
+- Key repeat and duplicate presses are ignored.
+- A release for a different binding does not finish the active interaction.
+- A tap sends one `attention` ping.
+- Holding for 300 ms opens the wheel without sending.
+- Angular movement selects the exact top/right/bottom/left mapping, including all four boundary angles.
+- The 24 px dead zone, 88 px visual radius, 12 px viewport margin, and edge clamping preserve logical selection based on movement from the captured press point.
+- Dead-zone release, `Escape`, blur, disconnect, map change, preference disable, and unmount cancel without sending.
+- Timer and event-listener cleanup are verified with fake timers.
+
+### Networking hook
+
+- Each selected type is included in the outgoing payload.
+- Optimistic and remote markers receive the same type.
+- The matching sound key is used for local and remote pings.
+- Rejection removes the correct optimistic marker.
+
+### Renderer and UI
+
+- Every type resolves to an exhaustive presentation entry.
+- Type-specific durations expire at the correct time.
+- Main map and minimap use the exact color and symbol from the product table and receive localized labels as data.
+- The wheel renders translated labels, uses the specified dimensions and segment order, highlights selection, clamps visually near viewport edges, and does not capture pointer events.
+- An `AppContent` integration test proves the hotkey lifecycle and wheel root are wired together.
+- A `MapChangeProcessor` test proves a changed `event.town.id` cancels pending/open interaction state and clears rendered markers.
+
+## Rollout and documentation
+
+The feature remains behind the existing `pings.enabled` preference and inherits current gateway authorization. No migration or feature flag is required.
+
+After implementation and verification, `/Users/kamil/Desktop/lootlog-feature-research.md` receives a dated progress entry containing the branch name, commit, delivered scope, verification commands, and any intentionally deferred items.

--- a/packages/types/src/common/map-ping.types.ts
+++ b/packages/types/src/common/map-ping.types.ts
@@ -1,5 +1,18 @@
+export const MAP_PING_TYPES = [
+  "attention",
+  "enemy",
+  "regroup",
+  "avoid",
+] as const;
+
+export type MapPingType = (typeof MAP_PING_TYPES)[number];
+
+export const isMapPingType = (value: unknown): value is MapPingType =>
+  typeof value === "string" && MAP_PING_TYPES.includes(value as MapPingType);
+
 export interface MapPingSendPayload {
   expectedMapId: number;
+  type: MapPingType;
   x: number;
   y: number;
 }
@@ -26,6 +39,7 @@ export interface MapPingEvent {
   pingId: string;
   world: string;
   mapId: number;
+  type: MapPingType;
   x: number;
   y: number;
   sender: {


### PR DESCRIPTION
## What changed

- adds four map ping types: attention, enemy, regroup, and avoid
- keeps tap-to-attention while opening a radial wheel after a 300 ms hold
- adds per-type colors, symbols, TTLs, localized labels, and sound profiles
- wires keyboard and mouse lifecycle handling with cancellation on Escape, blur, map changes, preference changes, and disconnects
- extends the shared socket contract and validates ping types in the gateway DTO and service
- documents the interaction and architecture in the committed design spec

## Why

The existing single map ping is useful but cannot communicate intent. Contextual pings turn it into a lightweight team communication system without requiring chat or voice.

## Impact

Players can quickly send the default attention ping or hold the configured hotkey to select a contextual ping. Recipients see and hear a presentation tailored to the selected type on the main map and handheld minimap.

## Validation

- `pnpm --filter @lootlog/types build`
- `pnpm --filter @lootlog/game-client build`
- `pnpm --filter @lootlog/gateway build`
- `pnpm --filter @lootlog/game-client test` — 145 files, 695 tests
- `pnpm --filter @lootlog/gateway test` — 17 files, 194 tests
- gateway lint, changed-file lint, format check, and pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contextual map pings with four types: attention, enemy, regroup, and avoid.
  * Added a tap/hold interaction with a radial selection wheel, visual symbols, labels, and accessibility support.
  * Added type-specific ping colors, durations, sounds, and translations.
  * Map changes now cancel active ping interactions and clear existing pings.

* **Bug Fixes**
  * Improved validation and handling of invalid or unsupported ping types.
  * Added safeguards for duplicate, mismatched, and canceled ping interactions.

* **Tests**
  * Expanded coverage for map ping interactions, rendering, hotkeys, sound profiles, and server validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->