### PR TITLE
fix(game-client): initialize default lootlog guild

### DIFF
--- a/apps/game-client/src/app-content.test.tsx
+++ b/apps/game-client/src/app-content.test.tsx
@@ -8,6 +8,7 @@ const mapPingHotkeyHandlers = vi.hoisted(() => ({
 }));
 const useHotkeys = vi.hoisted(() => vi.fn());
 const useAirTags = vi.hoisted(() => vi.fn());
+const useSelectedLootlogGuildInitialization = vi.hoisted(() => vi.fn());
 const eventModeQuery = vi.hoisted(() => ({
   data: {
     generatedAt: "2026-07-13T12:00:00.000Z",
@@ -20,6 +21,9 @@ vi.mock("@/features/map-pings/use-map-pings", () => ({
 }));
 vi.mock("@/features/air-tags/use-air-tags", () => ({ useAirTags }));
 vi.mock("@/hooks/use-hotkeys", () => ({ useHotkeys }));
+vi.mock("@/hooks/use-selected-lootlog-guild", () => ({
+  useSelectedLootlogGuildInitialization,
+}));
 vi.mock("@/features/map-pings/map-ping-wheel", () => ({
   MapPingWheel: () => <div data-testid="map-ping-wheel" />,
 }));
@@ -123,6 +127,7 @@ describe("AppContent map ping integration", () => {
 
     expect(useHotkeys).toHaveBeenCalledWith(mapPingHotkeyHandlers);
     expect(useAirTags).toHaveBeenCalledOnce();
+    expect(useSelectedLootlogGuildInitialization).toHaveBeenCalledOnce();
     expect(screen.getByTestId("map-ping-wheel")).toBeInTheDocument();
     expect(screen.getByTestId("event-mode")).toHaveAttribute(
       "data-has-query",

--- a/apps/game-client/src/app-content.tsx
+++ b/apps/game-client/src/app-content.tsx
@@ -31,10 +31,12 @@ import { usePartyReadyRoomSocket } from "@/features/party-finder/hooks/use-party
 import { usePartyReadyRoomSync } from "@/features/party-finder/hooks/use-party-ready-room-sync";
 import { useTimerSettingsMutationsRegistry } from "@/hooks/use-timer-settings-mutations-registry";
 import { useTimerSettingsSync } from "@/hooks/use-timer-settings-sync";
+import { useSelectedLootlogGuildInitialization } from "@/hooks/use-selected-lootlog-guild";
 
 export const AppContent = () => {
   useGameEventHandlers();
   useInit();
+  useSelectedLootlogGuildInitialization();
   useGameAccountPreferencesSync();
   const mapPingHotkeyHandlers = useMapPings();
   useAirTags();

--- a/apps/game-client/src/components/guild-switcher.test.tsx
+++ b/apps/game-client/src/components/guild-switcher.test.tsx
@@ -1,23 +1,20 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GuildIdentity } from "@/lib/api/generated-helpers";
-import { useUsersControllerGetCurrentUserAccessibleGuilds } from "@/lib/api/generated/main/users/users";
+import { useSettingsStore } from "@/store/settings.store";
 import { GuildSwitcher } from "./guild-switcher";
 
 const mockUseAccessibleGuilds = vi.fn();
 const mockUseUserPreferences = vi.fn();
+const runtime = vi.hoisted(() => ({ heroId: 123 as number | undefined }));
 
-vi.mock("@/lib/api/generated/main/users/users", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/lib/api/generated/main/users/users")
-  >("@/lib/api/generated/main/users/users");
-
-  return {
-    ...actual,
-    useUsersControllerGetCurrentUserAccessibleGuilds: () =>
-      mockUseAccessibleGuilds(),
-  };
-});
+vi.mock("@/lib/api/generated/main/users/users", () => ({
+  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey: () => [
+    "accessible-guilds",
+  ],
+  useUsersControllerGetCurrentUserAccessibleGuilds: () =>
+    mockUseAccessibleGuilds(),
+}));
 
 vi.mock("@/hooks/api/use-user-preferences", () => ({
   useUserPreferences: () => mockUseUserPreferences(),
@@ -26,7 +23,9 @@ vi.mock("@/hooks/api/use-user-preferences", () => ({
 vi.mock("@/lib/game", () => ({
   Game: {
     hero: {
-      id: 123,
+      get id() {
+        return runtime.heroId;
+      },
     },
   },
 }));
@@ -40,6 +39,8 @@ const createGuild = (id: string, name: string): GuildIdentity => ({
 describe("GuildSwitcher", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runtime.heroId = 123;
+    useSettingsStore.setState({ guildIdByCharId: {} });
 
     mockUseAccessibleGuilds.mockReturnValue({
       data: [
@@ -53,6 +54,31 @@ describe("GuildSwitcher", () => {
       data: {
         guildsOrder: [],
       },
+    });
+  });
+
+  it("does not initialize the global selection from an uncontrolled switcher", () => {
+    render(<GuildSwitcher />);
+
+    expect(useSettingsStore.getState().guildIdByCharId["123"]).toBeUndefined();
+  });
+
+  it("does not write a selection before the character identity is available", () => {
+    runtime.heroId = undefined;
+    render(<GuildSwitcher />);
+
+    fireEvent.click(screen.getAllByRole("button")[0]);
+
+    expect(useSettingsStore.getState().guildIdByCharId).toEqual({});
+  });
+
+  it("stores an explicitly clicked guild for the current character", () => {
+    render(<GuildSwitcher />);
+
+    fireEvent.click(screen.getAllByRole("button")[1]);
+
+    expect(useSettingsStore.getState().guildIdByCharId).toEqual({
+      "123": "guild-2",
     });
   });
 

--- a/apps/game-client/src/components/guild-switcher.tsx
+++ b/apps/game-client/src/components/guild-switcher.tsx
@@ -6,14 +6,14 @@ import { AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { type FC, useEffect, useRef } from "react";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { formatChatUnreadBadge } from "@/features/chat/chat-unread.helpers";
-import { Game } from "@/lib/game";
 import { GuildButton } from "@/components/guild-button";
-import type { GuildIdentity } from "@/lib/api/generated-helpers";
 import {
   getUsersControllerGetCurrentUserAccessibleGuildsQueryKey,
   useUsersControllerGetCurrentUserAccessibleGuilds,
 } from "@/lib/api/generated/main/users/users";
 import { useTranslation } from "react-i18next";
+import { orderLootlogGuilds } from "@/lib/selected-lootlog-guild";
+import { useCurrentCharacterId } from "@/hooks/use-selected-lootlog-guild";
 
 type GuildSwitcherProps = {
   disabled?: boolean;
@@ -28,30 +28,6 @@ type GuildSwitcherProps = {
   selectedValues?: string[];
   unreadCountByGuildId?: Record<string, number>;
   value?: string;
-};
-
-const orderGuilds = (
-  guilds: GuildIdentity[] | undefined,
-  guildsOrder?: string[],
-) => {
-  if (!guilds?.length) {
-    return [];
-  }
-
-  if (!guildsOrder?.length) {
-    return guilds;
-  }
-
-  const guildsById = new Map(guilds.map((guild) => [guild.id, guild] as const));
-  const orderedGuilds = guildsOrder
-    .map((guildId) => guildsById.get(guildId))
-    .filter((guild): guild is GuildIdentity => guild !== undefined);
-  const orderedGuildIds = new Set(orderedGuilds.map((guild) => guild.id));
-  const remainingGuilds = guilds.filter(
-    (guild) => !orderedGuildIds.has(guild.id),
-  );
-
-  return [...orderedGuilds, ...remainingGuilds];
 };
 
 export const GuildSwitcher: FC<GuildSwitcherProps> = ({
@@ -70,7 +46,7 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
 }) => {
   const { t } = useTranslation("common");
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
-  const characterId = String(Game.hero.id);
+  const characterId = useCurrentCharacterId();
   const { data: guilds, isFetched } =
     useUsersControllerGetCurrentUserAccessibleGuilds({
       query: {
@@ -82,33 +58,20 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
   const { data: userPreferences } = useUserPreferences();
   const { setGuildId, guildIdByCharId } = useSettingsStore();
   const guildsOrder = userPreferences?.guildsOrder;
-  const orderedGuilds = orderGuilds(guilds, guildsOrder);
+  const orderedGuilds = orderLootlogGuilds(guilds ?? [], guildsOrder);
 
-  const guildId = guildIdByCharId[characterId];
+  const guildId = characterId ? guildIdByCharId[characterId] : undefined;
 
   useEffect(() => {
     if (!isFetched || orderedGuilds.length === 0) return;
     if (multiple) return;
-    const currentValue = value !== undefined ? value : guildId;
+    if (!onChange) return;
+    const currentValue = value;
     if (allowAll && currentValue === "all") return;
     const exists = orderedGuilds.some((guild) => guild.id === currentValue);
     if (exists) return;
-    if (onChange) {
-      onChange(orderedGuilds[0].id);
-    } else {
-      setGuildId(characterId, orderedGuilds[0].id);
-    }
-  }, [
-    isFetched,
-    orderedGuilds,
-    guildId,
-    value,
-    allowAll,
-    multiple,
-    onChange,
-    characterId,
-    setGuildId,
-  ]);
+    onChange(orderedGuilds[0].id);
+  }, [isFetched, orderedGuilds, value, allowAll, multiple, onChange]);
 
   const selectedValue = value !== undefined ? value : guildId;
   const selectedGuildIds = selectedValues ?? [];
@@ -127,7 +90,9 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
       return;
     }
 
-    setGuildId(characterId, newGuildId);
+    if (characterId) {
+      setGuildId(characterId, newGuildId);
+    }
   };
 
   useEffect(() => {

--- a/apps/game-client/src/hooks/game-events/use-character-tooltip-catching-guilds.ts
+++ b/apps/game-client/src/hooks/game-events/use-character-tooltip-catching-guilds.ts
@@ -3,13 +3,10 @@ import { characterTooltipCatchingGuildsCoordinator } from "@/lib/character-toolt
 import { appendCatchingGuildsTooltipSection } from "@/lib/margonem-tooltips/catching-guilds";
 import { refreshActiveOtherCanvasTooltip } from "@/lib/margonem-tooltips/patcher";
 import { characterTooltipTransforms } from "@/lib/margonem-tooltips/registry";
-import {
-  getSelectedLootlogGuildId,
-  isConcreteLootlogGuildId,
-} from "@/lib/selected-lootlog-guild";
+import { isConcreteLootlogGuildId } from "@/lib/selected-lootlog-guild";
+import { useSelectedLootlogGuildId } from "@/hooks/use-selected-lootlog-guild";
 import { useCharacterTooltipCatchingGuildsStore } from "@/store/character-tooltip-catching-guilds.store";
 import { useOnlineCharacterOwnersStore } from "@/store/online-character-owners.store";
-import { useSettingsStore } from "@/store/settings.store";
 
 function refreshActiveOtherTooltip(): void {
   refreshActiveOtherCanvasTooltip();
@@ -39,8 +36,7 @@ export function useCharacterTooltipCatchingGuilds(): void {
   const ownersByCharacterKey = useOnlineCharacterOwnersStore(
     (state) => state.ownersByCharacterKey,
   );
-  const guildIdByCharId = useSettingsStore((state) => state.guildIdByCharId);
-  const selectedGuildId = getSelectedLootlogGuildId(guildIdByCharId);
+  const selectedGuildId = useSelectedLootlogGuildId();
 
   useEffect(() => {
     return characterTooltipTransforms.register(

--- a/apps/game-client/src/hooks/game-events/use-online-character-owners.ts
+++ b/apps/game-client/src/hooks/game-events/use-online-character-owners.ts
@@ -9,10 +9,8 @@ import {
   requestServerPresence,
   type PlayerPresenceUpdatePayload,
 } from "@/lib/online-players-presence";
-import {
-  getSelectedLootlogGuildId,
-  isConcreteLootlogGuildId,
-} from "@/lib/selected-lootlog-guild";
+import { isConcreteLootlogGuildId } from "@/lib/selected-lootlog-guild";
+import { useSelectedLootlogGuildId } from "@/hooks/use-selected-lootlog-guild";
 import { useCharacterTooltipCatchingGuildsStore } from "@/store/character-tooltip-catching-guilds.store";
 import {
   type GuildMembersByUserId,
@@ -76,9 +74,8 @@ export function useOnlineCharacterOwners(): void {
     (state) => state.isShiftPressed,
   );
   const ownersStatus = useOnlineCharacterOwnersStore((state) => state.status);
-  const guildIdByCharId = useSettingsStore((state) => state.guildIdByCharId);
   const worldByGuildId = useSettingsStore((state) => state.worldByGuildId);
-  const selectedGuildId = getSelectedLootlogGuildId(guildIdByCharId);
+  const selectedGuildId = useSelectedLootlogGuildId();
   const selectedWorld = isConcreteLootlogGuildId(selectedGuildId)
     ? (worldByGuildId[selectedGuildId] ?? getCurrentWorld())
     : undefined;

--- a/apps/game-client/src/hooks/game-events/use-other-catching-guild-glow.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-other-catching-guild-glow.test.tsx
@@ -11,9 +11,13 @@ import { useCharacterTooltipCatchingGuildsStore } from "@/store/character-toolti
 import { useOnlineCharacterOwnersStore } from "@/store/online-character-owners.store";
 import { useOthersStore } from "@/store/others.store";
 import { useSettingsStore } from "@/store/settings.store";
+import { useGlobalStore } from "@/store/global.store";
 
 const mocks = vi.hoisted(() => ({
+  afterGameEventHandler: undefined as (() => void) | undefined,
+  getAccessibleGuilds: vi.fn(),
   getPlayersCatchingGuilds: vi.fn(),
+  getUserPreferences: vi.fn(),
 }));
 
 vi.mock(
@@ -24,7 +28,33 @@ vi.mock(
   }),
 );
 
+vi.mock("@/lib/api/generated/main/users/users", () => ({
+  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey: () => [
+    "accessible-guilds",
+  ],
+  useUsersControllerGetCurrentUserAccessibleGuilds: () =>
+    mocks.getAccessibleGuilds(),
+}));
+
+vi.mock("@/hooks/api/use-user-preferences", () => ({
+  useUserPreferences: () => mocks.getUserPreferences(),
+}));
+
+vi.mock("@/lib/game-events-manager", () => ({
+  gameEventsManager: {
+    subscribeAfterGameEvent: (handler: () => void) => {
+      mocks.afterGameEventHandler = handler;
+      return () => {
+        if (mocks.afterGameEventHandler === handler) {
+          mocks.afterGameEventHandler = undefined;
+        }
+      };
+    },
+  },
+}));
+
 import { useOtherCatchingGuildGlow } from "./use-other-catching-guild-glow";
+import { useSelectedLootlogGuildInitialization } from "../use-selected-lootlog-guild";
 
 const originalWindowEngine = window.Engine;
 
@@ -65,13 +95,13 @@ function setOnlineOwners(others: Record<string, Other>): void {
   });
 }
 
-function setRuntime(): void {
+function setRuntime(heroId: number | null | undefined = 101): void {
   Object.defineProperty(window, "Engine", {
     configurable: true,
     value: {
       hero: {
         d: {
-          id: "hero-1",
+          id: heroId,
         },
       },
       imgLoader: {
@@ -97,11 +127,25 @@ function setRuntime(): void {
 
 describe("useOtherCatchingGuildGlow", () => {
   beforeEach(() => {
+    mocks.afterGameEventHandler = undefined;
+    mocks.getAccessibleGuilds.mockReset();
     mocks.getPlayersCatchingGuilds.mockReset();
+    mocks.getUserPreferences.mockReset();
+    mocks.getAccessibleGuilds.mockReturnValue({
+      data: [{ id: "guild-blue", name: "Blue Guild", icon: null }],
+      isFetched: true,
+    });
+    mocks.getUserPreferences.mockReturnValue({
+      data: { guildsOrder: ["guild-blue"] },
+      isFetched: true,
+    });
     lootlogOtherGlowManager.cleanup();
     useCharacterTooltipCatchingGuildsStore.getState().clear();
     useOnlineCharacterOwnersStore.getState().clearOwners();
     useOthersStore.getState().clearOthers();
+    useGlobalStore.setState({
+      gameState: { gameInitialized: true },
+    });
     useSettingsStore.setState({
       guildIdByCharId: {},
     });
@@ -116,6 +160,113 @@ describe("useOtherCatchingGuildGlow", () => {
     });
   });
 
+  it("uses the default guild on the first shift without a manual guild change", async () => {
+    const other = createOther("1");
+    setRuntime(undefined);
+    mocks.getAccessibleGuilds.mockReturnValue({
+      data: [
+        { id: "guild-red", name: "Red Guild", icon: null },
+        { id: "guild-blue", name: "Blue Guild", icon: null },
+      ],
+      isFetched: true,
+    });
+    useOthersStore.getState().setMany({ "1": other });
+    setOnlineOwners({ "1": other });
+    mocks.getPlayersCatchingGuilds.mockResolvedValue({
+      players: [
+        {
+          userId: "player-discord",
+          accountId: String(other.d.account),
+          characterId: String(other.d.id),
+          guilds: [{ id: "guild-blue", name: "Blue Guild" }],
+        },
+      ],
+    });
+
+    renderHook(() => {
+      useSelectedLootlogGuildInitialization();
+      useOtherCatchingGuildGlow();
+    });
+
+    expect(useSettingsStore.getState().guildIdByCharId).not.toHaveProperty(
+      "undefined",
+    );
+
+    window.Engine.hero.d.id = 101;
+    act(() => {
+      mocks.afterGameEventHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().guildIdByCharId["101"]).toBe(
+        "guild-blue",
+      );
+    });
+
+    act(() => {
+      useCharacterTooltipCatchingGuildsStore.getState().setShiftPressed(true);
+    });
+
+    await waitFor(() => {
+      expect(mocks.getPlayersCatchingGuilds).toHaveBeenCalledOnce();
+      expect(lootlogOtherGlowManager.getGlowColor("1")).toBe(
+        LOOTLOG_OTHER_GLOW_BLUE,
+      );
+    });
+  });
+
+  it("does not create a selection from a null character ID", () => {
+    setRuntime(null);
+
+    renderHook(() => useSelectedLootlogGuildInitialization());
+
+    expect(useSettingsStore.getState().guildIdByCharId).toEqual({});
+  });
+
+  it("uses API guild order when preferences finish without data", async () => {
+    mocks.getAccessibleGuilds.mockReturnValue({
+      data: [
+        { id: "guild-red", name: "Red Guild", icon: null },
+        { id: "guild-blue", name: "Blue Guild", icon: null },
+      ],
+      isFetched: true,
+    });
+    mocks.getUserPreferences.mockReturnValue({
+      data: undefined,
+      isFetched: true,
+    });
+
+    renderHook(() => useSelectedLootlogGuildInitialization());
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().guildIdByCharId["101"]).toBe(
+        "guild-red",
+      );
+    });
+  });
+
+  it("initializes a separate default after the current character changes", async () => {
+    renderHook(() => useSelectedLootlogGuildInitialization());
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().guildIdByCharId["101"]).toBe(
+        "guild-blue",
+      );
+    });
+
+    window.Engine.hero.d.id = 202;
+    act(() => {
+      mocks.afterGameEventHandler?.();
+    });
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().guildIdByCharId).toEqual({
+        "101": "guild-blue",
+        "202": "guild-blue",
+      });
+    });
+  });
+
   it("does one batch request for many others and colors successful entries by selected guild", async () => {
     const others = Object.fromEntries(
       Array.from({ length: 50 }, (_, index) => {
@@ -127,7 +278,7 @@ describe("useOtherCatchingGuildGlow", () => {
     setOnlineOwners(others);
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
     mocks.getPlayersCatchingGuilds.mockResolvedValue({
@@ -181,7 +332,7 @@ describe("useOtherCatchingGuildGlow", () => {
     setOnlineOwners(others);
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
     mocks.getPlayersCatchingGuilds.mockImplementation(
@@ -223,7 +374,7 @@ describe("useOtherCatchingGuildGlow", () => {
     setOnlineOwners(others);
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
     mocks.getPlayersCatchingGuilds.mockRejectedValue(new Error("broken"));
@@ -266,7 +417,7 @@ describe("useOtherCatchingGuildGlow", () => {
     useOthersStore.getState().setMany({ "1": other });
     setOnlineOwners({ "1": other });
     useSettingsStore.setState({
-      guildIdByCharId: { "hero-1": "all" },
+      guildIdByCharId: { "101": "all" },
     });
 
     renderHook(() => useOtherCatchingGuildGlow());
@@ -285,7 +436,7 @@ describe("useOtherCatchingGuildGlow", () => {
     });
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
 
@@ -308,7 +459,7 @@ describe("useOtherCatchingGuildGlow", () => {
     });
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
     mocks.getPlayersCatchingGuilds.mockResolvedValue({
@@ -368,7 +519,7 @@ describe("useOtherCatchingGuildGlow", () => {
     setOnlineOwners({ "1": firstOther, "2": secondOther });
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
     mocks.getPlayersCatchingGuilds
@@ -438,7 +589,7 @@ describe("useOtherCatchingGuildGlow", () => {
     setOnlineOwners({ "1": other });
     useSettingsStore.setState({
       guildIdByCharId: {
-        "hero-1": "guild-blue",
+        "101": "guild-blue",
       },
     });
     mocks.getPlayersCatchingGuilds.mockResolvedValue({

--- a/apps/game-client/src/hooks/game-events/use-other-catching-guild-glow.ts
+++ b/apps/game-client/src/hooks/game-events/use-other-catching-guild-glow.ts
@@ -6,10 +6,8 @@ import {
   LOOTLOG_OTHER_GLOW_UNKNOWN,
   lootlogOtherGlowManager,
 } from "@/lib/lootlog-other-glow-manager";
-import {
-  getSelectedLootlogGuildId,
-  isConcreteLootlogGuildId,
-} from "@/lib/selected-lootlog-guild";
+import { isConcreteLootlogGuildId } from "@/lib/selected-lootlog-guild";
+import { useSelectedLootlogGuildId } from "@/hooks/use-selected-lootlog-guild";
 import {
   getOtherCatchingGuildsTarget,
   getCharacterTooltipCatchingGuildsCharacterKey,
@@ -18,7 +16,6 @@ import {
 } from "@/store/character-tooltip-catching-guilds.store";
 import { useOnlineCharacterOwnersStore } from "@/store/online-character-owners.store";
 import { useOthersStore } from "@/store/others.store";
-import { useSettingsStore } from "@/store/settings.store";
 
 function getEntryCharacterId(targetKey: string): string {
   const separatorIndex = targetKey.lastIndexOf(":");
@@ -51,12 +48,11 @@ export function useOtherCatchingGuildGlow(): void {
   const isShiftPressed = useCharacterTooltipCatchingGuildsStore(
     (state) => state.isShiftPressed,
   );
-  const guildIdByCharId = useSettingsStore((state) => state.guildIdByCharId);
   const othersById = useOthersStore((state) => state.othersById);
   const ownersByCharacterKey = useOnlineCharacterOwnersStore(
     (state) => state.ownersByCharacterKey,
   );
-  const selectedGuildId = getSelectedLootlogGuildId(guildIdByCharId);
+  const selectedGuildId = useSelectedLootlogGuildId();
 
   useEffect(() => {
     lootlogOtherGlowManager.install();

--- a/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
+++ b/apps/game-client/src/hooks/game-events/use-who-is-here-lootlog-highlight.ts
@@ -2,17 +2,14 @@ import type { Other } from "@lootlog/margonem/others";
 import { useEffect, useRef, useState } from "react";
 import { getLootlogOtherGlowColor } from "@/lib/lootlog-other-glow-manager";
 import { patchOtherCharacterTooltip } from "@/lib/margonem-tooltips/patcher";
-import {
-  getSelectedLootlogGuildId,
-  isConcreteLootlogGuildId,
-} from "@/lib/selected-lootlog-guild";
+import { isConcreteLootlogGuildId } from "@/lib/selected-lootlog-guild";
+import { useSelectedLootlogGuildId } from "@/hooks/use-selected-lootlog-guild";
 import {
   getOtherCatchingGuildsTarget,
   useCharacterTooltipCatchingGuildsStore,
 } from "@/store/character-tooltip-catching-guilds.store";
 import { useOnlineCharacterOwnersStore } from "@/store/online-character-owners.store";
 import { useOthersStore } from "@/store/others.store";
-import { useSettingsStore } from "@/store/settings.store";
 
 const HIGHLIGHT_CLASS = "ll-who-is-here-lootlog-highlight";
 const STYLE_ELEMENT_ID = "ll-who-is-here-lootlog-style";
@@ -162,12 +159,11 @@ export function useWhoIsHereLootlogHighlight(): void {
   const activeTarget = useCharacterTooltipCatchingGuildsStore(
     (state) => state.activeTarget,
   );
-  const guildIdByCharId = useSettingsStore((state) => state.guildIdByCharId);
   const othersById = useOthersStore((state) => state.othersById);
   const ownersByCharacterKey = useOnlineCharacterOwnersStore(
     (state) => state.ownersByCharacterKey,
   );
-  const selectedGuildId = getSelectedLootlogGuildId(guildIdByCharId);
+  const selectedGuildId = useSelectedLootlogGuildId();
 
   useEffect(() => {
     const cleanupStyle = installStyle();

--- a/apps/game-client/src/hooks/use-selected-lootlog-guild.ts
+++ b/apps/game-client/src/hooks/use-selected-lootlog-guild.ts
@@ -1,0 +1,76 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { useUserPreferences } from "@/hooks/api/use-user-preferences";
+import { gameEventsManager } from "@/lib/game-events-manager";
+import {
+  getCurrentCharacterId,
+  orderLootlogGuilds,
+} from "@/lib/selected-lootlog-guild";
+import { useGlobalStore } from "@/store/global.store";
+import { useSettingsStore } from "@/store/settings.store";
+import {
+  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey,
+  useUsersControllerGetCurrentUserAccessibleGuilds,
+} from "@/lib/api/generated/main/users/users";
+
+const subscribeToCurrentCharacter = (onStoreChange: () => void) =>
+  gameEventsManager.subscribeAfterGameEvent(onStoreChange);
+
+export function useCurrentCharacterId(): string | null {
+  return useSyncExternalStore(
+    subscribeToCurrentCharacter,
+    getCurrentCharacterId,
+    getCurrentCharacterId,
+  );
+}
+
+export function useSelectedLootlogGuildId(): string | undefined {
+  const characterId = useCurrentCharacterId();
+
+  return useSettingsStore((state) =>
+    characterId ? state.guildIdByCharId[characterId] : undefined,
+  );
+}
+
+export function useSelectedLootlogGuildInitialization(): void {
+  const gameInitialized = useGlobalStore(
+    (state) => state.gameState.gameInitialized,
+  );
+  const characterId = useCurrentCharacterId();
+  const queryEnabled = gameInitialized && Boolean(characterId);
+  const { data: guilds, isFetched: areGuildsFetched } =
+    useUsersControllerGetCurrentUserAccessibleGuilds({
+      query: {
+        queryKey: getUsersControllerGetCurrentUserAccessibleGuildsQueryKey(),
+        enabled: queryEnabled,
+      },
+    });
+  const { data: userPreferences, isFetched: areUserPreferencesFetched } =
+    useUserPreferences(queryEnabled);
+  const ensureGuildId = useSettingsStore((state) => state.ensureGuildId);
+
+  useEffect(() => {
+    if (
+      !queryEnabled ||
+      !characterId ||
+      !areGuildsFetched ||
+      !areUserPreferencesFetched ||
+      !guilds?.length
+    ) {
+      return;
+    }
+
+    const orderedGuildIds = orderLootlogGuilds(
+      guilds,
+      userPreferences?.guildsOrder,
+    ).map((guild) => guild.id);
+    ensureGuildId(characterId, orderedGuildIds);
+  }, [
+    areGuildsFetched,
+    areUserPreferencesFetched,
+    characterId,
+    ensureGuildId,
+    guilds,
+    queryEnabled,
+    userPreferences?.guildsOrder,
+  ]);
+}

--- a/apps/game-client/src/lib/selected-lootlog-guild.ts
+++ b/apps/game-client/src/lib/selected-lootlog-guild.ts
@@ -1,11 +1,38 @@
 import { Game } from "@/lib/game";
+import type { GuildIdentity } from "@/lib/api/generated-helpers";
 
 export function getCurrentCharacterId(): string | null {
   try {
-    return String(Game.hero.id);
+    const characterId = Game.hero?.id;
+    if (characterId === undefined || characterId === null) {
+      return null;
+    }
+
+    const normalizedCharacterId = String(characterId).trim();
+    return normalizedCharacterId || null;
   } catch {
     return null;
   }
+}
+
+export function orderLootlogGuilds(
+  guilds: GuildIdentity[],
+  guildsOrder?: string[],
+): GuildIdentity[] {
+  if (!guildsOrder?.length) {
+    return guilds;
+  }
+
+  const guildsById = new Map(guilds.map((guild) => [guild.id, guild] as const));
+  const orderedGuilds = guildsOrder
+    .map((guildId) => guildsById.get(guildId))
+    .filter((guild): guild is GuildIdentity => guild !== undefined);
+  const orderedGuildIds = new Set(orderedGuilds.map((guild) => guild.id));
+
+  return [
+    ...orderedGuilds,
+    ...guilds.filter((guild) => !orderedGuildIds.has(guild.id)),
+  ];
 }
 
 export function getSelectedLootlogGuildId(

--- a/apps/game-client/src/store/settings.store.test.ts
+++ b/apps/game-client/src/store/settings.store.test.ts
@@ -37,4 +37,55 @@ describe("useSettingsStore", () => {
 
     expect(storedSettings.state?.animationEffectsEnabled).toBe(false);
   });
+
+  it("uses the first accessible guild when the current selection is missing", () => {
+    useSettingsStore
+      .getState()
+      .ensureGuildId("character-1", ["guild-2", "guild-1"]);
+
+    expect(useSettingsStore.getState().guildIdByCharId).toEqual({
+      "character-1": "guild-2",
+    });
+  });
+
+  it("replaces an inaccessible guild without changing other characters", () => {
+    useSettingsStore.setState({
+      guildIdByCharId: {
+        "character-1": "missing-guild",
+        "character-2": "guild-3",
+      },
+    });
+
+    useSettingsStore
+      .getState()
+      .ensureGuildId("character-1", ["guild-1", "guild-2"]);
+
+    expect(useSettingsStore.getState().guildIdByCharId).toEqual({
+      "character-1": "guild-1",
+      "character-2": "guild-3",
+    });
+  });
+
+  it.each(["all", "guild-2"])(
+    "preserves the valid %s selection",
+    (selectedGuildId) => {
+      useSettingsStore.setState({
+        guildIdByCharId: { "character-1": selectedGuildId },
+      });
+
+      useSettingsStore
+        .getState()
+        .ensureGuildId("character-1", ["guild-1", "guild-2"]);
+
+      expect(useSettingsStore.getState().guildIdByCharId["character-1"]).toBe(
+        selectedGuildId,
+      );
+    },
+  );
+
+  it("does not create a selection without accessible guilds", () => {
+    useSettingsStore.getState().ensureGuildId("character-1", []);
+
+    expect(useSettingsStore.getState().guildIdByCharId).toEqual({});
+  });
 });

--- a/apps/game-client/src/store/settings.store.ts
+++ b/apps/game-client/src/store/settings.store.ts
@@ -10,6 +10,7 @@ interface SettingsState {
   worldByGuildId: Record<string, string>;
   guildIdByCharId: Record<string, string>;
   selectedGuildIdsForTimersByCharId: Record<string, string[]>;
+  ensureGuildId: (charId: string, orderedGuildIds: string[]) => void;
   setGuildId: (charId: string, guildId: string) => void;
   setSelectedGuildIdsForTimers: (charId: string, guildIds: string[]) => void;
   setWorld: (guildId: string, world: string) => void;
@@ -25,6 +26,29 @@ export const useSettingsStore = create<SettingsState>()(
       worldByGuildId: {},
       guildIdByCharId: {},
       selectedGuildIdsForTimersByCharId: {},
+      ensureGuildId: (charId: string, orderedGuildIds: string[]) => {
+        set((state) => {
+          const currentGuildId = state.guildIdByCharId[charId];
+          if (
+            currentGuildId === "all" ||
+            (currentGuildId && orderedGuildIds.includes(currentGuildId))
+          ) {
+            return state;
+          }
+
+          const fallbackGuildId = orderedGuildIds[0];
+          if (!fallbackGuildId) {
+            return state;
+          }
+
+          return {
+            guildIdByCharId: {
+              ...state.guildIdByCharId,
+              [charId]: fallbackGuildId,
+            },
+          };
+        });
+      },
       setGuildId: (charId: string, guildId: string) => {
         set((state) => ({
           guildIdByCharId: {


### PR DESCRIPTION
## Summary

- initialize the selected lootlog guild centrally after game initialization, character resolution, and guild/preferences queries
- add a reactive current-character hook and a shared selected-guild hook for glow, tooltip, presence, and the who-is-here list
- atomically preserve valid manual selections and `all`, while replacing missing or inaccessible guilds with the first ordered accessible guild
- remove global selection initialization from `GuildSwitcher` while preserving controlled fallback behavior

## Root cause

The default selection was initialized as a side effect of mounting `GuildSwitcher`. On the first game load, the switcher could be absent or the hero ID could still be unavailable, leaving the lootlog feature without a selected guild until the user changed it manually.

## Impact

The first Shift after entering the game now uses the automatically initialized guild and shows the expected player glow without opening a window or changing the guild first. Character changes receive independent defaults, and invalid raw hero IDs no longer create settings entries such as `undefined`.

## Validation

- `pnpm exec vitest run` — 157 files, 766 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm exec oxlint <changed files>` — 0 warnings, 0 errors
- `pnpm exec oxfmt --check <changed files>`
- `pnpm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guild selections are now initialized automatically for the active character.
  * Guild ordering follows saved preferences, with sensible fallback selection.
  * Guild selections are preserved per character and updated safely when switching guilds.
  * Game highlights, tooltips, online presence, and catching indicators now consistently reflect the selected guild.

* **Bug Fixes**
  * Prevented guild selections from being stored before character identity is available.
  * Improved handling when selected guilds are unavailable or no accessible guilds exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->