### PR TITLE
fix(game-client): preserve battle warrior snapshots

### DIFF
--- a/apps/game-client/src/hooks/game-events/helpers/battle.helpers.test.ts
+++ b/apps/game-client/src/hooks/game-events/helpers/battle.helpers.test.ts
@@ -1,0 +1,46 @@
+import type { W } from "@lootlog/margonem/game-events";
+import { describe, expect, it } from "vitest";
+import type { BattleWarriorsWithAccountId } from "@/store/game-store/battle.store";
+import { mergeBattleWarriorPatches } from "./battle.helpers";
+
+const createWarrior = (
+  id: number,
+  name: string,
+  team: number,
+): BattleWarriorsWithAccountId[string] => ({
+  accountId: id > 0 ? id * 10 : undefined,
+  hpp: 100,
+  icon: `${name}.gif`,
+  id,
+  lvl: 300,
+  name,
+  originalId: Math.abs(id),
+  prof: "w",
+  team,
+  type: id < 0 ? 2 : 0,
+  wt: id < 0 ? 85 : 0,
+});
+
+describe("mergeBattleWarriorPatches", () => {
+  it("preserves complete participants while applying fragmentary updates", () => {
+    const currentWarriors = {
+      "101": createWarrior(101, "Hero", 1),
+      "102": createWarrior(102, "Ally", 1),
+      "-501": createWarrior(-501, "Boss", 2),
+    };
+    const patches = {
+      "101": { hpp: 75 },
+      "-501": { hpp: 0 },
+    } as unknown as W;
+
+    const mergedWarriors = mergeBattleWarriorPatches(patches, currentWarriors);
+
+    expect(mergedWarriors).toEqual({
+      "101": { ...currentWarriors["101"], hpp: 75 },
+      "102": currentWarriors["102"],
+      "-501": { ...currentWarriors["-501"], hpp: 0 },
+    });
+    expect(currentWarriors["101"].hpp).toBe(100);
+    expect(currentWarriors["-501"].hpp).toBe(100);
+  });
+});

--- a/apps/game-client/src/hooks/game-events/helpers/battle.helpers.ts
+++ b/apps/game-client/src/hooks/game-events/helpers/battle.helpers.ts
@@ -4,15 +4,17 @@ import { useOthersStore } from "@/store/others.store";
 import type { BattleWarriorsWithAccountId } from "@/store/game-store/battle.store";
 import type { W } from "@lootlog/margonem/game-events";
 
