### PR TITLE
feat(game-client): add toggleable loot debug logs

### DIFF
--- a/apps/game-client/src/api/loot.api.ts
+++ b/apps/game-client/src/api/loot.api.ts
@@ -1,4 +1,8 @@
 import { getApiClient } from "@/lib/api-client";
+import {
+  logLootCreateDebug,
+  type LootCreateDebugContext,
+} from "@/lib/loot-create-debug";
 import { runSingleLoggedAction } from "@/lib/logs/log-actions";
 import { GAME_EVENT_RETRY_OPTIONS } from "@/api/retry-policy";
 import type { Item } from "@lootlog/margonem/game-events";
@@ -48,8 +52,10 @@ type CreateLootResponse = {
 
 export async function createLoot(
   options: CreateLootOptions,
+  debugContext: LootCreateDebugContext,
 ): Promise<CreateLootResponse> {
   const client = getApiClient("default");
+  let attempt = 0;
   const response = await runSingleLoggedAction({
     actionType: "create_loot",
     actionPayload: options,
@@ -58,7 +64,36 @@ export async function createLoot(
       endpoint: "/loots",
       payload: options,
     },
-    execute: () => client.post<CreateLootResponse>("/loots", options),
+    execute: async () => {
+      attempt += 1;
+      logLootCreateDebug("http-request", {
+        ...debugContext,
+        attempt,
+        endpoint: "/loots",
+        method: "POST",
+        payload: options,
+      });
+
+      try {
+        const requestResponse = await client.post<CreateLootResponse>(
+          "/loots",
+          options,
+        );
+        logLootCreateDebug("http-success", {
+          ...debugContext,
+          attempt,
+          response: requestResponse.data,
+        });
+        return requestResponse;
+      } catch (error) {
+        logLootCreateDebug("http-error", {
+          ...debugContext,
+          attempt,
+          error,
+        });
+        throw error;
+      }
+    },
     retry: GAME_EVENT_RETRY_OPTIONS,
   });
 

--- a/apps/game-client/src/features/settings/components/logs/logs-settings-tab.test.tsx
+++ b/apps/game-client/src/features/settings/components/logs/logs-settings-tab.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LogsSettingsTab } from "./logs-settings-tab";
 import { LOGS_STORAGE_KEY, useLogsStore } from "@/store/logs.store";
+import { useSettingsStore } from "@/store/settings.store";
 
 const toastMocks = vi.hoisted(() => ({
   success: vi.fn(),
@@ -31,6 +32,7 @@ describe("LogsSettingsTab", () => {
     vi.clearAllMocks();
     window.localStorage.removeItem(LOGS_STORAGE_KEY);
     useLogsStore.getState().clearActions();
+    useSettingsStore.getState().setLootDebugLoggingEnabled(false);
 
     const clipboard = {
       writeText: mockClipboardWriteText,
@@ -101,6 +103,22 @@ describe("LogsSettingsTab", () => {
         },
       ],
     });
+  });
+
+  it("enables loot debug console logging", async () => {
+    const user = userEvent.setup();
+    const { container } = render(<LogsSettingsTab />);
+    const toggle = container.querySelector("#loot-debug-logging");
+
+    expect(toggle).toBeInTheDocument();
+    expect(useSettingsStore.getState().lootDebugLoggingEnabled).toBe(false);
+    if (!toggle) {
+      throw new Error("Loot debug logging toggle was not rendered");
+    }
+
+    await user.click(toggle);
+
+    expect(useSettingsStore.getState().lootDebugLoggingEnabled).toBe(true);
   });
 
   it("filters actions by search, type and status", async () => {

--- a/apps/game-client/src/features/settings/components/logs/logs-settings-tab.tsx
+++ b/apps/game-client/src/features/settings/components/logs/logs-settings-tab.tsx
@@ -1,8 +1,10 @@
 import { SettingsEmptyState } from "@/components/settings/settings-empty-state";
+import { SettingsControlRow } from "@/components/settings/settings-control-row";
 import { SettingsSection } from "@/components/settings/settings-section";
 import { SettingsTabLayout } from "@/components/settings/settings-tab-layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -25,6 +27,7 @@ import {
   type LoggedAction,
   type LoggedApiRequest,
 } from "@/store/logs.store";
+import { useSettingsStore } from "@/store/settings.store";
 import { toast } from "sonner";
 import { type FC, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -38,6 +41,12 @@ const FILTER_CONTROL_CLASS_NAME = "ll:w-full ll:text-xs";
 export const LogsSettingsTab: FC = () => {
   const actions = useLogsStore((state) => state.actions);
   const clearActions = useLogsStore((state) => state.clearActions);
+  const lootDebugLoggingEnabled = useSettingsStore(
+    (state) => state.lootDebugLoggingEnabled,
+  );
+  const setLootDebugLoggingEnabled = useSettingsStore(
+    (state) => state.setLootDebugLoggingEnabled,
+  );
   const [actionTypeFilter, setActionTypeFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState<LogStatusFilter>("all");
   const [searchTerm, setSearchTerm] = useState("");
@@ -143,6 +152,19 @@ export const LogsSettingsTab: FC = () => {
         </div>
       }
     >
+      <SettingsSection title={t("settings.logs.consoleDebugTitle")}>
+        <SettingsControlRow
+          label={t("settings.logs.lootDebugLoggingLabel")}
+          description={t("settings.logs.lootDebugLoggingDescription")}
+        >
+          <Switch
+            checked={lootDebugLoggingEnabled}
+            id="loot-debug-logging"
+            onCheckedChange={setLootDebugLoggingEnabled}
+          />
+        </SettingsControlRow>
+      </SettingsSection>
+
       <SettingsSection
         title={t("settings.logs.filtersTitle")}
         description={t("settings.logs.filtersDescription")}

--- a/apps/game-client/src/i18n/translations/settings.json
+++ b/apps/game-client/src/i18n/translations/settings.json
@@ -291,6 +291,9 @@
   "logs": {
     "title": "Logi",
     "description": "Zapisane akcje użytkownika z rozwijanymi wywołaniami API, payloadem, odpowiedzią i statusem.",
+    "consoleDebugTitle": "Diagnostyka konsoli",
+    "lootDebugLoggingLabel": "Loguj tworzenie łupów",
+    "lootDebugLoggingDescription": "Zapisuje w konsoli przeglądarki pełny przebieg tworzenia łupów z walk i dialogów. Logi zawierają pełne payloady, w tym nazwy oraz identyfikatory kont, postaci i NPC.",
     "filtersTitle": "Filtry",
     "filtersDescription": "Zawęź wpisy po typie, statusie lub fragmencie treści.",
     "searchPlaceholder": "Szukaj w logach",

--- a/apps/game-client/src/lib/loot-create-debug.test.ts
+++ b/apps/game-client/src/lib/loot-create-debug.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsStore } from "@/store/settings.store";
+import {
+  LOOT_CREATE_DEBUG_PREFIX,
+  createLootDebugContext,
+  logLootCreateDebug,
+} from "./loot-create-debug";
+
+describe("loot create debug logging", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useSettingsStore.getState().setLootDebugLoggingEnabled(false);
+  });
+
+  it("does not write to the console when logging is disabled", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+
+    logLootCreateDebug("event-detected", {
+      attemptId: "attempt-1",
+      source: "dialog",
+    });
+
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it("writes structured lifecycle details when logging is enabled", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+
+    logLootCreateDebug("request-prepared", {
+      attemptId: "attempt-1",
+      payload: { source: "DIALOG" },
+      source: "dialog",
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "attempt-1",
+      payload: { source: "DIALOG" },
+      source: "dialog",
+      stage: "request-prepared",
+    });
+  });
+
+  it("creates a correlation context for a loot attempt", () => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000001",
+    );
+
+    expect(createLootDebugContext("fight")).toEqual({
+      attemptId: "00000000-0000-4000-8000-000000000001",
+      source: "fight",
+    });
+  });
+});

--- a/apps/game-client/src/lib/loot-create-debug.ts
+++ b/apps/game-client/src/lib/loot-create-debug.ts
@@ -1,0 +1,30 @@
+import { useSettingsStore } from "@/store/settings.store";
+
+export const LOOT_CREATE_DEBUG_PREFIX = "[DEBUG-loot-create]";
+
+export type LootCreateDebugContext = {
+  attemptId: string;
+  source: "dialog" | "fight";
+};
+
+export const createLootDebugContext = (
+  source: LootCreateDebugContext["source"],
+): LootCreateDebugContext => ({
+  attemptId: crypto.randomUUID(),
+  source,
+});
+
+export const logLootCreateDebug = (
+  stage: string,
+  details: Record<string, unknown>,
+): void => {
+  if (!useSettingsStore.getState().lootDebugLoggingEnabled) {
+    return;
+  }
+
+  // oxlint-disable-next-line no-console -- This module intentionally emits opt-in console diagnostics.
+  console.log(LOOT_CREATE_DEBUG_PREFIX, {
+    ...details,
+    stage,
+  });
+};

--- a/apps/game-client/src/processors/dialog-processor.test.ts
+++ b/apps/game-client/src/processors/dialog-processor.test.ts
@@ -1,5 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LOOT_CREATE_DEBUG_PREFIX } from "@/lib/loot-create-debug";
 import { useDialogStore } from "@/store/game-store/dialog.store";
+import { useSettingsStore } from "@/store/settings.store";
 import { DialogProcessor } from "./dialog-processor";
 
 describe("DialogProcessor", () => {
@@ -10,6 +12,7 @@ describe("DialogProcessor", () => {
     useDialogStore.setState({
       talkingNpcId: null,
     });
+    useSettingsStore.getState().setLootDebugLoggingEnabled(false);
   });
 
   it("ignores invalid dialog payloads", () => {
@@ -25,5 +28,21 @@ describe("DialogProcessor", () => {
     processor.handle({ d: ["show", "dialog", "404"] });
 
     expect(useDialogStore.getState().talkingNpcId).toBe("404");
+  });
+
+  it("logs tracked dialog npc context when loot debug logging is enabled", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    const event = { d: ["show", "dialog", "404"] };
+
+    processor.handle(event);
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      dialog: event.d,
+      npcId: "404",
+      stage: "dialog-npc-tracked",
+    });
   });
 });

