### PR TITLE
fix(game-client): stabilize party gathering workflow

### DIFF
--- a/apps/api/src/messaging/ready-room/ready-room.service.spec.ts
+++ b/apps/api/src/messaging/ready-room/ready-room.service.spec.ts
@@ -1,4 +1,5 @@
 import type { PartyReadyRoomCharacter } from "@lootlog/types";
+import { ConflictException } from "@nestjs/common";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   CommitReadyRoomResult,
@@ -349,6 +350,12 @@ describe("ReadyRoomService", () => {
       "organizer",
       createCharacter("other-character"),
     ).catch((error: unknown) => error);
+    expect(sameOrganizerError).toBeInstanceOf(ConflictException);
+    expect((sameOrganizerError as ConflictException).getStatus()).toBe(409);
+    expect((sameOrganizerError as ConflictException).getResponse()).toEqual({
+      code: "ACTIVE_GATHERING_EXISTS",
+      notificationId: "room-1",
+    });
     expect(getErrorCode(sameOrganizerError)).toMatchObject({
       code: "ACTIVE_GATHERING_EXISTS",
       notificationId: "room-1",

--- a/apps/game-client/src/features/chat/components/chat-message-list.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.test.tsx
@@ -73,8 +73,19 @@ vi.mock("./chat-date-divider", () => ({
 }));
 
 vi.mock("./chat-message", () => ({
-  ChatMessage: ({ message }: { message: { id: string; message?: string } }) => (
-    <div data-testid={message.id}>{message.message}</div>
+  ChatMessage: ({
+    message,
+  }: {
+    message: {
+      id: string;
+      message?: string;
+      partyGathering?: { notificationId: string };
+    };
+  }) => (
+    <div data-testid={message.id}>
+      {message.message}
+      {message.partyGathering && <button type="button">Join party</button>}
+    </div>
   ),
 }));
 
@@ -388,6 +399,54 @@ describe("ChatMessageList", () => {
     expect(viewport.scrollTop).toBe(0);
     expect(screen.getByTestId("message-0")).toBeInTheDocument();
     expect(screen.queryByTestId("message-300")).not.toBeInTheDocument();
+  });
+
+  it("shows updates to an existing party gathering while the user reads history", () => {
+    const initialRenderables = createRenderables(300);
+    const initialGathering = initialRenderables[0];
+    if (!initialGathering || initialGathering.kind !== "message") {
+      throw new Error("Expected the first renderable to be a message");
+    }
+    initialRenderables[0] = {
+      ...initialGathering,
+      message: {
+        ...initialGathering.message,
+        message: "Gathering open",
+        partyGathering: {
+          discordId: "organizer-1",
+          notificationId: "gathering-1",
+          world: "tempest",
+        },
+      },
+    };
+    const { rerender } = renderMessageList(initialRenderables);
+    const viewport = screen.getByTestId("chat-scroll-viewport");
+
+    fireEvent.wheel(viewport, { deltaY: -500 });
+    viewport.scrollTop = 0;
+    fireEvent.scroll(viewport);
+
+    expect(screen.getByRole("button", { name: "Join party" })).toBeVisible();
+
+    const updatedRenderables = initialRenderables.map((renderable) =>
+      renderable.kind === "message" && renderable.key === "message-0"
+        ? {
+            ...renderable,
+            message: {
+              ...renderable.message,
+              message: "Hero zakonczyl zbieranie grupy",
+              partyGathering: undefined,
+            },
+          }
+        : renderable,
+    );
+    rerender(createMessageListElement(updatedRenderables));
+
+    expect(screen.getByText("Hero zakonczyl zbieranie grupy")).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Join party" }),
+    ).not.toBeInTheDocument();
+    expect(viewport.scrollTop).toBe(0);
   });
 
   it("freezes the rendered snapshot when history evicts its oldest message", () => {

--- a/apps/game-client/src/features/chat/components/chat-message-list.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.tsx
@@ -7,7 +7,10 @@ import {
   type ChatScrollController,
 } from "../chat-scroll-controller";
 import { subscribeToChatScrollToMessage } from "../chat-scroll-to-message";
-import type { ChatRenderableMessage } from "../chat.helpers";
+import {
+  getChatRenderableMessagesSignature,
+  type ChatRenderableMessage,
+} from "../chat.helpers";
 import { ChatDateDivider } from "./chat-date-divider";
 import { ChatMessage } from "./chat-message";
 import { ChatNpcMessage } from "./chat-npc-message";
@@ -73,6 +76,19 @@ const getChatRowMeasurementSource = (renderable: ChatRenderableMessage) =>
   renderable.kind === "date-divider"
     ? renderable.timestamp
     : renderable.message;
+
+const refreshDisplayedChatRenderables = (
+  displayedRenderables: ChatRenderableMessage[],
+  latestRenderables: ChatRenderableMessage[],
+) => {
+  const latestRenderablesByKey = new Map(
+    latestRenderables.map((renderable) => [renderable.key, renderable]),
+  );
+
+  return displayedRenderables.map(
+    (renderable) => latestRenderablesByKey.get(renderable.key) ?? renderable,
+  );
+};
 
 const getEstimatedChatRowHeight = (
   renderable: ChatRenderableMessage,
@@ -234,6 +250,16 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
       hasRenderableMessages: latestHasRenderableMessages,
       renderSignature: latestRenderSignature,
       renderables: latestRenderables,
+    };
+  } else {
+    const refreshedRenderables = refreshDisplayedChatRenderables(
+      displayedMessagesRef.current.renderables,
+      latestRenderables,
+    );
+    displayedMessagesRef.current = {
+      ...displayedMessagesRef.current,
+      renderSignature: getChatRenderableMessagesSignature(refreshedRenderables),
+      renderables: refreshedRenderables,
     };
   }
   const { hasRenderableMessages, renderSignature, renderables } =

--- a/apps/game-client/src/features/party-finder/active-party-gathering-error.ts
+++ b/apps/game-client/src/features/party-finder/active-party-gathering-error.ts
@@ -1,0 +1,8 @@
+export class ActivePartyGatheringError extends Error {
+  readonly code = "ACTIVE_GATHERING_EXISTS";
+
+  constructor(readonly notificationId: string) {
+    super("An active party gathering already exists");
+    this.name = "ActivePartyGatheringError";
+  }
+}

--- a/apps/game-client/src/features/party-finder/get-create-party-gathering-error-message.test.ts
+++ b/apps/game-client/src/features/party-finder/get-create-party-gathering-error-message.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/lib/api-client";
+import { ActivePartyGatheringError } from "./active-party-gathering-error";
 import { getCreatePartyGatheringErrorMessage } from "./get-create-party-gathering-error-message";
 
 const createApiError = (status?: number, data?: unknown) =>
@@ -40,6 +41,14 @@ describe("getCreatePartyGatheringErrorMessage", () => {
     expect(
       getCreatePartyGatheringErrorMessage(
         createApiError(409, { code: "ACTIVE_GATHERING_EXISTS" }),
+      ),
+    ).toBe("Masz już aktywną zbiórkę grupy");
+  });
+
+  it("explains an active gathering detected locally", () => {
+    expect(
+      getCreatePartyGatheringErrorMessage(
+        new ActivePartyGatheringError("room-1"),
       ),
     ).toBe("Masz już aktywną zbiórkę grupy");
   });

--- a/apps/game-client/src/features/party-finder/get-create-party-gathering-error-message.ts
+++ b/apps/game-client/src/features/party-finder/get-create-party-gathering-error-message.ts
@@ -1,9 +1,14 @@
 import { getFixedT } from "@/i18n/get-fixed-t";
 import { isApiError } from "@/lib/api-client";
+import { ActivePartyGatheringError } from "./active-party-gathering-error";
 
 export const getCreatePartyGatheringErrorMessage = (error: unknown): string => {
   const t = getFixedT("partyFinder");
   const defaultMessage = t("errors.defaultCreate");
+
+  if (error instanceof ActivePartyGatheringError) {
+    return t("errors.activeGatheringExists");
+  }
 
   if (!isApiError(error)) {
     return defaultMessage;

--- a/apps/game-client/src/features/party-finder/hooks/use-party-gathering-orchestration.test.tsx
+++ b/apps/game-client/src/features/party-finder/hooks/use-party-gathering-orchestration.test.tsx
@@ -1,0 +1,212 @@
+import { act, renderHook } from "@testing-library/react";
+import type { PartyReadyRoomProjection } from "@lootlog/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api-client";
+import { usePartyFinderStore } from "@/store/party-finder.store";
+import { usePartyGatheringOrchestration } from "./use-party-gathering-orchestration";
+
+const mocks = vi.hoisted(() => ({
+  createNotification: vi.fn(),
+  createPartyGathering: vi.fn(),
+  getPartyGathering: vi.fn(),
+  sendChatMessage: vi.fn(),
+  setOpen: vi.fn(),
+}));
+
+vi.mock("@/hooks/api/use-send-chat-message", () => ({
+  useSendChatMessage: () => ({ mutateAsync: mocks.sendChatMessage }),
+}));
+
+vi.mock("@/lib/api/generated/main/messaging/messaging", () => ({
+  useMessagingControllerSendNotification: () => ({
+    mutateAsync: mocks.createNotification,
+  }),
+}));
+
+vi.mock("@/lib/api/generated/main/party-ready-room/party-ready-room", () => ({
+  partyReadyRoomControllerGet: (...args: unknown[]) =>
+    mocks.getPartyGathering(...args),
+  usePartyReadyRoomControllerCreate: () => ({
+    mutateAsync: mocks.createPartyGathering,
+  }),
+}));
+
+vi.mock("@/lib/api/generated-helpers", () => ({
+  buildChatCharacterData: () => ({ nick: "Hero" }),
+  buildCurrentCharacterPayload: () => ({ nick: "Hero" }),
+}));
+
+vi.mock("@/lib/game", () => ({
+  Game: { hero: { nick: "Hero" } },
+}));
+
+vi.mock("@/store/windows.store", () => ({
+  useWindowsStore: (
+    selector: (state: { setOpen: typeof mocks.setOpen }) => unknown,
+  ) => selector({ setOpen: mocks.setOpen }),
+}));
+
+const projection: PartyReadyRoomProjection = {
+  schemaVersion: 3,
+  notificationId: "room-1",
+  organizerDiscordId: "organizer-1",
+  organizerCharacter: {
+    accountId: "account-1",
+    characterId: "character-1",
+    icon: "hero.gif",
+    lvl: 200,
+    nick: "Hero",
+    prof: "w",
+  },
+  guildIds: ["guild-1"],
+  world: "tempest",
+  status: "ACTIVE",
+  revision: 1,
+  createdAt: "2026-07-22T10:00:00.000Z",
+  updatedAt: "2026-07-22T10:00:00.000Z",
+  expiresAt: "2026-07-22T10:30:00.000Z",
+  viewer: "ORGANIZER",
+  participants: {},
+  ownedParticipantIds: [],
+};
+
+describe("usePartyGatheringOrchestration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePartyFinderStore.getState().clearReadyRooms();
+    mocks.createPartyGathering.mockResolvedValue(projection);
+    mocks.sendChatMessage.mockResolvedValue([]);
+  });
+
+  it("uses the Ready Room organizer when publishing a chat gathering", async () => {
+    const { result } = renderHook(() => usePartyGatheringOrchestration());
+
+    await act(() =>
+      result.current.startPartyGathering({
+        guildIds: ["guild-1"],
+        world: "tempest",
+      }),
+    );
+
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partyGathering: expect.objectContaining({
+          discordId: "organizer-1",
+          notificationId: "room-1",
+        }),
+      }),
+    );
+  });
+
+  it("keeps the created gathering open when chat publishing fails", async () => {
+    mocks.sendChatMessage.mockRejectedValue(new Error("Chat unavailable"));
+    const { result } = renderHook(() => usePartyGatheringOrchestration());
+
+    await expect(
+      act(() =>
+        result.current.startPartyGathering({
+          guildIds: ["guild-1"],
+          world: "tempest",
+          closeCreateWindow: true,
+        }),
+      ),
+    ).resolves.toEqual({
+      notificationId: "room-1",
+      guildIds: ["guild-1"],
+    });
+
+    expect(mocks.setOpen).toHaveBeenCalledWith("create-party-gathering", false);
+    expect(mocks.setOpen).toHaveBeenCalledWith("party-finder", true);
+    expect(mocks.setOpen.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      mocks.sendChatMessage.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(usePartyFinderStore.getState().projections["room-1"]).toBeDefined();
+  });
+
+  it("opens a known active gathering without creating another one", async () => {
+    usePartyFinderStore.getState().mergeProjection(projection);
+    const { result } = renderHook(() => usePartyGatheringOrchestration());
+
+    const error = await act(() =>
+      result.current
+        .startPartyGathering({
+          guildIds: ["guild-1"],
+          world: "tempest",
+          closeCreateWindow: true,
+        })
+        .catch((caughtError: unknown) => caughtError),
+    );
+
+    expect(error).toMatchObject({ code: "ACTIVE_GATHERING_EXISTS" });
+    expect(mocks.createPartyGathering).not.toHaveBeenCalled();
+    expect(mocks.sendChatMessage).not.toHaveBeenCalled();
+    expect(mocks.setOpen).toHaveBeenCalledWith("create-party-gathering", false);
+    expect(mocks.setOpen).toHaveBeenCalledWith("party-finder", true);
+  });
+
+  it("synchronizes an active gathering reported by the backend", async () => {
+    const conflict = new ApiError({
+      status: 409,
+      data: {
+        code: "ACTIVE_GATHERING_EXISTS",
+        notificationId: "room-1",
+      },
+      url: "/messaging/party-gathering",
+      method: "POST",
+      message: "Conflict",
+    });
+    mocks.createPartyGathering.mockRejectedValue(conflict);
+    mocks.getPartyGathering.mockResolvedValue(projection);
+    const { result } = renderHook(() => usePartyGatheringOrchestration());
+
+    const error = await act(() =>
+      result.current
+        .startPartyGathering({
+          guildIds: ["guild-1"],
+          world: "tempest",
+        })
+        .catch((caughtError: unknown) => caughtError),
+    );
+
+    expect(error).toBe(conflict);
+    expect(mocks.getPartyGathering).toHaveBeenCalledWith({
+      notificationId: "room-1",
+    });
+    expect(usePartyFinderStore.getState().projections["room-1"]).toEqual(
+      projection,
+    );
+    expect(mocks.setOpen).toHaveBeenCalledWith("party-finder", true);
+    expect(mocks.sendChatMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses the fetched organizer when publishing an NPC gathering", async () => {
+    mocks.createNotification.mockResolvedValue({
+      notificationId: "room-1",
+      guildIds: ["guild-1"],
+    });
+    mocks.getPartyGathering.mockResolvedValue(projection);
+    const { result } = renderHook(() => usePartyGatheringOrchestration());
+
+    await act(() =>
+      result.current.startNpcPartyGathering({
+        npc: {
+          id: 1,
+          nick: "Hydra",
+          lvl: 250,
+          prof: "m",
+        } as never,
+        guildIds: ["guild-1"],
+        world: "tempest",
+      }),
+    );
+
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partyGathering: expect.objectContaining({
+          discordId: "organizer-1",
+          notificationId: "room-1",
+        }),
+      }),
+    );
+  });
+});