-export const addAccountIdsToWarriors = (
+export const mergeBattleWarriorPatches = (
   warriors: W,
   currentWarriors: BattleWarriorsWithAccountId,
   ingress?: RuntimeIngressSnapshot,
 ) => {
-  const copy = { ...warriors } as BattleWarriorsWithAccountId;
+  const mergedWarriors = {
+    ...currentWarriors,
+  } as BattleWarriorsWithAccountId;
   const game = ingress?.game ?? useGameStore.getState().game;
 
-  Object.entries(copy).forEach(([key, warrior]) => {
+  Object.entries(warriors).forEach(([key, warrior]) => {
     let accountId = currentWarriors[key]?.accountId;
     if (accountId === undefined && key === game?.hero.characterId) {
       accountId = Number(game.hero.accountId);
@@ -26,11 +28,12 @@ export const addAccountIdsToWarriors = (
         : undefined;
     }
 
-    copy[key] = {
+    mergedWarriors[key] = {
+      ...currentWarriors[key],
       ...warrior,
       accountId,
     };
   });
 
-  return copy;
+  return mergedWarriors;
 };

--- a/apps/game-client/src/hooks/game-events/helpers/battle.helpers.ts
+++ b/apps/game-client/src/hooks/game-events/helpers/battle.helpers.ts
@@ -4,6 +4,48 @@ import { useOthersStore } from "@/store/others.store";
 import type { BattleWarriorsWithAccountId } from "@/store/game-store/battle.store";
 import type { W } from "@lootlog/margonem/game-events";
 
+type ModernBattleHp = {
+  cur?: unknown;
+  hpp?: unknown;
+  max?: unknown;
+};
+
+const parseNumericHpValue = (value: unknown) => {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsedValue = Number.parseFloat(value);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+  }
+
+  return null;
+};
+
+const getModernHpPercentage = (
+  warrior: W[string],
+  currentWarrior?: BattleWarriorsWithAccountId[string],
+) => {
+  const hp = (warrior as W[string] & { hp?: ModernBattleHp }).hp;
+  if (!hp) return undefined;
+
+  const hpPercentage = parseNumericHpValue(hp.hpp);
+  if (hpPercentage !== null) return hpPercentage;
+
+  const currentHp = parseNumericHpValue(hp.cur);
+  if (currentHp !== null && currentHp <= 0) return 0;
+
+  const currentHpData = (
+    currentWarrior as
+      | (BattleWarriorsWithAccountId[string] & { hp?: ModernBattleHp })
+      | undefined
+  )?.hp;
+  const maxHp = parseNumericHpValue(hp.max ?? currentHpData?.max);
+  if (currentHp !== null && maxHp !== null && maxHp > 0) {
+    return (currentHp / maxHp) * 100;
+  }
+
+  return undefined;
+};
+
 export const mergeBattleWarriorPatches = (
   warriors: W,
   currentWarriors: BattleWarriorsWithAccountId,
@@ -15,7 +57,9 @@ export const mergeBattleWarriorPatches = (
   const game = ingress?.game ?? useGameStore.getState().game;
 
   Object.entries(warriors).forEach(([key, warrior]) => {
-    let accountId = currentWarriors[key]?.accountId;
+    const currentWarrior = currentWarriors[key];
+    const modernHpPercentage = getModernHpPercentage(warrior, currentWarrior);
+    let accountId = currentWarrior?.accountId;
     if (accountId === undefined && key === game?.hero.characterId) {
       accountId = Number(game.hero.accountId);
     } else if (accountId === undefined) {
@@ -29,8 +73,9 @@ export const mergeBattleWarriorPatches = (
     }
 
     mergedWarriors[key] = {
-      ...currentWarriors[key],
+      ...currentWarrior,
       ...warrior,
+      ...(modernHpPercentage === undefined ? {} : { hpp: modernHpPercentage }),
       accountId,
     };
   });

--- a/apps/game-client/src/lib/game-event-pipeline.golden.test.ts
+++ b/apps/game-client/src/lib/game-event-pipeline.golden.test.ts
@@ -397,9 +397,14 @@ describe("game event pipeline golden replay", () => {
     dispatcher.cleanup();
   });
 
-  it.each(["same packet", "next packet"] as const)(
-    "submits complete participants after a fragmentary final fight update (%s)",
-    (lootTiming) => {
+  it.each([
+    ["same packet", "legacy"],
+    ["next packet", "legacy"],
+    ["same packet", "modern"],
+    ["next packet", "modern"],
+  ] as const)(
+    "submits complete participants after a fragmentary final fight update (%s, %s HP)",
+    async (lootTiming, hpFormat) => {
       resetPipelineState();
       useOthersStore.getState().replaceOthers({
         "111": Object.freeze({
@@ -422,6 +427,7 @@ describe("game event pipeline golden replay", () => {
           init: "1",
           w: {
             "12345": {
+              hp: { cur: 1_000, hpp: 100, max: 1_000 },
               hpp: 100,
               icon: "hero.gif",
               id: 12_345,
@@ -446,6 +452,7 @@ describe("game event pipeline golden replay", () => {
               wt: 0,
             },
             "-100": {
+              hp: { cur: 1_000, hpp: 100, max: 1_000 },
               hpp: 100,
               icon: "boss.gif",
               id: -100,
@@ -461,14 +468,21 @@ describe("game event pipeline golden replay", () => {
         },
       } as GameEvent);
 
+      const finalWarriorPatches =
+        hpFormat === "modern"
+          ? {
+              "12345": { hp: { cur: 750, hpp: 75, max: 1_000 } },
+              "-100": { hp: { cur: 0 } },
+            }
+          : {
+              "12345": { hpp: 75 },
+              "-100": { hpp: 0 },
+            };
       const fragmentaryFinalFightEvent = {
         f: {
           endBattle: 1,
           m: ["final"],
-          w: {
-            "12345": { hpp: 75 },
-            "-100": { hpp: 0 },
-          },
+          w: finalWarriorPatches,
         },
       } as unknown as GameEvent;
 
@@ -521,6 +535,7 @@ describe("game event pipeline golden replay", () => {
         }),
         expect.objectContaining({ source: "fight" }),
       );
+      await vi.waitFor(() => expect(api.createKill).toHaveBeenCalledOnce());
 
       dispatcher.cleanup();
     },

--- a/apps/game-client/src/lib/game-event-pipeline.golden.test.ts
+++ b/apps/game-client/src/lib/game-event-pipeline.golden.test.ts
@@ -13,6 +13,8 @@ import type * as ApiModule from "@/api";
 import { useGameStore } from "@/store/game.store";
 import type { MargonemRuntimeAdapter } from "./margonem-runtime/runtime-adapter";
 import { RuntimeStateSynchronizer } from "./margonem-runtime/runtime-state-synchronizer";
+import { useNpcsStore } from "@/store/npcs.store";
+import { useOthersStore } from "@/store/others.store";
 
 const effects = vi.hoisted(() => ({
   cancelMapPingInteraction: vi.fn(),
@@ -189,6 +191,8 @@ function resetPipelineState(): void {
     socketState: { connected: false, joined: false, joinedGuilds: [] },
   });
   useLootStore.setState({ lastLootId: null });
+  useNpcsStore.getState().clearNpcs();
+  useOthersStore.getState().clearOthers();
   useGameStore.getState().replaceGame({
     hero: {
       accountId: "67890",
@@ -392,4 +396,133 @@ describe("game event pipeline golden replay", () => {
 
     dispatcher.cleanup();
   });
+
+  it.each(["same packet", "next packet"] as const)(
+    "submits complete participants after a fragmentary final fight update (%s)",
+    (lootTiming) => {
+      resetPipelineState();
+      useOthersStore.getState().replaceOthers({
+        "111": Object.freeze({
+          accountId: "222",
+          characterId: "111",
+          icon: "warrior.gif",
+          level: 300,
+          name: "Warrior",
+          profession: "w",
+        }),
+      });
+      const dispatcher = new EventDispatcher();
+      pipelineWindow.successData = vi.fn(() => "game-result");
+      margonemRuntimeBridge.setupProxies();
+      dispatcher.register();
+      margonemRuntimeBridge.setReady(true);
+
+      pipelineWindow.successData?.({
+        f: {
+          init: "1",
+          w: {
+            "12345": {
+              hpp: 100,
+              icon: "hero.gif",
+              id: 12_345,
+              lvl: 300,
+              name: "Hero",
+              originalId: 12_345,
+              prof: "w",
+              team: 1,
+              type: 0,
+              wt: 0,
+            },
+            "111": {
+              hpp: 100,
+              icon: "warrior.gif",
+              id: 111,
+              lvl: 300,
+              name: "Warrior",
+              originalId: 111,
+              prof: "w",
+              team: 1,
+              type: 0,
+              wt: 0,
+            },
+            "-100": {
+              hpp: 100,
+              icon: "boss.gif",
+              id: -100,
+              lvl: 300,
+              name: "Boss",
+              originalId: 100,
+              prof: "m",
+              team: 2,
+              type: 2,
+              wt: 85,
+            },
+          },
+        },
+      } as GameEvent);
+
+      const fragmentaryFinalFightEvent = {
+        f: {
+          endBattle: 1,
+          m: ["final"],
+          w: {
+            "12345": { hpp: 75 },
+            "-100": { hpp: 0 },
+          },
+        },
+      } as unknown as GameEvent;
+
+      if (lootTiming === "same packet") {
+        pipelineWindow.successData?.({
+          ...fightLootEvent,
+          ...fragmentaryFinalFightEvent,
+        } as GameEvent);
+      } else {
+        pipelineWindow.successData?.(fragmentaryFinalFightEvent);
+        pipelineWindow.successData?.(fightLootEvent);
+      }
+
+      expect(api.createLoot).toHaveBeenCalledOnce();
+      expect(api.createLoot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          npcs: [
+            {
+              hpp: 0,
+              icon: "boss.gif",
+              id: 100,
+              location: "Nithal",
+              lvl: 300,
+              name: "Boss",
+              prof: "m",
+              type: 2,
+              wt: 85,
+            },
+          ],
+          players: expect.arrayContaining([
+            {
+              accountId: 67_890,
+              hpp: 75,
+              icon: "hero.gif",
+              id: 12_345,
+              lvl: 300,
+              name: "Hero",
+              prof: "w",
+            },
+            {
+              accountId: 222,
+              hpp: 100,
+              icon: "warrior.gif",
+              id: 111,
+              lvl: 300,
+              name: "Warrior",
+              prof: "w",
+            },
+          ]),
+        }),
+        expect.objectContaining({ source: "fight" }),
+      );
+
+      dispatcher.cleanup();
+    },
+  );
 });

--- a/apps/game-client/src/processors/battle-event-processor.golden.test.ts
+++ b/apps/game-client/src/processors/battle-event-processor.golden.test.ts
@@ -15,7 +15,7 @@ vi.mock("@/api", () => ({
 }));
 
 vi.mock("@/hooks/game-events/helpers/battle.helpers", () => ({
-  addAccountIdsToWarriors: (warriors: unknown) => warriors,
+  mergeBattleWarriorPatches: (warriors: unknown) => warriors,
 }));
 
 vi.mock("@/lib/game", () => ({

--- a/apps/game-client/src/processors/battle-event-processor.test.ts
+++ b/apps/game-client/src/processors/battle-event-processor.test.ts
@@ -50,7 +50,7 @@ vi.mock("@/helpers/mappers/battlelog.mappers", () => ({
 }));
 
 vi.mock("@/hooks/game-events/helpers/battle.helpers", () => ({
-  addAccountIdsToWarriors: vi.fn().mockImplementation((warriors) => warriors),
+  mergeBattleWarriorPatches: vi.fn().mockImplementation((warriors) => warriors),
 }));
 
 const mockBattlePanelStore = {

--- a/apps/game-client/src/processors/battle-event-processor.ts
+++ b/apps/game-client/src/processors/battle-event-processor.ts
@@ -3,7 +3,7 @@ import { mapBattleEventsToPayload } from "@/helpers/mappers/battlelog.mappers";
 import { LOOTLOG_APP_URL } from "@/config/app";
 import { getNpcTypeByWt } from "@lootlog/types";
 import { NpcType } from "@/api/npcs.api";
-import { addAccountIdsToWarriors } from "@/hooks/game-events/helpers/battle.helpers";
+import { mergeBattleWarriorPatches } from "@/hooks/game-events/helpers/battle.helpers";
 import { useGameStore } from "@/store/game.store";
 import type { RuntimeIngressSnapshot } from "@/lib/margonem-runtime/runtime.types";
 import { useBattlePanelStore } from "@/store/battle-panel.store";
@@ -150,7 +150,7 @@ export class BattleEventProcessor {
 
     let battleWarriors = startsBattle ? {} : stateAtIngress.battleWarriors;
     if (event.f.w) {
-      battleWarriors = addAccountIdsToWarriors(
+      battleWarriors = mergeBattleWarriorPatches(
         event.f.w,
         battleWarriors,
         ingress,


### PR DESCRIPTION
## Summary

- merge fragmentary `f.w` updates into the existing battle warrior snapshot
- preserve participants omitted from subsequent fight packets and retain unchanged warrior fields
- keep account ID enrichment from the hero, runtime ingress snapshot, and others store
- use the complete merged snapshot for fight loot arriving in the final packet or immediately afterwards

## Root cause

Margonem sends `f.w` as incremental patches. The optimized battle pipeline replaced `battleWarriors` with the latest patch instead of applying it to the accumulated state. As a result, serialized loot payloads could contain NPCs with only `location` and `type`, and players with only `accountId`.

## Impact

Fight loot payloads now include complete NPC and player data even when the final fight update is fragmentary or the NPC has already disappeared from `npcs.store`. A new fight still resets the accumulator, so participant data cannot leak between fights.

## Validation

- `pnpm --filter=@lootlog/game-client exec vitest run src/hooks/game-events/helpers/battle.helpers.test.ts src/lib/game-event-pipeline.golden.test.ts src/processors/battle-event-processor.test.ts src/processors/battle-event-processor.golden.test.ts`
- `pnpm --filter=@lootlog/game-client test` (225 files, 1167 tests)
- `pnpm --filter=@lootlog/game-client check-types`
- `pnpm --filter=@lootlog/game-client lint`
- pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of partial battle updates so warrior health and other changed details are merged without losing unchanged participant information.
  - Preserved existing battle data when updates arrive across separate event packets.
  - Improved final-fight loot records to include all relevant participants and NPCs, with accurate fragmentary health values.
  - Prevented previously received warrior information from being unintentionally modified during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->