### PR TITLE
fix(api-client): preserve fetch receiver and optional params

### DIFF
--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -1431,14 +1431,14 @@ paths:
       operationId: LootsController_fetchLootsByGuildId
       parameters:
         - name: limit
-          required: true
+          required: false
           in: query
           schema:
             minimum: 1
             maximum: 100
             type: integer
         - name: cursor
-          required: true
+          required: false
           in: query
           schema:
             minimum: -9007199254740991
@@ -1485,42 +1485,42 @@ paths:
           schema:
             type: string
         - name: npcLevelMin
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: npcLevelMax
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: itemLevelMin
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: itemLevelMax
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: playerLevelMin
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: playerLevelMax
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
@@ -1640,14 +1640,14 @@ paths:
       operationId: LootsController_countLootsByGuildId
       parameters:
         - name: limit
-          required: true
+          required: false
           in: query
           schema:
             minimum: 1
             maximum: 100
             type: integer
         - name: cursor
-          required: true
+          required: false
           in: query
           schema:
             minimum: -9007199254740991
@@ -1694,42 +1694,42 @@ paths:
           schema:
             type: string
         - name: npcLevelMin
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: npcLevelMax
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: itemLevelMin
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: itemLevelMax
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: playerLevelMin
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: playerLevelMax
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
@@ -5694,14 +5694,14 @@ paths:
             example: "123"
             type: string
         - name: minLvl
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
             maximum: 500
             type: integer
         - name: maxLvl
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0
@@ -5742,7 +5742,7 @@ paths:
             maximum: 100
             type: integer
         - name: cursor
-          required: true
+          required: false
           in: query
           schema:
             minimum: 0

--- a/apps/api/src/loots/dto/fetch-loots-params.dto.spec.ts
+++ b/apps/api/src/loots/dto/fetch-loots-params.dto.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { FetchLootsParamsDto } from "./fetch-loots-params.dto";
+
+describe("FetchLootsParamsDto", () => {
+  it.each([
+    { input: undefined, expected: undefined },
+    { input: "", expected: undefined },
+    { input: "42", expected: 42 },
+  ])(
+    "parses an optional numeric query value from $input",
+    ({ input, expected }) => {
+      const result = FetchLootsParamsDto.schema.parse({ cursor: input });
+
+      expect(result.cursor).toBe(expected);
+    },
+  );
+});

--- a/packages/api-client/scripts/check-openapi.ts
+++ b/packages/api-client/scripts/check-openapi.ts
@@ -7,6 +7,11 @@ type YamlModule = {
 };
 
 type OpenApiSchema = Record<string, unknown>;