--- a/apps/game-client/src/processors/dialog-processor.ts
+++ b/apps/game-client/src/processors/dialog-processor.ts
@@ -1,3 +1,4 @@
+import { logLootCreateDebug } from "@/lib/loot-create-debug";
 import { useDialogStore } from "@/store/game-store/dialog.store";
 import type { GameEvent } from "@lootlog/margonem/game-events";
 
@@ -9,6 +10,10 @@ export class DialogProcessor {
 
     if (npcId && typeof npcId === "string") {
       useDialogStore.getState().setTalkingNpcId(npcId);
+      logLootCreateDebug("dialog-npc-tracked", {
+        dialog: event.d,
+        npcId,
+      });
     }
   }
 }

--- a/apps/game-client/src/processors/loot-event-processor.test.ts
+++ b/apps/game-client/src/processors/loot-event-processor.test.ts
@@ -2,8 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useBattleStore } from "@/store/game-store/battle.store";
 import { useDialogStore } from "@/store/game-store/dialog.store";
 import { useLootStore } from "@/store/game-store/loot.store";
+import { LOOT_CREATE_DEBUG_PREFIX } from "@/lib/loot-create-debug";
+import { useSettingsStore } from "@/store/settings.store";
 import { LootEventProcessor } from "./loot-event-processor";
 import type { GameEvent } from "@lootlog/margonem/game-events";
