### PR TITLE
fix(game-client): stabilize chat rendering and scrolling

### DIFF
--- a/apps/game-client/src/features/chat/chat-scroll-controller.ts
+++ b/apps/game-client/src/features/chat/chat-scroll-controller.ts
@@ -98,6 +98,12 @@ export const createChatScrollController = ({
       }
     },
     pinToBottom: (snapshot) => {
+      const maximumScrollTop = getMaximumScrollTop(snapshot);
+      if (Math.abs(snapshot.scrollTop - maximumScrollTop) <= 1) {
+        programmaticTarget = null;
+        return;
+      }
+
       scroll(snapshot, "auto", snapshot.scrollHeight);
     },
     registerUserScrollIntent: (snapshot) => {

--- a/apps/game-client/src/features/chat/components/chat-message-list.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.test.tsx
@@ -272,6 +272,79 @@ describe("ChatMessageList", () => {
     ).toBe("124px");
   });
 
+  it("limits unstable row measurements to one render per animation frame", () => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverHarness);
+    let measuredHeight = 40;
+    let measurementCount = 0;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        measurementCount += 1;
+        measuredHeight = measuredHeight === 40 ? 41 : 40;
+
+        return {
+          bottom: measuredHeight,
+          height: measuredHeight,
+          left: 0,
+          right: 100,
+          top: 0,
+          width: 100,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    );
+
+    expect(() => renderMessageList(createRenderables(1))).not.toThrow();
+    expect(measurementCount).toBeGreaterThan(0);
+    const visibleRow = document.querySelector<HTMLElement>(
+      "[data-chat-virtual-index]",
+    );
+    expect(visibleRow).toBeDefined();
+
+    const measurementCountBeforeResize = measurementCount;
+    act(() => {
+      triggerResizeObserver(visibleRow as HTMLElement);
+      triggerResizeObserver(visibleRow as HTMLElement);
+      triggerResizeObserver(visibleRow as HTMLElement);
+    });
+    expect(measurementCount).toBe(measurementCountBeforeResize + 3);
+
+    for (let frame = 0; frame < 3; frame += 1) {
+      const previousMeasurementCount = measurementCount;
+      flushAnimationFrames(1);
+      expect(measurementCount).toBe(previousMeasurementCount + 1);
+    }
+  });
+
+  it("does not continuously scroll to the bottom while row heights remain unstable", () => {
+    let measuredHeight = 40;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        measuredHeight = measuredHeight === 40 ? 41 : 40;
+
+        return {
+          bottom: measuredHeight,
+          height: measuredHeight,
+          left: 0,
+          right: 100,
+          top: 0,
+          width: 100,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    );
+
+    renderMessageList(createRenderables(1));
+    scrollRequests.length = 0;
+
+    flushAnimationFrames(20);
+
+    expect(scrollRequests.length).toBeLessThanOrEqual(1);
+  });
+
   it("keeps the exact scroll position while history rows are remeasured", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserverHarness);
     const measuredHeightsByIndex = new Map<number, number>();

--- a/apps/game-client/src/features/chat/components/chat-message-list.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.tsx
@@ -190,9 +190,7 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
 }) => {
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const messageListRef = useRef<HTMLDivElement>(null);
-  const [measuredRows, setMeasuredRows] = useState(
-    () => new Map<string, MeasuredChatRow>(),
-  );
+  const measuredRowsRef = useRef(new Map<string, MeasuredChatRow>());
   const [measurementCycle, setMeasurementCycle] = useState(0);
   const [viewport, setViewport] = useState<ChatViewport>({
     height: CHAT_LIST_FALLBACK_HEIGHT_PX,
@@ -282,16 +280,18 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
     scrollToBottomRequest,
   ]);
 
-  const activeMeasuredRows = new Map(measuredRows);
-  pruneChatRowMeasurements(activeMeasuredRows, renderables);
+  useEffect(() => {
+    pruneChatRowMeasurements(measuredRowsRef.current, renderables);
+  }, [renderables]);
+
   const virtualLayout = getChatVirtualLayout({
-    measuredRows: activeMeasuredRows,
+    measuredRows: measuredRowsRef.current,
     renderables,
     viewport,
   });
   const { endIndex, rowOffsets, startIndex, totalHeight } = virtualLayout;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     virtualLayoutRef.current = virtualLayout;
   }, [virtualLayout]);
 