+type OpenApiParameter = {
+  in?: string;
+  name?: string;
+  required?: boolean;
+};
 type OpenApiDocument = {
   components?: {
     schemas?: Record<string, OpenApiSchema>;
@@ -16,6 +21,7 @@ type OpenApiDocument = {
     Record<
       string,
       {
+        parameters?: OpenApiParameter[];
         responses?: Record<
           string,
           {
@@ -68,6 +74,21 @@ const requiredSchemas = [
   "NotificationJobPayloadSnapshotResponseDto",
 ] as const;
 
+const optionalLootQueryParameters = [
+  "cursor",
+  "npcLevelMin",
+  "npcLevelMax",
+  "itemLevelMin",
+  "itemLevelMax",
+  "playerLevelMin",
+  "playerLevelMax",
+] as const;
+
+const lootQueryPaths = [
+  "/guilds/{guildId}/loots",
+  "/guilds/{guildId}/loots/count",
+] as const;
+
 const assert = (condition: unknown, message: string): void => {
   if (!condition) {
     throw new Error(message);
@@ -101,5 +122,21 @@ export const checkOpenApi = (): void => {
       document.components?.schemas?.[schemaName],
       `Missing raw OpenAPI component schema ${schemaName}`,
     );
+  }
+
+  for (const pathKey of lootQueryPaths) {
+    const parameters = document.paths?.[pathKey]?.get?.parameters ?? [];
+
+    for (const parameterName of optionalLootQueryParameters) {
+      const parameter = parameters.find(
+        (candidate) =>
+          candidate.in === "query" && candidate.name === parameterName,
+      );
+
+      assert(
+        parameter?.required === false,
+        `Expected raw OpenAPI query parameter ${parameterName} for GET ${pathKey} to be optional`,
+      );
+    }
   }
 };

--- a/packages/api-client/scripts/openapi-transformer.ts
+++ b/packages/api-client/scripts/openapi-transformer.ts
@@ -1,24 +1,10 @@
 import { sanitizeOpenApiDocument } from "@lootlog/nest-shared/openapi";
 
 type OpenApiSchema = Record<string, unknown>;
-type OpenApiParameter = {
-  in?: string;
-  name?: string;
-  required?: boolean;
-};
 type OpenApiDocument = {
   components?: {
     schemas?: Record<string, OpenApiSchema>;
   };
-  paths?: Record<
-    string,
-    Record<
-      string,
-      {
-        parameters?: OpenApiParameter[];
-      }
-    >
-  >;
 };
 
 const replaceSchemaRef = (value: unknown, fromRef: string, toRef: string) => {
@@ -79,26 +65,6 @@ const aliasJsonValueSchema = (document: OpenApiDocument) => {
   delete schemas[generatedSchemaName];
 };
 
-const setOperationParameterRequired = (
-  document: OpenApiDocument,
-  path: string,
-  method: string,
-  parameterName: string,
-  required: boolean,
-) => {
-  const parameters = document.paths?.[path]?.[method]?.parameters;
-
-  if (!parameters) {
-    return;
-  }
-
-  for (const parameter of parameters) {
-    if (parameter.in === "query" && parameter.name === parameterName) {
-      parameter.required = required;
-    }
-  }
-};
-
 export default function transformOpenApiDocument<TDocument>(
   inputDocument: TDocument,
 ) {
@@ -111,29 +77,6 @@ export default function transformOpenApiDocument<TDocument>(
     "LootShareResponseDto_Output",
     "LootShareResponseDto",
   );
-
-  for (const path of [
-    "/guilds/{guildId}/loots",
-    "/guilds/{guildId}/loots/count",
-  ]) {
-    for (const parameterName of [
-      "cursor",
-      "npcLevelMin",
-      "npcLevelMax",
-      "itemLevelMin",
-      "itemLevelMax",
-      "playerLevelMin",
-      "playerLevelMax",
-    ]) {
-      setOperationParameterRequired(
-        document,
-        path,
-        "get",
-        parameterName,
-        false,
-      );
-    }
-  }
 
   return document;
 }

--- a/packages/api-client/src/generated/core/main/kills/kills.ts
+++ b/packages/api-client/src/generated/core/main/kills/kills.ts
@@ -310,7 +310,7 @@ export const killsControllerGetNpcKillers = async ({ guildId, npcId }: KillsCont
 
 
 export const getKillsControllerGetMemberKillsUrl = ({ guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams,) => {
+    params?: KillsControllerGetMemberKillsParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -330,7 +330,7 @@ export const getKillsControllerGetMemberKillsUrl = ({ guildId, memberId }: Kills
  * @summary Get kill statistics for a specific guild member
  */
 export const killsControllerGetMemberKills = async ({ guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: Parameters<typeof mainFetch>[1]): Promise<MemberKillsResponseDtoOutput> => {
+    params?: KillsControllerGetMemberKillsParams, options?: Parameters<typeof mainFetch>[1]): Promise<MemberKillsResponseDtoOutput> => {
 
   return mainFetch<MemberKillsResponseDtoOutput>(getKillsControllerGetMemberKillsUrl({ guildId, memberId },params),
   {

--- a/packages/api-client/src/generated/core/main/loots/loots.ts
+++ b/packages/api-client/src/generated/core/main/loots/loots.ts
@@ -104,7 +104,7 @@ import type {
 import { mainFetch } from '../../../../mutators';
 
 export const getLootsControllerFetchLootsByGuildIdUrl = ({ guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams,) => {
+    params?: LootsControllerFetchLootsByGuildIdParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -124,7 +124,7 @@ export const getLootsControllerFetchLootsByGuildIdUrl = ({ guildId }: LootsContr
  * @summary Get guild loots
  */
 export const lootsControllerFetchLootsByGuildId = async ({ guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<LootResponseDto[]> => {
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<LootResponseDto[]> => {
 
   return mainFetch<LootResponseDto[]>(getLootsControllerFetchLootsByGuildIdUrl({ guildId },params),
   {
@@ -170,7 +170,7 @@ export const lootsControllerGetLootStats = async ({ guildId }: LootsControllerGe
 
 
 export const getLootsControllerCountLootsByGuildIdUrl = ({ guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams,) => {
+    params?: LootsControllerCountLootsByGuildIdParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -190,7 +190,7 @@ export const getLootsControllerCountLootsByGuildIdUrl = ({ guildId }: LootsContr
  * @summary Get guild loots count
  */
 export const lootsControllerCountLootsByGuildId = async ({ guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<CountResponseDtoOutput> => {
+    params?: LootsControllerCountLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<CountResponseDtoOutput> => {
 
   return mainFetch<CountResponseDtoOutput>(getLootsControllerCountLootsByGuildIdUrl({ guildId },params),
   {

--- a/packages/api-client/src/generated/models/main/kills-controller-get-member-kills-params.ts
+++ b/packages/api-client/src/generated/models/main/kills-controller-get-member-kills-params.ts
@@ -13,12 +13,12 @@ export type KillsControllerGetMemberKillsParams = {
  * @minimum 0
  * @maximum 500
  */
-minLvl: number;
+minLvl?: number;
 /**
  * @minimum 0
  * @maximum 500
  */
-maxLvl: number;
+maxLvl?: number;
 world?: string;
 npcTypes?: KillsControllerGetMemberKillsNpcTypesItem[];
 search?: string;
@@ -31,6 +31,6 @@ limit?: number;
  * @minimum 0
  * @maximum 9007199254740991
  */
-cursor: number;
+cursor?: number;
 period?: KillsControllerGetMemberKillsPeriod;
 };

--- a/packages/api-client/src/generated/models/main/loots-controller-count-loots-by-guild-id-params.ts
+++ b/packages/api-client/src/generated/models/main/loots-controller-count-loots-by-guild-id-params.ts
@@ -11,7 +11,7 @@ export type LootsControllerCountLootsByGuildIdParams = {
  * @minimum 1
  * @maximum 100
  */
-limit: number;
+limit?: number;
 /**
  * @minimum -9007199254740991
  * @maximum 9007199254740991

--- a/packages/api-client/src/generated/models/main/loots-controller-fetch-loots-by-guild-id-params.ts
+++ b/packages/api-client/src/generated/models/main/loots-controller-fetch-loots-by-guild-id-params.ts
@@ -11,7 +11,7 @@ export type LootsControllerFetchLootsByGuildIdParams = {
  * @minimum 1
  * @maximum 100
  */
-limit: number;
+limit?: number;
 /**
  * @minimum -9007199254740991
  * @maximum 9007199254740991

--- a/packages/api-client/src/generated/react-query/main/kills/kills.ts
+++ b/packages/api-client/src/generated/react-query/main/kills/kills.ts
@@ -1137,7 +1137,7 @@ export const useGetKillsControllerGetNpcKillersQueryData = () => {
 
 
 export const getKillsControllerGetMemberKillsUrl = ({ guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams,) => {
+    params?: KillsControllerGetMemberKillsParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -1157,7 +1157,7 @@ export const getKillsControllerGetMemberKillsUrl = ({ guildId, memberId }: Kills
  * @summary Get kill statistics for a specific guild member
  */
 export const killsControllerGetMemberKills = async ({ guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: Parameters<typeof mainFetch>[1]): Promise<MemberKillsResponseDtoOutput> => {
+    params?: KillsControllerGetMemberKillsParams, options?: Parameters<typeof mainFetch>[1]): Promise<MemberKillsResponseDtoOutput> => {
 
   return mainFetch<MemberKillsResponseDtoOutput>(getKillsControllerGetMemberKillsUrl({ guildId, memberId },params),
   {
@@ -1181,7 +1181,7 @@ export const getKillsControllerGetMemberKillsQueryKey = ({ guildId, memberId }: 
 
 
 export const getKillsControllerGetMemberKillsQueryOptions = <TData = Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError = ErrorType<void>>({ guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
@@ -1205,7 +1205,7 @@ export type KillsControllerGetMemberKillsQueryError = ErrorType<void>
 
 export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError = ErrorType<void>>(
  pathParams: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>> & Pick<
+    params: undefined |  KillsControllerGetMemberKillsParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof killsControllerGetMemberKills>>,
           TError,
@@ -1216,7 +1216,7 @@ export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<type
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError = ErrorType<void>>(
  pathParams: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>> & Pick<
+    params?: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof killsControllerGetMemberKills>>,
           TError,
@@ -1227,7 +1227,7 @@ export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<type
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError = ErrorType<void>>(
  pathParams: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
@@ -1236,7 +1236,7 @@ export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<type
 
 export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError = ErrorType<void>>(
  { guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
@@ -1252,7 +1252,7 @@ export function useKillsControllerGetMemberKills<TData = Awaited<ReturnType<type
  */
 export const prefetchKillsControllerGetMemberKillsQuery = async <TData = Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError = ErrorType<void>>(
  queryClient: QueryClient, { guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: KillsControllerGetMemberKillsParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof killsControllerGetMemberKills>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
 
   ): Promise<QueryClient> => {
 
@@ -1268,7 +1268,7 @@ export const prefetchKillsControllerGetMemberKillsQuery = async <TData = Awaited
  */
 export const invalidateKillsControllerGetMemberKills = async (
  queryClient: QueryClient, { guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams, options?: InvalidateOptions
+    params?: KillsControllerGetMemberKillsParams, options?: InvalidateOptions
   ): Promise<QueryClient> => {
 
   await queryClient.invalidateQueries({ queryKey: getKillsControllerGetMemberKillsQueryKey({ guildId, memberId },params) }, options);
@@ -1293,6 +1293,6 @@ export const useSetKillsControllerGetMemberKillsQueryData = () => {
 export const useGetKillsControllerGetMemberKillsQueryData = () => {
   const queryClient = useQueryClient();
   return ({ guildId, memberId }: KillsControllerGetMemberKillsPathParameters,
-    params: KillsControllerGetMemberKillsParams,) =>
+    params?: KillsControllerGetMemberKillsParams,) =>
     queryClient.getQueryData<Awaited<ReturnType<typeof killsControllerGetMemberKills>>>(getKillsControllerGetMemberKillsQueryKey({ guildId, memberId },params));
 }

--- a/packages/api-client/src/generated/react-query/main/loots/loots.ts
+++ b/packages/api-client/src/generated/react-query/main/loots/loots.ts
@@ -131,7 +131,7 @@ type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 
 export const getLootsControllerFetchLootsByGuildIdUrl = ({ guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams,) => {
+    params?: LootsControllerFetchLootsByGuildIdParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -151,7 +151,7 @@ export const getLootsControllerFetchLootsByGuildIdUrl = ({ guildId }: LootsContr
  * @summary Get guild loots
  */
 export const lootsControllerFetchLootsByGuildId = async ({ guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<LootResponseDto[]> => {
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<LootResponseDto[]> => {
 
   return mainFetch<LootResponseDto[]>(getLootsControllerFetchLootsByGuildIdUrl({ guildId },params),
   {
@@ -175,7 +175,7 @@ export const getLootsControllerFetchLootsByGuildIdQueryKey = ({ guildId }: Loots
 
 
 export const getLootsControllerFetchLootsByGuildIdQueryOptions = <TData = Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError = ErrorType<void>>({ guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
@@ -199,7 +199,7 @@ export type LootsControllerFetchLootsByGuildIdQueryError = ErrorType<void>
 
 export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError = ErrorType<void>>(
  pathParams: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>> & Pick<
+    params: undefined |  LootsControllerFetchLootsByGuildIdParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>,
           TError,
@@ -210,7 +210,7 @@ export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError = ErrorType<void>>(
  pathParams: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>> & Pick<
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>,
           TError,
@@ -221,7 +221,7 @@ export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError = ErrorType<void>>(
  pathParams: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
@@ -230,7 +230,7 @@ export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType
 
 export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError = ErrorType<void>>(
  { guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
@@ -246,7 +246,7 @@ export function useLootsControllerFetchLootsByGuildId<TData = Awaited<ReturnType
  */
 export const prefetchLootsControllerFetchLootsByGuildIdQuery = async <TData = Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError = ErrorType<void>>(
  queryClient: QueryClient, { guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
 
   ): Promise<QueryClient> => {
 
@@ -262,7 +262,7 @@ export const prefetchLootsControllerFetchLootsByGuildIdQuery = async <TData = Aw
  */
 export const invalidateLootsControllerFetchLootsByGuildId = async (
  queryClient: QueryClient, { guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams, options?: InvalidateOptions
+    params?: LootsControllerFetchLootsByGuildIdParams, options?: InvalidateOptions
   ): Promise<QueryClient> => {
 
   await queryClient.invalidateQueries({ queryKey: getLootsControllerFetchLootsByGuildIdQueryKey({ guildId },params) }, options);
@@ -287,7 +287,7 @@ export const useSetLootsControllerFetchLootsByGuildIdQueryData = () => {
 export const useGetLootsControllerFetchLootsByGuildIdQueryData = () => {
   const queryClient = useQueryClient();
   return ({ guildId }: LootsControllerFetchLootsByGuildIdPathParameters,
-    params: LootsControllerFetchLootsByGuildIdParams,) =>
+    params?: LootsControllerFetchLootsByGuildIdParams,) =>
     queryClient.getQueryData<Awaited<ReturnType<typeof lootsControllerFetchLootsByGuildId>>>(getLootsControllerFetchLootsByGuildIdQueryKey({ guildId },params));
 }
 
@@ -455,7 +455,7 @@ export const useGetLootsControllerGetLootStatsQueryData = () => {
 
 
 export const getLootsControllerCountLootsByGuildIdUrl = ({ guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams,) => {
+    params?: LootsControllerCountLootsByGuildIdParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -475,7 +475,7 @@ export const getLootsControllerCountLootsByGuildIdUrl = ({ guildId }: LootsContr
  * @summary Get guild loots count
  */
 export const lootsControllerCountLootsByGuildId = async ({ guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<CountResponseDtoOutput> => {
+    params?: LootsControllerCountLootsByGuildIdParams, options?: Parameters<typeof mainFetch>[1]): Promise<CountResponseDtoOutput> => {
 
   return mainFetch<CountResponseDtoOutput>(getLootsControllerCountLootsByGuildIdUrl({ guildId },params),
   {
@@ -499,7 +499,7 @@ export const getLootsControllerCountLootsByGuildIdQueryKey = ({ guildId }: Loots
 
 
 export const getLootsControllerCountLootsByGuildIdQueryOptions = <TData = Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError = ErrorType<void>>({ guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
 ) => {
 
 const {query: queryOptions, request: requestOptions} = options ?? {};
@@ -523,7 +523,7 @@ export type LootsControllerCountLootsByGuildIdQueryError = ErrorType<void>
 
 export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError = ErrorType<void>>(
  pathParams: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>> & Pick<
+    params: undefined |  LootsControllerCountLootsByGuildIdParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>> & Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>,
           TError,
@@ -534,7 +534,7 @@ export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType
   ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError = ErrorType<void>>(
  pathParams: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>> & Pick<
+    params?: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>> & Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>,
           TError,
@@ -545,7 +545,7 @@ export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError = ErrorType<void>>(
  pathParams: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient
   ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
@@ -554,7 +554,7 @@ export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType
 
 export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError = ErrorType<void>>(
  { guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient
  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
@@ -570,7 +570,7 @@ export function useLootsControllerCountLootsByGuildId<TData = Awaited<ReturnType
  */
 export const prefetchLootsControllerCountLootsByGuildIdQuery = async <TData = Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError = ErrorType<void>>(
  queryClient: QueryClient, { guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
+    params?: LootsControllerCountLootsByGuildIdParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>, TError, TData>>, request?: SecondParameter<typeof mainFetch>}
 
   ): Promise<QueryClient> => {
 
@@ -586,7 +586,7 @@ export const prefetchLootsControllerCountLootsByGuildIdQuery = async <TData = Aw
  */
 export const invalidateLootsControllerCountLootsByGuildId = async (
  queryClient: QueryClient, { guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams, options?: InvalidateOptions
+    params?: LootsControllerCountLootsByGuildIdParams, options?: InvalidateOptions
   ): Promise<QueryClient> => {
 
   await queryClient.invalidateQueries({ queryKey: getLootsControllerCountLootsByGuildIdQueryKey({ guildId },params) }, options);
@@ -611,7 +611,7 @@ export const useSetLootsControllerCountLootsByGuildIdQueryData = () => {
 export const useGetLootsControllerCountLootsByGuildIdQueryData = () => {
   const queryClient = useQueryClient();
   return ({ guildId }: LootsControllerCountLootsByGuildIdPathParameters,
-    params: LootsControllerCountLootsByGuildIdParams,) =>
+    params?: LootsControllerCountLootsByGuildIdParams,) =>
     queryClient.getQueryData<Awaited<ReturnType<typeof lootsControllerCountLootsByGuildId>>>(getLootsControllerCountLootsByGuildIdQueryKey({ guildId },params));
 }
 

--- a/packages/api-client/src/transport.test.ts
+++ b/packages/api-client/src/transport.test.ts
@@ -68,6 +68,30 @@ describe("API client transport", () => {
     expect(headers.get("x-request")).toBe("request");
   });
 
+  it("preserves the receiver for a service-configured fetch", async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(function (
+      this: typeof globalThis | undefined,
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) {
+      if (this !== globalThis) {
+        throw new TypeError("Illegal invocation");
+      }
+      return Promise.resolve(Response.json({ ok: true }));
+    });
+    restoreConfiguration = configureApiClients({
+      main: {
+        baseUrl: "https://api.example.test",
+        fetch: fetchImplementation,
+      },
+    });
+
+    await expect(createApiClient("main").get("/status")).resolves.toEqual({
+      ok: true,
+    });
+    expect(fetchImplementation).toHaveBeenCalledOnce();
+  });
+
   it("supports isolated per-request configuration without global state", async () => {
     const firstFetch = vi
       .fn<typeof fetch>()
@@ -99,6 +123,29 @@ describe("API client transport", () => {
     expect(String(secondFetch.mock.calls[0]?.[0])).toBe(
       "https://second.example.test/items",
     );
+  });
+
+  it("preserves the receiver for a per-request fetch override", async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(function (
+      this: typeof globalThis | undefined,
+      _input: RequestInfo | URL,
+      _init?: RequestInit,
+    ) {
+      if (this !== globalThis) {
+        throw new TypeError("Illegal invocation");
+      }
+      return Promise.resolve(Response.json({ ok: true }));
+    });
+
+    await expect(
+      createApiClient("search").get("/items", {
+        apiClient: {
+          baseUrl: "https://search.example.test",
+          fetch: fetchImplementation,
+        },
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchImplementation).toHaveBeenCalledOnce();
   });
 
   it("restores nested configurations safely when disposed out of order", async () => {

--- a/packages/api-client/src/transport.ts
+++ b/packages/api-client/src/transport.ts
@@ -353,7 +353,7 @@ const executeFetch = async ({
 
     const fetchImplementation = configuration.fetch;
     if (fetchImplementation) {
-      return await fetchImplementation(url, requestOptions);
+      return await fetchImplementation.call(globalThis, url, requestOptions);
     }
 
     return await fetch(url, requestOptions);

--- a/packages/nest-shared/src/validators/query-helpers.ts
+++ b/packages/nest-shared/src/validators/query-helpers.ts
@@ -36,7 +36,7 @@ export const booleanFromString = z.preprocess(
 );
 
 export const optionalFromQuery = <T extends z.ZodTypeAny>(schema: T) =>
-  z.preprocess(emptyStringToUndefined, schema.optional());
+  z.preprocess(emptyStringToUndefined, schema.optional()).optional();
 
 export const intFromString = (opts?: IntFromStringOptions) => {
   let schema = z.coerce.number().int();


### PR DESCRIPTION
## What

- invoke service-configured and per-request `fetch` implementations with `globalThis` as the receiver while keeping the native fallback unchanged
- fix `optionalFromQuery` at the Zod source and regenerate the raw OpenAPI document plus central clients
- validate seven optional loot query parameters on both loot endpoints before the Orval transform
- remove the loot-specific `required` workaround from the Orval transformer
- add receiver-sensitive transport tests and DTO runtime coverage for `undefined`, an empty string, and a valid number

## Why

Follow-up to #1159 and the unresolved [OpenAPI review thread](https://github.com/lootlog/monorepo/pull/1159#discussion_r3640747095). The source fix also correctly makes `minLvl`, `maxLvl`, and `cursor` optional for member-kills.

## Verification

- `pnpm --filter @lootlog/api-client test` (16 tests)
- `pnpm --filter @lootlog/api-client check-types`
- `pnpm --filter @lootlog/api-client lint`
- `pnpm --filter @lootlog/api lint` (passes; existing warnings remain outside this diff)
- `pnpm --filter @lootlog/api build`
- `pnpm --filter @lootlog/api test` (96 files, 967 tests)
- two consecutive `pnpm api:client:generate` runs produced identical generated diffs
- post-commit `pnpm api:client:check` (12/12 Turbo tasks)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Loot listing and count endpoints now support requests without pagination or level-range filters.
  - Kill statistics requests can omit level-range and cursor parameters.
- **Bug Fixes**
  - Improved compatibility for custom API clients by preserving the correct context when making requests.
  - Optional query values are now handled more consistently, including empty or missing inputs.
- **Tests**
  - Added coverage for optional query parsing and custom request behavior.
  - Added validation to ensure supported API parameters remain optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->