### PR TITLE
fix(game-client): filter third-party Sentry errors

### DIFF
--- a/apps/game-client/src/lib/error-monitoring.test.ts
+++ b/apps/game-client/src/lib/error-monitoring.test.ts
@@ -51,7 +51,7 @@ describe("error monitoring", () => {
     );
   });
 
-  it("initializes errors-only monitoring when a Sentry DSN is configured", async () => {
+  it("drops errors containing non-game-client frames", async () => {
     vi.stubEnv("VITE_SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
 
     const { initializeErrorMonitoring } = await import("./error-monitoring");
@@ -84,7 +84,7 @@ describe("error monitoring", () => {
       ]),
     ).toEqual([{ name: "GlobalHandlers" }, { name: "ThirdPartyErrorFilter" }]);
     expect(sentryMocks.thirdPartyErrorFilterIntegration).toHaveBeenCalledWith({
-      behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+      behaviour: "drop-error-if-contains-third-party-frames",
       filterKeys: ["lootlog-game-client"],
     });
   });

--- a/apps/game-client/src/lib/error-monitoring.ts
+++ b/apps/game-client/src/lib/error-monitoring.ts
@@ -173,7 +173,7 @@ export const initializeErrorMonitoring = (): void => {
           ...integrations,
           Sentry.thirdPartyErrorFilterIntegration({
             filterKeys: [SENTRY_APPLICATION_KEY],
-            behaviour: "drop-error-if-exclusively-contains-third-party-frames",
+            behaviour: "drop-error-if-contains-third-party-frames",
           }),
         ];
       },


### PR DESCRIPTION
## What changed

- switch Sentry's third-party error filter to drop events containing any non-`game-client` stack frame
- update the regression test to lock the stricter behavior

## Why

The previous `drop-error-if-exclusively-contains-third-party-frames` behavior still sent mixed stack traces containing both Lootlog and external frames. As a result, Sentry captured data from Margonem and other userscripts.

With `drop-error-if-contains-third-party-frames`, only errors whose stack frames are entirely marked with the `lootlog-game-client` application key are sent.

## Validation

- 204 test files passed
- 1075 tests passed
- TypeScript check passed
- oxlint passed with 0 warnings and 0 errors
- `git diff --check` passed