--- a/apps/game-client/src/features/party-finder/hooks/use-party-gathering-orchestration.ts
+++ b/apps/game-client/src/features/party-finder/hooks/use-party-gathering-orchestration.ts
@@ -1,6 +1,6 @@
 import { MessageType, type SendChatMessageOptions } from "@/api/chat.api";
+import { ActivePartyGatheringError } from "@/features/party-finder/active-party-gathering-error";
 import { useSendChatMessage } from "@/hooks/api/use-send-chat-message";
-import { useSession } from "@/hooks/auth/use-session";
 import { useMessagingControllerSendNotification } from "@/lib/api/generated/main/messaging/messaging";
 import {
   partyReadyRoomControllerGet,
@@ -11,8 +11,12 @@ import {
   buildChatCharacterData,
   buildCurrentCharacterPayload,
 } from "@/lib/api/generated-helpers";
+import { isApiError } from "@/lib/api-client";
 import { Game } from "@/lib/game";
-import { usePartyFinderStore } from "@/store/party-finder.store";
+import {
+  selectOwnedReadyRoom,
+  usePartyFinderStore,
+} from "@/store/party-finder.store";
 import { useWindowsStore } from "@/store/windows.store";
 import {
   buildNpcChatMessagePayload,
@@ -49,6 +53,23 @@ type FinalizePartyGatheringOptions = {
   chatMessageOptions: SendChatMessageOptions;
 };
 
+const getActivePartyGatheringNotificationId = (error: unknown) => {
+  if (
+    !isApiError(error) ||
+    error.status !== 409 ||
+    typeof error.data !== "object" ||
+    error.data === null
+  ) {
+    return undefined;
+  }
+
+  const { code, notificationId } = error.data as Record<string, unknown>;
+  return code === "ACTIVE_GATHERING_EXISTS" &&
+    typeof notificationId === "string"
+    ? notificationId
+    : undefined;
+};
+
 export const usePartyGatheringOrchestration = () => {
   const [isCreatingPartyGathering, setIsCreatingPartyGathering] =
     useState(false);
@@ -61,10 +82,15 @@ export const usePartyGatheringOrchestration = () => {
   const { mutateAsync: createNotificationAsync } =
     useMessagingControllerSendNotification();
   const { mutateAsync: sendChatMessageAsync } = useSendChatMessage();
-  const { data: session } = useSession();
-  const discordId = session?.user?.discordId ?? "";
   const mergeProjection = usePartyFinderStore((state) => state.mergeProjection);
   const setOpen = useWindowsStore((state) => state.setOpen);
+
+  const openPartyFinder = (closeCreateWindow = false) => {
+    if (closeCreateWindow) {
+      setOpen("create-party-gathering", false);
+    }
+    setOpen("party-finder", true);
+  };
 
   const finalizePartyGathering = async ({
     notificationId,
@@ -72,13 +98,13 @@ export const usePartyGatheringOrchestration = () => {
     closeCreateWindow,
     chatMessageOptions,
   }: FinalizePartyGatheringOptions) => {
-    await sendChatMessageAsync(chatMessageOptions);
+    openPartyFinder(closeCreateWindow);
 
-    if (closeCreateWindow) {
-      setOpen("create-party-gathering", false);
+    try {
+      await sendChatMessageAsync(chatMessageOptions);
+    } catch {
+      // The Ready Room is already committed and remains the source of truth.
     }
-
-    setOpen("party-finder", true);
 
     return {
       notificationId,
@@ -94,19 +120,38 @@ export const usePartyGatheringOrchestration = () => {
     maxLvl,
     closeCreateWindow = false,
   }: StartPartyGatheringOptions) => {
+    const ownedReadyRoom = selectOwnedReadyRoom(usePartyFinderStore.getState());
+    if (ownedReadyRoom) {
+      openPartyFinder(closeCreateWindow);
+      throw new ActivePartyGatheringError(ownedReadyRoom.notificationId);
+    }
+
     setIsCreatingPartyGathering(true);
 
     try {
-      const response = await createPartyGatheringAsync({
-        data: {
-          guildIds,
-          world,
-          character: buildCurrentCharacterPayload(),
-          description,
-          minLvl,
-          maxLvl,
-        },
-      });
+      let response: Awaited<ReturnType<typeof createPartyGatheringAsync>>;
+      try {
+        response = await createPartyGatheringAsync({
+          data: {
+            guildIds,
+            world,
+            character: buildCurrentCharacterPayload(),
+            description,
+            minLvl,
+            maxLvl,
+          },
+        });
+      } catch (error) {
+        const notificationId = getActivePartyGatheringNotificationId(error);
+        if (notificationId) {
+          const existingProjection = (await partyReadyRoomControllerGet({
+            notificationId,
+          })) as unknown as PartyReadyRoomProjection;
+          mergeProjection(existingProjection);
+          openPartyFinder(closeCreateWindow);
+        }
+        throw error;
+      }
       const projection = response as unknown as PartyReadyRoomProjection;
       mergeProjection(projection);
       const resolvedGuildIds = projection.guildIds;
@@ -122,7 +167,7 @@ export const usePartyGatheringOrchestration = () => {
           characterData: buildChatCharacterData(),
           partyGathering: {
             notificationId: projection.notificationId,
-            discordId,
+            discordId: projection.organizerDiscordId,
             description,
             minLvl,
             maxLvl,
@@ -167,7 +212,7 @@ export const usePartyGatheringOrchestration = () => {
           message: `${npc.nick} (${npc.lvl}${npc.prof ?? ""})`,
           partyGathering: {
             notificationId: response.notificationId,
-            discordId,
+            discordId: projection.organizerDiscordId,
             world,
           },
         }),

--- a/apps/game-client/src/hooks/api/use-cancel-party-gathering.test.ts
+++ b/apps/game-client/src/hooks/api/use-cancel-party-gathering.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
 import { useCancelPartyGathering } from "./use-cancel-party-gathering";
 import { usePartyFinderStore } from "@/store/party-finder.store";
+import { getChatControllerGetChatMessagesQueryKey } from "@/lib/api/generated/main/chat/chat";
 
 const mockCancelPartyGathering = vi.fn();
 const mockSetOpen = vi.fn();
@@ -28,10 +29,11 @@ vi.mock("@/lib/game", () => ({
   Game: { hero: { nick: "TestPlayer" } },
 }));
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createWrapper(
+  queryClient = new QueryClient({
     defaultOptions: { mutations: { retry: false } },
-  });
+  }),
+) {
   return ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client: queryClient }, children);
 }
@@ -92,5 +94,30 @@ describe("useCancelPartyGathering", () => {
       },
     });
     expect(mockSetOpen).toHaveBeenCalledWith("party-finder", false);
+  });
+
+  it("invalidates affected chat histories after cancellation", async () => {
+    mockCancelPartyGathering.mockResolvedValue({
+      schemaVersion: 3,
+      type: "REMOVE",
+      notificationId: "notif-123",
+      revision: 2,
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+    const chatQueryKey = getChatControllerGetChatMessagesQueryKey({
+      guildId: "guild-1",
+    });
+    queryClient.setQueryData(chatQueryKey, [{ id: "message-1" }]);
+    const { result } = renderHook(() => useCancelPartyGathering(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryState(chatQueryKey)?.isInvalidated).toBe(true);
   });
 });

--- a/apps/game-client/src/hooks/api/use-cancel-party-gathering.ts
+++ b/apps/game-client/src/hooks/api/use-cancel-party-gathering.ts
@@ -1,5 +1,6 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PartyReadyRoomClientUpdate } from "@lootlog/types";
+import { getChatControllerGetChatMessagesQueryKey } from "@/lib/api/generated/main/chat/chat";
 import { partyReadyRoomControllerCancel } from "@/lib/api/generated/main/party-ready-room/party-ready-room";
 import {
   selectOwnedReadyRoom,
@@ -10,6 +11,7 @@ import { getFixedT } from "@/i18n/get-fixed-t";
 
 export const useCancelPartyGathering = () => {
   const t = getFixedT("partyFinder");
+  const queryClient = useQueryClient();
   const setOpen = useWindowsStore((s) => s.setOpen);
 
   return useMutation({
@@ -27,6 +29,15 @@ export const useCancelPartyGathering = () => {
         { expectedRevision: ownedReadyRoom.revision },
       );
       state.applyUpdate(response as unknown as PartyReadyRoomClientUpdate);
+      await Promise.all(
+        ownedReadyRoom.guildIds.map((guildId) =>
+          queryClient.invalidateQueries({
+            queryKey: getChatControllerGetChatMessagesQueryKey({ guildId }),
+            exact: true,
+            refetchType: "active",
+          }),
+        ),
+      );
 
       return response;
     },


### PR DESCRIPTION
## What changed

- use the authoritative Ready Room organizer Discord ID when publishing Party Finder chat messages
- open and persist the created gathering before chat publication, keeping it active when chat delivery fails
- reuse a known active gathering locally and synchronize an existing room returned by the backend's 409 response
- invalidate affected guild chat histories after cancellation so the organizer sees the completed state even without the websocket update
- refresh existing chat rows while structural history updates remain frozen
- strengthen regression coverage for cancellation, duplicate creation, chat publication failures, and the backend conflict contract

## Why

Party Gathering creation could partially succeed: the Ready Room was created, but chat publication failed when the session had not yet supplied a Discord ID. The Party Finder window stayed closed, retries attempted to create another gathering, and cancellation feedback could remain stale for the organizer when the websocket update was missed.

## Impact

Creating a gathering now consistently opens the active room, duplicate attempts recover the existing room instead of creating another one, and cancellation removes the join action and shows the completed message for all affected chats.

## Validation

- game-client: 204 test files, 1075 tests passed
- API: 94 test files, 951 tests passed
- gateway routing: 56 tests passed
- game-client typecheck passed
- lint passed with no errors (API retains pre-existing warnings)
- pre-commit checks passed