@@ -379,17 +379,15 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
     if (!messageList) return () => undefined;
 
     const measureRows = (elements: Element[]) => {
-      const measurements: Array<{
-        height: number;
-        key: string;
-        source: unknown;
-      }> = [];
+      const currentLayout = virtualLayoutRef.current;
+      if (!currentLayout) return;
 
+      let changed = false;
       for (const element of elements) {
         if (!(element instanceof HTMLElement)) continue;
 
         const rowIndex = Number(element.dataset.chatVirtualIndex);
-        const renderable = virtualLayout.renderables[rowIndex];
+        const renderable = currentLayout.renderables[rowIndex];
         if (!renderable) continue;
 
         const devicePixelRatio = window.devicePixelRatio || 1;
@@ -400,35 +398,23 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
         if (measuredHeight <= 0 && element.childElementCount > 0) continue;
 
         const measurementSource = getChatRowMeasurementSource(renderable);
-        measurements.push({
-          height: measuredHeight,
-          key: renderable.key,
-          source: measurementSource,
-        });
-      }
-
-      const nextRows = new Map(measuredRows);
-      const previousRowCount = nextRows.size;
-      pruneChatRowMeasurements(nextRows, virtualLayout.renderables);
-      let changed = nextRows.size !== previousRowCount;
-      for (const measurement of measurements) {
-        const currentMeasurement = measuredRows.get(measurement.key);
+        const currentMeasurement = measuredRowsRef.current.get(renderable.key);
         if (
-          currentMeasurement &&
-          currentMeasurement.source === measurement.source &&
-          Math.abs(currentMeasurement.height - measurement.height) <
-            1 / (window.devicePixelRatio || 1)
+          currentMeasurement?.source === measurementSource &&
+          Math.abs(currentMeasurement.height - measuredHeight) <
+            1 / devicePixelRatio
         ) {
           continue;
         }
-        nextRows.set(measurement.key, {
-          height: measurement.height,
-          source: measurement.source,
+
+        measuredRowsRef.current.set(renderable.key, {
+          height: measuredHeight,
+          source: measurementSource,
         });
         changed = true;
       }
+
       if (!changed) return;
-      setMeasuredRows(nextRows);
 
       const scrollMode = scrollController.getMode();
       if (


### PR DESCRIPTION
## What changed

- keep virtualized chat row measurements in a non-reactive ref and batch layout refreshes through the existing animation-frame cycle
- make `pinToBottom` idempotent when the viewport is already within 1 px of the physical bottom
- add regression coverage for unstable row heights, repeated `ResizeObserver` callbacks, maximum update depth crashes, and repeated bottom-scroll commands

## Why

The production userscript could crash with `Maximum update depth exceeded` while chat was open. A recent refactor moved the row measurement cache into React state, so an unstable measured height could synchronously trigger another render and measurement indefinitely.

The same unstable layout also exposed a second loop during chat initialization: `pinToBottom` issued a new `scrollTo` command every animation frame even when the viewport had already reached the target, causing visible scroll flicker.

## Impact

Chat layout measurements no longer create synchronous nested React updates. Unstable or late-changing row heights are processed at most once per animation frame, and an already-satisfied bottom target does not issue redundant browser scroll commands.

## Validation

- `pnpm --filter @lootlog/game-client test` — 207 files, 1092 tests passed
- `pnpm --filter @lootlog/game-client lint`
- `pnpm --filter @lootlog/game-client check-types`
- `pnpm --filter @lootlog/game-client build`
- pre-commit checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrolling to avoid redundant auto-scroll requests when already at the bottom.
  * Reduced unnecessary layout updates during chat rendering, improving stability with changing message heights.
  * Prevented repeated scroll-to-bottom requests when chat row measurements remain unstable.

* **Tests**
  * Added coverage for unstable row heights, resize events, and repeated animation frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->