### PR TITLE
fix(game-client): keep context menus above windows

### DIFF
--- a/apps/game-client/src/components/ui/context-menu.tsx
+++ b/apps/game-client/src/components/ui/context-menu.tsx
@@ -33,11 +33,14 @@ const ContextMenuContent = React.forwardRef<
   ContextMenuContentProps
 >(({ className, collisionPadding = 8, ...props }, ref) => (
   <BaseContextMenu.Portal container={getLootlogPortalContainer()}>
-    <BaseContextMenu.Positioner collisionPadding={collisionPadding}>
+    <BaseContextMenu.Positioner
+      className="ll:z-[500]"
+      collisionPadding={collisionPadding}
+    >
       <BaseContextMenu.Popup
         ref={ref}
         className={cn(
-          "ll:z-500 ll:max-h-[var(--available-height)] ll:min-w-32 ll:overflow-y-auto ll:overflow-x-hidden ll:rounded-md ll:border ll:p-1 ll:text-popover-foreground ll:shadow-md ll:animate-in ll:fade-in-0 ll:zoom-in-95 data-[ending-style]:ll:animate-out data-[ending-style]:ll:fade-out-0 data-[ending-style]:ll:zoom-out-95 data-[side=bottom]:ll:slide-in-from-top-2 data-[side=left]:ll:slide-in-from-right-2 data-[side=right]:ll:slide-in-from-left-2 data-[side=top]:ll:slide-in-from-bottom-2 ll:origin-[var(--transform-origin)] ll:bg-black/80 ll:flex ll:flex-col ll:gap-0.5 ll:border-solid ll:border-gray-400 ll:text-xs",
+          "ll:z-[500] ll:max-h-[var(--available-height)] ll:min-w-32 ll:overflow-y-auto ll:overflow-x-hidden ll:rounded-md ll:border ll:p-1 ll:text-popover-foreground ll:shadow-md ll:animate-in ll:fade-in-0 ll:zoom-in-95 data-[ending-style]:ll:animate-out data-[ending-style]:ll:fade-out-0 data-[ending-style]:ll:zoom-out-95 data-[side=bottom]:ll:slide-in-from-top-2 data-[side=left]:ll:slide-in-from-right-2 data-[side=right]:ll:slide-in-from-left-2 data-[side=top]:ll:slide-in-from-bottom-2 ll:origin-[var(--transform-origin)] ll:bg-black/80 ll:flex ll:flex-col ll:gap-0.5 ll:border-solid ll:border-gray-400 ll:text-xs",
           className,
         )}
         {...props}

--- a/apps/game-client/src/components/ui/portal-theme-boundary.test.tsx
+++ b/apps/game-client/src/components/ui/portal-theme-boundary.test.tsx
@@ -101,6 +101,15 @@ describe("overlay theme boundary", () => {
     expect(["6px", "calc(8px - 2px)"]).toContain(
       getComputedStyle(screen.getByTestId("context-menu-content")).borderRadius,
     );
+    const contextMenuPositioner = screen.getByTestId(
+      "context-menu-content",
+    ).parentElement;
+
+    expect(contextMenuPositioner).not.toBeNull();
+    if (!contextMenuPositioner) {
+      throw new Error("Context menu positioner was not rendered");
+    }
+    expect(getComputedStyle(contextMenuPositioner).zIndex).toBe("500");
   });
 
   it("keeps a context menu open when item selection is prevented", () => {


### PR DESCRIPTION
## What changed

- apply the shared overlay z-index to the Base UI context-menu positioner
- normalize the popup z-index utility to the explicit `500` value
- add regression coverage for the positioner's computed stacking level

## Why

Draggable windows create independent stacking contexts. The context-menu popup previously had a high z-index only on the popup itself, while its positioner remained below adjacent windows. This caused menus opened inside one draggable window to render underneath another window.

The fix mirrors the established tooltip layering behavior by placing `z-index: 500` on the positioner.

## Impact

All game-client context menus using the shared component now render above draggable windows without changing their public interface or interaction behavior.

## Validation

- `pnpm --filter game-client test --run src/components/ui/portal-theme-boundary.test.tsx`
- `pnpm --filter game-client lint`
- `pnpm --filter game-client check-types`
- pre-commit changed-package suite: 207 test files, 1090 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved context-menu layering so menus consistently appear above other interface elements.
  - Fixed positioning behavior within themed interface areas to prevent menus from being obscured or displayed behind overlays.

- **Tests**
  - Added coverage to verify that context menus maintain the correct stacking order across theme boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->