### PR TITLE
fix(game-client): stabilize detector window and player glows

### DIFF
--- a/apps/game-client/src/components/draggable-window-frame.tsx
+++ b/apps/game-client/src/components/draggable-window-frame.tsx
@@ -127,18 +127,34 @@ const getMeasuredContentHeight = (
       let nextMeasuredHeight = viewportElement.scrollHeight;
 
       if (viewportContent instanceof HTMLElement) {
-        const renderedHeight = Math.ceil(
-          viewportContent.getBoundingClientRect().height,
+        const contentChildren = Array.from(viewportContent.children).filter(
+          (element): element is HTMLElement => element instanceof HTMLElement,
         );
-        const scrollHeight = viewportContent.scrollHeight;
-        const isSmallTransformedUndershoot =
-          renderedHeight > 0 &&
-          scrollHeight > renderedHeight &&
-          scrollHeight - renderedHeight <= TRANSFORMED_MEASUREMENT_TOLERANCE;
 
-        nextMeasuredHeight = isSmallTransformedUndershoot
-          ? scrollHeight
-          : renderedHeight || scrollHeight;
+        if (contentChildren.length > 0) {
+          nextMeasuredHeight = contentChildren.reduce(
+            (maxContentHeight, contentChild) => {
+              const renderedHeight = Math.ceil(
+                contentChild.getBoundingClientRect().height,
+              );
+              const scrollHeight = contentChild.scrollHeight;
+              const isSmallTransformedUndershoot =
+                renderedHeight > 0 &&
+                scrollHeight > renderedHeight &&
+                scrollHeight - renderedHeight <=
+                  TRANSFORMED_MEASUREMENT_TOLERANCE;
+              const contentChildHeight = isSmallTransformedUndershoot
+                ? scrollHeight
+                : renderedHeight || scrollHeight;
+
+              return Math.max(
+                maxContentHeight,
+                contentChild.offsetTop + contentChildHeight,
+              );
+            },
+            0,
+          );
+        }
       }
 
       return Math.max(maxScrollHeight, nextMeasuredHeight);

--- a/apps/game-client/src/components/draggable-window.test.tsx
+++ b/apps/game-client/src/components/draggable-window.test.tsx
@@ -64,6 +64,14 @@ const flushAnimationFrame = async () => {
   });
 };
 