+import type * as ApiModule from "@/api";
 
 const { mockCreateLoot, mockGetLoot, mockGetBattleParticipants, mockGame } =
   vi.hoisted(() => ({
@@ -32,7 +35,7 @@ const { mockCreateLoot, mockGetLoot, mockGetBattleParticipants, mockGame } =
   }));
 
 vi.mock("@/api", async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import("@/api")>();
+  const originalModule = await importOriginal<typeof ApiModule>();
 
   return {
     ...originalModule,
@@ -52,17 +55,6 @@ vi.mock("@/utils/game/get-battle-participants", () => ({
 vi.mock("@/lib/game", () => ({
   Game: mockGame,
 }));
-
-const createDeferred = <T>() => {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return { promise, resolve, reject };
-};
 
 const createBattleWarrior = () => ({
   id: 1,
@@ -137,6 +129,7 @@ describe("LootEventProcessor", () => {
     useDialogStore.setState({
       talkingNpcId: null,
     });
+    useSettingsStore.getState().setLootDebugLoggingEnabled(false);
   });
 
   it("ignores battle loot when item is missing or source is not fight", () => {
@@ -148,13 +141,34 @@ describe("LootEventProcessor", () => {
   });
 
   it("ignores battle loot when there are no tracked battle warriors", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000002",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+
     processor.handleLootFromBattle(createBattleLootEvent());
 
     expect(mockCreateLoot).not.toHaveBeenCalled();
     expect(useLootStore.getState().lastLootId).toBe(44);
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000002",
+      reason: "missing-battle-warriors",
+      source: "fight",
+      stage: "skipped",
+    });
   });
 
   it("creates loot from battle and stores returned loot id", async () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000001",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
     useBattleStore.setState({
       battleWarriors: {
         "1": createBattleWarrior(),
@@ -174,7 +188,19 @@ describe("LootEventProcessor", () => {
       id: 999,
     });
 
-    processor.handleLootFromBattle(createBattleLootEvent());
+    const event = createBattleLootEvent();
+    const expectedPayload = {
+      world: "pandora",
+      source: "FIGHT",
+      location: "Ithan",
+      npcs: [{ id: 501, name: "Boss" }],
+      loots: [{ id: 1, name: "Legendarny miecz" }],
+      players: [{ id: 101, name: "Tester" }],
+      accountId: "202",
+      characterId: "101",
+    };
+
+    processor.handleLootFromBattle(event);
 
     expect(useLootStore.getState().lastLootId).toBeNull();
 
@@ -184,20 +210,41 @@ describe("LootEventProcessor", () => {
     expect(mockGetBattleParticipants).toHaveBeenCalledWith(
       useBattleStore.getState().battleWarriors,
     );
-    expect(mockCreateLoot).toHaveBeenCalledWith({
-      world: "pandora",
-      source: "FIGHT",
-      location: "Ithan",
-      npcs: [{ id: 501, name: "Boss" }],
-      loots: [{ id: 1, name: "Legendarny miecz" }],
-      players: [{ id: 101, name: "Tester" }],
-      accountId: "202",
-      characterId: "101",
+    expect(mockCreateLoot).toHaveBeenCalledWith(expectedPayload, {
+      attemptId: "00000000-0000-4000-8000-000000000001",
+      source: "fight",
     });
     expect(useLootStore.getState().lastLootId).toBe(999);
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000001",
+      battleWarriors: useBattleStore.getState().battleWarriors,
+      event,
+      source: "fight",
+      stage: "event-detected",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000001",
+      payload: expectedPayload,
+      source: "fight",
+      stage: "request-prepared",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000001",
+      lastLootId: 999,
+      response: { id: 999 },
+      source: "fight",
+      stage: "completed",
+    });
   });
 
   it("stops battle loot creation when parsed loot list is empty", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000003",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
     useBattleStore.setState({
       battleWarriors: {
         "1": createBattleWarrior(),
@@ -209,12 +256,52 @@ describe("LootEventProcessor", () => {
 
     expect(mockCreateLoot).not.toHaveBeenCalled();
     expect(useLootStore.getState().lastLootId).toBeNull();
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000003",
+      reason: "empty-parsed-loots",
+      source: "fight",
+      stage: "skipped",
+    });
+  });
+
+  it("logs when battle fight data is missing", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000004",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    useBattleStore.setState({
+      battleWarriors: {
+        "1": createBattleWarrior(),
+      },
+    });
+    const event = createBattleLootEvent();
+    delete event.f;
+
+    processor.handleLootFromBattle(event);
+
+    expect(mockCreateLoot).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000004",
+      reason: "missing-fight-data",
+      source: "fight",
+      stage: "skipped",
+    });
   });
 
   it("logs warning when battle loot request fails", async () => {
     const consoleWarnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000005",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
 
     useBattleStore.setState({
       battleWarriors: {
@@ -237,16 +324,43 @@ describe("LootEventProcessor", () => {
       "[LootEventProcessor] Failed to create loot:",
       expect.any(Error),
     );
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000005",
+      error: expect.any(Error),
+      source: "fight",
+      stage: "failed",
+    });
   });
 
   it("ignores dialog loot without tracked npc", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000007",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+
     processor.handleDialogLoot(createDialogLootEvent());
 
     expect(mockCreateLoot).not.toHaveBeenCalled();
     expect(useLootStore.getState().lastLootId).toBe(44);
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000007",
+      reason: "missing-talking-npc-id",
+      source: "dialog",
+      stage: "skipped",
+    });
   });
 
   it("creates dialog loot using npcs_del payload", async () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000006",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
     useDialogStore.setState({
       talkingNpcId: "501",
     });
@@ -256,14 +370,8 @@ describe("LootEventProcessor", () => {
       id: 321,
     });
 
-    processor.handleDialogLoot(createDialogLootEvent([501]));
-
-    expect(useLootStore.getState().lastLootId).toBeNull();
-
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(mockCreateLoot).toHaveBeenCalledWith({
+    const event = createDialogLootEvent([501]);
+    const expectedPayload = {
       world: "pandora",
       source: "DIALOG",
       location: "Ithan",
@@ -294,6 +402,38 @@ describe("LootEventProcessor", () => {
       ],
       accountId: "202",
       characterId: "101",
+    };
+
+    processor.handleDialogLoot(event);
+
+    expect(useLootStore.getState().lastLootId).toBeNull();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCreateLoot).toHaveBeenCalledWith(expectedPayload, {
+      attemptId: "00000000-0000-4000-8000-000000000006",
+      source: "dialog",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000006",
+      event,
+      source: "dialog",
+      stage: "event-detected",
+      talkingNpcId: "501",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000006",
+      payload: expectedPayload,
+      source: "dialog",
+      stage: "request-prepared",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000006",
+      lastLootId: 321,
+      response: { id: 321 },
+      source: "dialog",
+      stage: "completed",
     });
     expect(useLootStore.getState().lastLootId).toBe(321);
   });
@@ -330,6 +470,13 @@ describe("LootEventProcessor", () => {
   });
 
   it("does not create dialog loot when npc lookup returns empty data", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000008",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
     useDialogStore.setState({
       talkingNpcId: "777",
     });
@@ -340,12 +487,76 @@ describe("LootEventProcessor", () => {
 
     expect(mockCreateLoot).not.toHaveBeenCalled();
     expect(useLootStore.getState().lastLootId).toBeNull();
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000008",
+      npcId: "777",
+      reason: "missing-fallback-npc",
+      source: "dialog",
+      stage: "skipped",
+    });
+  });
+
+  it("logs when npcs deleted by a dialog can no longer be resolved", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000009",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    useDialogStore.setState({
+      talkingNpcId: "501",
+    });
+    mockGetLoot.mockReturnValue([{ id: 7 }]);
+    mockGame.getNpc.mockReturnValue(undefined);
+
+    processor.handleDialogLoot(createDialogLootEvent([501]));
+
+    expect(mockCreateLoot).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000009",
+      npcIds: [501],
+      reason: "unresolved-dialog-npcs",
+      source: "dialog",
+      stage: "skipped",
+    });
+  });
+
+  it("logs when parsed dialog loot is empty", () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000010",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    useDialogStore.setState({
+      talkingNpcId: "501",
+    });
+    mockGetLoot.mockReturnValue([]);
+
+    processor.handleDialogLoot(createDialogLootEvent([501]));
+
+    expect(mockCreateLoot).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000010",
+      reason: "empty-parsed-loots",
+      source: "dialog",
+      stage: "skipped",
+    });
   });
 
   it("logs warning when dialog loot request fails", async () => {
     const consoleWarnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(
+      "00000000-0000-4000-8000-000000000011",
+    );
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
 
     useDialogStore.setState({
       talkingNpcId: "501",
@@ -363,6 +574,12 @@ describe("LootEventProcessor", () => {
       "[LootEventProcessor] Failed to create dialog loot:",
       expect.any(Error),
     );
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      attemptId: "00000000-0000-4000-8000-000000000011",
+      error: expect.any(Error),
+      source: "dialog",
+      stage: "failed",
+    });
   });
 
   it("does not clear tracked id when dialog source is not used", () => {

--- a/apps/game-client/src/processors/loot-event-processor.ts
+++ b/apps/game-client/src/processors/loot-event-processor.ts
@@ -1,4 +1,9 @@
 import { Game } from "@/lib/game";
+import {
+  createLootDebugContext,
+  logLootCreateDebug,
+  type LootCreateDebugContext,
+} from "@/lib/loot-create-debug";
 import { getLoot } from "@/utils/game/get-loots";
 import {
   getBattleParticipants,
@@ -16,47 +21,97 @@ export class LootEventProcessor {
   handleLootFromBattle(event: GameEvent): void {
     if (!event.item || event.loot?.source !== "fight") return;
 
+    const debugContext = createLootDebugContext("fight");
     const battleStore = useBattleStore.getState();
     const lootStore = useLootStore.getState();
 
-    if (isEmpty(battleStore.battleWarriors)) return;
+    logLootCreateDebug("event-detected", {
+      ...debugContext,
+      battleWarriors: battleStore.battleWarriors,
+      event,
+    });
+
+    if (isEmpty(battleStore.battleWarriors)) {
+      logLootCreateDebug("skipped", {
+        ...debugContext,
+        reason: "missing-battle-warriors",
+      });
+      return;
+    }
 
     lootStore.setLastLootId(null);
-    this.createLootFromBattle(event);
+    this.createLootFromBattle(event, debugContext);
   }
 
   handleDialogLoot(event: GameEvent): void {
     if (!event.item || event.loot?.source !== "dialog") return;
 
+    const debugContext = createLootDebugContext("dialog");
     const dialogStore = useDialogStore.getState();
-    if (!dialogStore.talkingNpcId) return;
+    logLootCreateDebug("event-detected", {
+      ...debugContext,
+      event,
+      talkingNpcId: dialogStore.talkingNpcId,
+    });
+    if (!dialogStore.talkingNpcId) {
+      logLootCreateDebug("skipped", {
+        ...debugContext,
+        reason: "missing-talking-npc-id",
+      });
+      return;
+    }
 
     const lootStore = useLootStore.getState();
     lootStore.setLastLootId(null);
 
     if (event.npcs_del?.length) {
-      this.createLootFromDialog(event);
+      this.createLootFromDialog(event, debugContext);
     } else if (dialogStore.talkingNpcId) {
       const npc = Game.getNpc(+dialogStore.talkingNpcId);
       if (npc) {
-        this.createLootFromDialog({ ...event, npcs_del: [{ id: npc.id }] });
+        this.createLootFromDialog(
+          { ...event, npcs_del: [{ id: npc.id }] },
+          debugContext,
+        );
+      } else {
+        logLootCreateDebug("skipped", {
+          ...debugContext,
+          npcId: dialogStore.talkingNpcId,
+          reason: "missing-fallback-npc",
+        });
       }
     }
   }
 
-  private createLootFromBattle(event: GameEvent): void {
+  private createLootFromBattle(
+    event: GameEvent,
+    debugContext: LootCreateDebugContext,
+  ): void {
     const loot = event.loot;
-    if (!loot || !event.f) return;
+    if (!loot) return;
+    if (!event.f) {
+      logLootCreateDebug("skipped", {
+        ...debugContext,
+        reason: "missing-fight-data",
+      });
+      return;
+    }
 
     const loots = getLoot(event.item, loot);
-    if (!loots.length) return;
+    if (!loots.length) {
+      logLootCreateDebug("skipped", {
+        ...debugContext,
+        reason: "empty-parsed-loots",
+      });
+      return;
+    }
 
     const battleStore = useBattleStore.getState();
     const { npcs, party } = getBattleParticipants(battleStore.battleWarriors);
     const hero = Game.hero;
     const map = Game.map;
 
-    createLoot({
+    const payload = {
       world: Game.getWorldName(),
       source: loot.source.toUpperCase(),
       location: map.name,
@@ -65,21 +120,46 @@ export class LootEventProcessor {
       players: party,
       accountId: String(hero.account),
       characterId: String(hero.id),
-    })
+    };
+
+    logLootCreateDebug("request-prepared", {
+      ...debugContext,
+      payload,
+    });
+
+    createLoot(payload, debugContext)
       .then((response) => {
         useLootStore.getState().setLastLootId(response.id);
+        logLootCreateDebug("completed", {
+          ...debugContext,
+          lastLootId: response.id,
+          response,
+        });
       })
       .catch((error) => {
+        logLootCreateDebug("failed", {
+          ...debugContext,
+          error,
+        });
         console.warn("[LootEventProcessor] Failed to create loot:", error);
       });
   }
 
-  private createLootFromDialog(event: GameEvent): void {
+  private createLootFromDialog(
+    event: GameEvent,
+    debugContext: LootCreateDebugContext,
+  ): void {
     const loot = event.loot;
     if (!loot) return;
 
     const loots = getLoot(event.item, loot);
-    if (!loots.length) return;
+    if (!loots.length) {
+      logLootCreateDebug("skipped", {
+        ...debugContext,
+        reason: "empty-parsed-loots",
+      });
+      return;
+    }
 
     const mapName = Game.map.name;
     const npcs: Npc[] = [];
@@ -104,7 +184,14 @@ export class LootEventProcessor {
       });
     }
 
-    if (npcs.length === 0) return;
+    if (npcs.length === 0) {
+      logLootCreateDebug("skipped", {
+        ...debugContext,
+        npcIds: (event.npcs_del ?? []).map((npc) => npc.id),
+        reason: "unresolved-dialog-npcs",
+      });
+      return;
+    }
 
     const hero = Game.hero;
     const players: PartyMember[] = [
@@ -121,7 +208,7 @@ export class LootEventProcessor {
       },
     ];
 
-    createLoot({
+    const payload = {
       world: Game.getWorldName(),
       source: loot.source.toUpperCase(),
       location: mapName,
@@ -130,11 +217,27 @@ export class LootEventProcessor {
       players,
       accountId: String(hero.account),
       characterId: String(hero.id),
-    })
+    };
+
+    logLootCreateDebug("request-prepared", {
+      ...debugContext,
+      payload,
+    });
+
+    createLoot(payload, debugContext)
       .then((response) => {
         useLootStore.getState().setLastLootId(response.id);
+        logLootCreateDebug("completed", {
+          ...debugContext,
+          lastLootId: response.id,
+          response,
+        });
       })
       .catch((error) => {
+        logLootCreateDebug("failed", {
+          ...debugContext,
+          error,
+        });
         console.warn(
           "[LootEventProcessor] Failed to create dialog loot:",
           error,

--- a/apps/game-client/src/services/api.service.test.ts
+++ b/apps/game-client/src/services/api.service.test.ts
@@ -6,6 +6,8 @@ import {
   sendChatMessage,
 } from "@/api";
 import { LOGS_STORAGE_KEY, useLogsStore } from "@/store/logs.store";
+import { LOOT_CREATE_DEBUG_PREFIX } from "@/lib/loot-create-debug";
+import { useSettingsStore } from "@/store/settings.store";
 
 const { mockPost, mockPatch, mockSendNotification, mockSendChatMessage } =
   vi.hoisted(() => ({
@@ -35,30 +37,19 @@ describe("api.service logging", () => {
     vi.clearAllMocks();
     window.localStorage.removeItem(LOGS_STORAGE_KEY);
     useLogsStore.getState().clearActions();
+    useSettingsStore.getState().setLootDebugLoggingEnabled(false);
   });
 
   it("logs createLoot action and successful API response", async () => {
-    mockPost.mockResolvedValueOnce({
-      status: 201,
-      data: {
-        id: 77,
-        submittedGuilds: [
-          {
-            guildId: "guild-1",
-            guildName: "Guild One",
-          },
-        ],
-        rejectedGuilds: [
-          {
-            guildId: "guild-2",
-            guildName: "Guild Two",
-            reason: "NOT_ON_CHARACTER_WHITELIST",
-          },
-        ],
-      },
-    });
-
-    const response = await createLoot({
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    const debugContext = {
+      attemptId: "attempt-fight-1",
+      source: "fight" as const,
+    };
+    const payload = {
       world: "pandora",
       source: "FIGHT",
       location: "Karka-han",
@@ -67,7 +58,29 @@ describe("api.service logging", () => {
       players: [],
       accountId: "10",
       characterId: "20",
+    };
+    const responseData = {
+      id: 77,
+      submittedGuilds: [
+        {
+          guildId: "guild-1",
+          guildName: "Guild One",
+        },
+      ],
+      rejectedGuilds: [
+        {
+          guildId: "guild-2",
+          guildName: "Guild Two",
+          reason: "NOT_ON_CHARACTER_WHITELIST",
+        },
+      ],
+    };
+    mockPost.mockResolvedValueOnce({
+      status: 201,
+      data: responseData,
     });
+
+    const response = await createLoot(payload, debugContext);
 
     expect(response).toEqual({
       id: 77,
@@ -116,9 +129,31 @@ describe("api.service logging", () => {
         status: "success",
       }),
     ]);
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      ...debugContext,
+      attempt: 1,
+      endpoint: "/loots",
+      method: "POST",
+      payload,
+      stage: "http-request",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      ...debugContext,
+      attempt: 1,
+      response: responseData,
+      stage: "http-success",
+    });
   });
 
   it("logs createLoot error responses and marks the action as failed", async () => {
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    const debugContext = {
+      attemptId: "attempt-dialog-1",
+      source: "dialog" as const,
+    };
     const apiError = {
       message: "Request failed",
       status: 400,
@@ -128,16 +163,19 @@ describe("api.service logging", () => {
     mockPost.mockRejectedValueOnce(apiError);
 
     await expect(
-      createLoot({
-        world: "pandora",
-        source: "DIALOG",
-        location: "Karka-han",
-        npcs: [],
-        loots: [{ name: "Tarcza" }],
-        players: [],
-        accountId: "10",
-        characterId: "20",
-      }),
+      createLoot(
+        {
+          world: "pandora",
+          source: "DIALOG",
+          location: "Karka-han",
+          npcs: [],
+          loots: [{ name: "Tarcza" }],
+          players: [],
+          accountId: "10",
+          characterId: "20",
+        },
+        debugContext,
+      ),
     ).rejects.toBe(apiError);
 
     const [action] = useLogsStore.getState().actions;
@@ -157,6 +195,86 @@ describe("api.service logging", () => {
         },
       }),
     ]);
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      ...debugContext,
+      attempt: 1,
+      endpoint: "/loots",
+      method: "POST",
+      payload: expect.objectContaining({ source: "DIALOG" }),
+      stage: "http-request",
+    });
+    expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+      ...debugContext,
+      attempt: 1,
+      error: apiError,
+      stage: "http-error",
+    });
+  });
+
+  it("logs every createLoot retry with the same correlation context", async () => {
+    vi.useFakeTimers();
+    const consoleLogSpy = vi
+      .spyOn(console, "log")
+      .mockImplementation(() => undefined);
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+    const debugContext = {
+      attemptId: "attempt-fight-retry",
+      source: "fight" as const,
+    };
+    const payload = {
+      world: "pandora",
+      source: "FIGHT",
+      location: "Karka-han",
+      npcs: [],
+      loots: [{ name: "Miecz" }],
+      players: [],
+      accountId: "10",
+      characterId: "20",
+    };
+    const retryableError = {
+      message: "Temporary failure",
+      status: 500,
+      data: { message: "retry" },
+    };
+    const responseData = {
+      id: 88,
+      submittedGuilds: [],
+      rejectedGuilds: [],
+    };
+    mockPost
+      .mockRejectedValueOnce(retryableError)
+      .mockResolvedValueOnce({ data: responseData, status: 201 });
+
+    try {
+      const responsePromise = createLoot(payload, debugContext);
+
+      await vi.runAllTimersAsync();
+
+      await expect(responsePromise).resolves.toEqual(responseData);
+      expect(mockPost).toHaveBeenCalledTimes(2);
+      expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+        ...debugContext,
+        attempt: 1,
+        error: retryableError,
+        stage: "http-error",
+      });
+      expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+        ...debugContext,
+        attempt: 2,
+        endpoint: "/loots",
+        method: "POST",
+        payload,
+        stage: "http-request",
+      });
+      expect(consoleLogSpy).toHaveBeenCalledWith(LOOT_CREATE_DEBUG_PREFIX, {
+        ...debugContext,
+        attempt: 2,
+        response: responseData,
+        stage: "http-success",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("logs createNotification action and returns created notification", async () => {

--- a/apps/game-client/src/store/settings.store.test.ts
+++ b/apps/game-client/src/store/settings.store.test.ts
@@ -14,6 +14,34 @@ describe("useSettingsStore", () => {
     expect(useSettingsStore.getState().animationEffectsEnabled).toBe(true);
   });
 
+  it("disables loot debug logging by default", () => {
+    expect(useSettingsStore.getState().lootDebugLoggingEnabled).toBe(false);
+  });
+
+  it("updates loot debug logging", () => {
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+
+    expect(useSettingsStore.getState().lootDebugLoggingEnabled).toBe(true);
+
+    useSettingsStore.getState().setLootDebugLoggingEnabled(false);
+
+    expect(useSettingsStore.getState().lootDebugLoggingEnabled).toBe(false);
+  });
+
+  it("persists loot debug logging in settings storage", () => {
+    useSettingsStore.getState().setLootDebugLoggingEnabled(true);
+
+    const storedSettings = JSON.parse(
+      localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "{}",
+    ) as {
+      state?: {
+        lootDebugLoggingEnabled?: boolean;
+      };
+    };
+
+    expect(storedSettings.state?.lootDebugLoggingEnabled).toBe(true);
+  });
+
   it("toggles animation effects", () => {
     useSettingsStore.getState().toggleAnimationEffects();
 

--- a/apps/game-client/src/store/settings.store.ts
+++ b/apps/game-client/src/store/settings.store.ts
@@ -6,6 +6,7 @@ const STORAGE_KEY = storageKey("ll:settings:state");
 
 interface SettingsState {
   animationEffectsEnabled: boolean;
+  lootDebugLoggingEnabled: boolean;
   allowWorldSelection?: boolean;
   worldByGuildId: Record<string, string>;
   guildIdByCharId: Record<string, string>;
@@ -13,6 +14,7 @@ interface SettingsState {
   ensureGuildId: (charId: string, orderedGuildIds: string[]) => void;
   setGuildId: (charId: string, guildId: string) => void;
   setSelectedGuildIdsForTimers: (charId: string, guildIds: string[]) => void;
+  setLootDebugLoggingEnabled: (enabled: boolean) => void;
   setWorld: (guildId: string, world: string) => void;
   toggleAnimationEffects: () => void;
   toggleAllowWorldSelection: () => void;
@@ -22,6 +24,7 @@ export const useSettingsStore = create<SettingsState>()(
   persist(
     (set) => ({
       animationEffectsEnabled: true,
+      lootDebugLoggingEnabled: false,
       allowWorldSelection: false,
       worldByGuildId: {},
       guildIdByCharId: {},
@@ -65,6 +68,9 @@ export const useSettingsStore = create<SettingsState>()(
           },
         }));
       },
+      setLootDebugLoggingEnabled: (lootDebugLoggingEnabled) => {
+        set({ lootDebugLoggingEnabled });
+      },
       setWorld: (guildId: string, world: string) => {
         set((state) => ({
           worldByGuildId: {
@@ -86,6 +92,7 @@ export const useSettingsStore = create<SettingsState>()(
       name: STORAGE_KEY,
       partialize: (state) => ({
         animationEffectsEnabled: state.animationEffectsEnabled,
+        lootDebugLoggingEnabled: state.lootDebugLoggingEnabled,
         allowWorldSelection: state.allowWorldSelection,
         worldByGuildId: state.worldByGuildId,
         guildIdByCharId: state.guildIdByCharId,


### PR DESCRIPTION
## Summary

- add a persisted, opt-in loot debug logging toggle under **Settings → Logs**
- trace dialog and fight loot creation from event detection through client-side skip reasons and final state updates
- correlate every lifecycle entry and physical `POST /loots` retry with the same attempt ID
- include complete request payloads, backend responses, and per-attempt errors in console diagnostics

## Why

Loot creation is very rarely missing from the loot log, especially for dialog rewards. The existing action logs start only after `createLoot()` is called, so they cannot distinguish client-side early exits from an HTTP or backend failure. This instrumentation makes those stages observable without enabling noisy logs for every user by default.

## Impact

The diagnostics are disabled by default and stored locally per browser. When enabled, users can filter the browser console by `[DEBUG-loot-create]`. Existing backend contracts, retry behavior, and warning logs are unchanged.

## Validation

- `pnpm --filter @lootlog/game-client test` — 158 test files, 778 tests passed
- `pnpm --filter @lootlog/game-client build`
- `pnpm --filter @lootlog/game-client exec tsc --noEmit`
- `oxlint`, `oxfmt --check`, and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional loot creation diagnostics setting in Logs settings.
  * Added detailed, correlated console diagnostics for loot creation requests, retries, successes, failures, and skipped events.
  * Diagnostics can be enabled or disabled and the preference is saved automatically.
  * Added diagnostic context for loot generated from battles and dialogs, including relevant payload details.

* **Tests**
  * Added coverage for the diagnostics toggle, persistence, logging behavior, retries, and loot-processing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->