+const triggerResizeObserverCycles = async (remainingCycles: number) => {
+  if (remainingCycles === 0) return;
+
+  await triggerResizeObservers();
+  await flushAnimationFrame();
+  await triggerResizeObserverCycles(remainingCycles - 1);
+};
+
 const mockElementRenderedHeight = (element: HTMLElement, height: number) => {
   Object.defineProperty(element, "getBoundingClientRect", {
     configurable: true,
@@ -747,6 +755,76 @@ describe("DraggableWindow", () => {
     await waitFor(() => {
       expect(windowElement.style.height).toBe("210px");
     });
+  });
+
+  it("keeps auto height stable when scroll content mirrors the viewport with fractional pixels", async () => {
+    const { container } = render(
+      <DraggableWindow
+        isOpen
+        id="notifications"
+        title="Powiadomienia"
+        resizable={false}
+        minWidth={242}
+        minHeight={82}
+        heightMode="auto-up-to-max"
+        maxContentHeight={272}
+      >
+        {createScrollAreaChildren()}
+      </DraggableWindow>,
+    );
+
+    const {
+      windowElement,
+      titleBarElement,
+      contentElement,
+      viewportElement,
+      viewportContent,
+      measuredContentElement,
+    } = getNestedScrollAreaElements(container);
+
+    Object.defineProperty(titleBarElement, "offsetHeight", {
+      configurable: true,
+      value: 28,
+    });
+    Object.defineProperty(contentElement, "clientHeight", {
+      configurable: true,
+      get: () =>
+        Math.max(0, Number.parseFloat(windowElement.style.height) - 28),
+    });
+    Object.defineProperty(viewportElement, "scrollHeight", {
+      configurable: true,
+      get: () => contentElement.clientHeight,
+    });
+    Object.defineProperty(viewportContent, "scrollHeight", {
+      configurable: true,
+      get: () => contentElement.clientHeight,
+    });
+    Object.defineProperty(measuredContentElement, "scrollHeight", {
+      configurable: true,
+      value: 54,
+    });
+    mockElementRenderedHeight(measuredContentElement, 54);
+    Object.defineProperty(viewportContent, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        const height = contentElement.clientHeight + 0.6;
+        return {
+          width: 0,
+          height,
+          top: 0,
+          right: 0,
+          bottom: height,
+          left: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    });
+
+    await triggerResizeObserverCycles(8);
+
+    expect(windowElement.style.height).toBe("82px");
   });
 
   it("does not undershoot nested scroll area height while the window opening scale transform is active", async () => {

--- a/apps/game-client/src/hooks/game-events/use-other-catching-guild-glow.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-other-catching-guild-glow.test.tsx
@@ -474,6 +474,33 @@ describe("useOtherCatchingGuildGlow", () => {
     );
   });
 
+  it("ignores flat runtime handles when shift activates glows", () => {
+    useOthersStore.getState().setMany({
+      "1": {
+        accountId: "9822301",
+        characterId: "1",
+        icon: "other.gif",
+        level: 300,
+        name: "Other 1",
+        profession: "w",
+      },
+    });
+    useSettingsStore.setState({
+      guildIdByCharId: {
+        "101": "guild-blue",
+      },
+    });
+
+    renderHook(() => useOtherCatchingGuildGlow());
+
+    expect(() => {
+      act(() => {
+        useCharacterTooltipCatchingGuildsStore.getState().setShiftPressed(true);
+      });
+    }).not.toThrow();
+    expect(lootlogOtherGlowManager.getGlowCount()).toBe(0);
+  });
+
   it("requests visible characters when online owners become known after shift", async () => {
     const other = createOther("1");
     useOthersStore.getState().setMany({

--- a/apps/game-client/src/lib/lootlog-other-glow-manager.test.ts
+++ b/apps/game-client/src/lib/lootlog-other-glow-manager.test.ts
@@ -124,6 +124,25 @@ describe("lootlogOtherGlowManager", () => {
     );
   });
 
+  it("ignores flat other handles from the legacy interface", () => {
+    const flatOther = {
+      account: 1,
+      icon: "other.gif",
+      id: "617",
+      lvl: 300,
+      nick: "Other 617",
+      prof: "w",
+    };
+
+    expect(() =>
+      lootlogOtherGlowManager.setGlow(
+        flatOther as unknown as Other,
+        LOOTLOG_OTHER_GLOW_BLUE,
+      ),
+    ).not.toThrow();
+    expect(lootlogOtherGlowManager.getGlowCount()).toBe(0);
+  });
+
   it("updates colors and clears only managed glows", () => {
     lootlogOtherGlowManager.install();
     lootlogOtherGlowManager.setGlow(

--- a/apps/game-client/src/lib/margonem-runtime/adapters/glow-runtime-adapter.ts
+++ b/apps/game-client/src/lib/margonem-runtime/adapters/glow-runtime-adapter.ts
@@ -289,6 +289,8 @@ class LootlogOtherGlowManager {
   }
 
   setGlow(other: Other, color: string): void {
+    if (!other?.d || other.d.id === undefined || other.d.id === null) return;
+
     const characterId = String(other.d.id);
     const runtimeOther = other as RuntimeOther;
     const existingGlow = this.glowsByCharacterId.get(characterId);


### PR DESCRIPTION
## What changed

- measure draggable window content from its rendered children instead of the scroll-area wrapper
- prevent repeated resize observations from incrementally growing auto-sized detector windows
- ignore flat legacy-interface player handles in the NI-only glow renderer
- add regression coverage for repeated resize cycles and Shift-triggered player glow activation

## Root cause

The scroll-area wrapper uses `min-height: 100%`. Measuring that wrapper together with fractional layout rounding created a one-pixel ResizeObserver feedback loop on affected browser/layout configurations.

Separately, the standardized Margonem runtime integration began exposing flat SI player handles alongside NI handles. The glow renderer still assumed every handle had the NI `{ d: ... }` shape, so pressing Shift could attempt to read `other.d.id` from a flat handle.

## Impact

Detector windows remain fitted to their content instead of growing for several seconds. Pressing Shift on the legacy interface no longer opens the application error dialog.

## Validation

- `pnpm --filter game-client test` — 207 files, 1095 tests passed
- `pnpm --filter game-client check-types`
- `pnpm --filter game-client lint`
- formatting and pre-commit checks passed