### PR TITLE
Simplify NPC chat group counter

### DIFF
--- a/apps/game-client/src/features/chat/chat.helpers.test.ts
+++ b/apps/game-client/src/features/chat/chat.helpers.test.ts
@@ -283,14 +283,12 @@ describe("chat helpers", () => {
         timestamp: "2026-01-01T10:00:30.000Z",
       },
       {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: "npc-group:npc-1",
         count: 2,
         message: secondNpcMessage,
       },
       {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: "npc-group:npc-3",
         count: 1,
@@ -365,14 +363,12 @@ describe("chat helpers", () => {
         timestamp: "2026-01-01T10:00:10.000Z",
       },
       {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: "npc-group:npc-a-1",
         count: 2,
         message: expect.objectContaining({ id: "npc-a-2" }),
       },
       {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: "npc-group:npc-b-1",
         count: 2,
@@ -430,14 +426,12 @@ describe("chat helpers", () => {
         timestamp: "2026-01-01T10:00:00.000Z",
       },
       {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: "npc-group:npc-1",
         count: 1,
         message: expect.objectContaining({ id: "npc-1" }),
       },
       {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: "npc-group:npc-2",
         count: 1,
@@ -446,7 +440,7 @@ describe("chat helpers", () => {
     ]);
   });
 
-  it("tracks additional unique senders inside a grouped npc burst", () => {
+  it("counts grouped npc messages without exposing sender aggregation", () => {
     const hydraNpc = {
       id: 10,
       name: "Hydra",
@@ -495,7 +489,6 @@ describe("chat helpers", () => {
         timestamp: "2026-01-01T10:00:10.000Z",
       },
       {
-        additionalSenderCount: 2,
         kind: "npc-group",
         key: "npc-group:npc-a-1",
         count: 3,

--- a/apps/game-client/src/features/chat/chat.helpers.ts
+++ b/apps/game-client/src/features/chat/chat.helpers.ts
@@ -27,7 +27,6 @@ export type ChatRenderableMessage =
   | {
       kind: "npc-group";
       key: string;
-      additionalSenderCount: number;
       count: number;
       message: ChatMessageType;
     };
@@ -180,7 +179,6 @@ type InternalRenderableMessage =
   | (Extract<ChatRenderableMessage, { kind: "npc-group" }> & {
       firstTimestamp: number;
       order: number;
-      senderIds: Set<string>;
       sortTimestamp: number;
     });
 
@@ -218,14 +216,12 @@ export const getChatRenderableMessages = (
         InternalRenderableMessage,
         { kind: "npc-group" }
       > = {
-        additionalSenderCount: 0,
         kind: "npc-group",
         key: `npc-group:${message.id}`,
         count: 1,
         message,
         firstTimestamp: timestamp,
         order: renderables.length,
-        senderIds: new Set([message.senderId]),
         sortTimestamp: timestamp,
       };
 
@@ -236,7 +232,6 @@ export const getChatRenderableMessages = (
 
     existingGroup.count += 1;
     existingGroup.message = message;
-    existingGroup.senderIds.add(message.senderId);
     existingGroup.sortTimestamp = timestamp;
   }
 
@@ -263,7 +258,6 @@ export const getChatRenderableMessages = (
             message: renderable.message,
           }
         : {
-            additionalSenderCount: Math.max(renderable.senderIds.size - 1, 0),
             kind: "npc-group",
             key: renderable.key,
             count: renderable.count,

--- a/apps/game-client/src/features/chat/components/chat-message-list.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.tsx
@@ -432,7 +432,6 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
             ) : renderable.kind === "npc-group" ? (
               <ChatNpcMessage
                 appearance={appearance}
-                additionalSenderCount={renderable.additionalSenderCount}
                 all={selectedGuildId === "all"}
                 count={renderable.count}
                 guildName={guildNamesById[renderable.message.guildId]}

--- a/apps/game-client/src/features/chat/components/chat-npc-count-badge.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-count-badge.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ChatNpcCountBadge } from "./chat-npc-count-badge";
+
+describe("ChatNpcCountBadge", () => {
+  it("renders grouped history without playing the increment animation", () => {
+    render(<ChatNpcCountBadge count={3} />);
+
+    expect(screen.getByText("x3")).not.toHaveClass("ll-chat-npc-count-bump");
+  });
+
+  it("plays the bump when a second grouped message arrives", () => {
+    const { rerender } = render(<ChatNpcCountBadge count={1} />);
+
+    expect(screen.queryByText("x1")).not.toBeInTheDocument();
+
+    rerender(<ChatNpcCountBadge count={2} />);
+
+    expect(screen.getByText("x2")).toHaveClass("ll-chat-npc-count-bump");
+  });
+
+  it("restarts the bump for each consecutive count increase", () => {
+    const { rerender } = render(<ChatNpcCountBadge count={1} />);
+
+    rerender(<ChatNpcCountBadge count={2} />);
+    const secondMessageBadge = screen.getByText("x2");
+
+    rerender(<ChatNpcCountBadge count={3} />);
+    const thirdMessageBadge = screen.getByText("x3");
+
+    expect(thirdMessageBadge).toHaveClass("ll-chat-npc-count-bump");
+    expect(thirdMessageBadge).not.toBe(secondMessageBadge);
+  });
+});

--- a/apps/game-client/src/features/chat/components/chat-npc-count-badge.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-count-badge.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef, type FC } from "react";
+import { cn } from "@/lib/utils";
+
+type ChatNpcCountBadgeProps = {
+  count: number;
+};
+
+export const ChatNpcCountBadge: FC<ChatNpcCountBadgeProps> = ({ count }) => {
+  const previousCountRef = useRef(count);
+  const shouldAnimateIncrement = count > previousCountRef.current;
+
+  useEffect(() => {
+    previousCountRef.current = count;
+  }, [count]);
+
+  if (count <= 1) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        "ll:inline-flex ll:shrink-0 ll:rounded-full ll:bg-red-600 ll:px-[var(--ll-chat-space-md)] ll:py-px ll:text-[length:var(--ll-chat-detail-font-size)] ll:font-bold ll:leading-none ll:text-white",
+        shouldAnimateIncrement && "ll-chat-npc-count-bump",
+      )}
+      key={count}
+    >
+      x{count}
+    </span>
+  );
+};

--- a/apps/game-client/src/features/chat/components/chat-npc-message-view.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-message-view.test.tsx
@@ -50,7 +50,6 @@ describe("ChatNpcMessageView", () => {
   it("renders the production tile metadata through its public interface", () => {
     render(
       <ChatNpcMessageView
-        additionalSenderCount={2}
         all
         appearance={CHAT_APPEARANCE_READABLE_PRESET}
         count={3}
@@ -64,12 +63,14 @@ describe("ChatNpcMessageView", () => {
     expect(screen.getByText("[Northern Guard]")).toBeInTheDocument();
     expect(screen.getByText("Arianna:")).toHaveStyle({ color: "#abcdef" });
     expect(screen.getByText("Dark Hunter tile")).toBeInTheDocument();
-    expect(screen.getByText("Dark Hunter")).toBeInTheDocument();
+    const npcName = screen.getByText("Dark Hunter");
+    const countBadge = screen.getByText("x3");
+
+    expect(npcName).toBeInTheDocument();
+    expect(npcName.parentElement?.parentElement).toContainElement(countBadge);
     expect(screen.getByText("(120m)")).toBeInTheDocument();
     expect(screen.getByText("Old Ruins")).toBeInTheDocument();
     expect(screen.getByText("(42, 18)")).toBeInTheDocument();
-    expect(screen.getByText("x3")).toBeInTheDocument();
-    expect(screen.getByText("+2")).toBeInTheDocument();
   });
 
   it("renders the inline variant without disabled metadata", () => {

--- a/apps/game-client/src/features/chat/components/chat-npc-message-view.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-message-view.tsx
@@ -15,9 +15,9 @@ import {
   getChatNpcTextColor,
   isChatMessageYesterdayOrOlder,
 } from "./chat-message.helpers";
+import { ChatNpcCountBadge } from "./chat-npc-count-badge";
 
 type ChatNpcMessageViewProps = {
-  additionalSenderCount?: number;
   all: boolean;
   appearance?: ChatAppearanceSettings;
   count?: number;
@@ -30,7 +30,6 @@ type ChatNpcMessageViewProps = {
 };
 
 export const ChatNpcMessageView: FC<ChatNpcMessageViewProps> = ({
-  additionalSenderCount = 0,
   all,
   appearance = CHAT_APPEARANCE_READABLE_PRESET,
   count = 1,
@@ -101,11 +100,6 @@ export const ChatNpcMessageView: FC<ChatNpcMessageViewProps> = ({
           </span>
         ) : null}
         {wrapSender ? wrapSender(sender) : sender}{" "}
-        {count > 1 ? (
-          <span className="ll:ml-[var(--ll-chat-space-sm)] ll:inline-flex ll:rounded-full ll:bg-red-600 ll:px-[var(--ll-chat-space-md)] ll:py-px ll:text-[length:var(--ll-chat-detail-font-size)] ll:font-bold ll:leading-none ll:text-white">
-            x{count}
-          </span>
-        ) : null}
       </div>
       <div
         className={cn(
@@ -153,16 +147,7 @@ export const ChatNpcMessageView: FC<ChatNpcMessageViewProps> = ({
                 </span>
               ) : null}
             </div>
-            {additionalSenderCount > 0 ? (
-              <span
-                className={cn(
-                  "ll:shrink-0 ll:rounded-full ll:bg-gray-700/80 ll:px-[var(--ll-chat-space-sm)] ll:py-px ll:text-[length:var(--ll-chat-badge-font-size)] ll:font-semibold ll:leading-none ll:text-gray-200",
-                  { "ll:opacity-50": isMsgYesterday },
-                )}
-              >
-                +{additionalSenderCount}
-              </span>
-            ) : null}
+            <ChatNpcCountBadge count={count} />
           </div>
 
           {appearance.showNpcLocationAndCoordinates &&

--- a/apps/game-client/src/features/chat/components/chat-npc-message.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-message.test.tsx
@@ -87,7 +87,6 @@ describe("ChatNpcMessage", () => {
   it("renders a compact npc card with sender, guild label and group badge", () => {
     render(
       <ChatNpcMessage
-        additionalSenderCount={2}
         all
         guildName="Guild"
         message={makeChatMessage()}
@@ -103,7 +102,6 @@ describe("ChatNpcMessage", () => {
     expect(screen.getByText("Hydra").parentElement).toHaveTextContent(
       "Hydra(250m)",
     );
-    expect(screen.getByText("+2")).toBeInTheDocument();
     expect(screen.getByText("(250m)")).toBeInTheDocument();
     expect(screen.getByText("Swamp")).toBeInTheDocument();
     expect(screen.getByText("(7, 9)")).toHaveClass("ll:whitespace-nowrap");
@@ -121,21 +119,6 @@ describe("ChatNpcMessage", () => {
     );
 
     expect(screen.queryByText("x1")).not.toBeInTheDocument();
-  });
-
-  it("does not show the additional sender badge when only one sender contributed", () => {
-    render(
-      <ChatNpcMessage
-        additionalSenderCount={0}
-        all={false}
-        guildName="Guild"
-        message={makeChatMessage()}
-        member={member}
-        count={3}
-      />,
-    );
-
-    expect(screen.queryByText("+1")).not.toBeInTheDocument();
   });
 
   it("falls back to the character nick when member metadata is missing", () => {

--- a/apps/game-client/src/features/chat/components/chat-npc-message.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-message.tsx
@@ -7,7 +7,6 @@ import { ChatCharacterTooltip } from "./chat-character-tooltip";
 import { ChatNpcMessageView } from "./chat-npc-message-view";
 
 type ChatNpcMessageProps = {
-  additionalSenderCount?: number;
   all: boolean;
   appearance?: ChatAppearanceSettings;
   count?: number;
@@ -18,7 +17,6 @@ type ChatNpcMessageProps = {
 };
 
 export const ChatNpcMessage: FC<ChatNpcMessageProps> = ({
-  additionalSenderCount = 0,
   all,
   appearance,
   count = 1,
@@ -32,7 +30,6 @@ export const ChatNpcMessage: FC<ChatNpcMessageProps> = ({
 
   return (
     <ChatNpcMessageView
-      additionalSenderCount={additionalSenderCount}
       all={all}
       appearance={appearance}
       count={count}

--- a/apps/game-client/src/index.css
+++ b/apps/game-client/src/index.css
@@ -248,6 +248,50 @@ body.si > #lootlog-root .checkbox-custom [type="checkbox"] + label {
   animation-iteration-count: infinite !important;
 }
 
+@keyframes ll-chat-npc-count-bump {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(1.22);
+  }
+  60% {
+    transform: scale(0.95);
+  }
+  78% {
+    transform: scale(1.04);
+  }
+}
+
+@keyframes ll-chat-npc-count-highlight {
+  0%,
+  100% {
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.18;
+  }
+}
+
+#lootlog-root .ll-chat-npc-count-bump {
+  position: relative;
+  overflow: hidden;
+  animation: ll-chat-npc-count-bump 340ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  transform-origin: center;
+}
+
+#lootlog-root .ll-chat-npc-count-bump::after {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: rgb(255 255 255 / 100%);
+  content: "";
+  pointer-events: none;
+  animation: ll-chat-npc-count-highlight 340ms cubic-bezier(0.16, 1, 0.3, 1)
+    both;
+}
+
 @keyframes ll-npc-detection-flash {
   0% {
     opacity: 0;


### PR DESCRIPTION
## Summary

- remove the separate `+N` unique-sender indicator from grouped NPC chat messages
- move the existing red `xN` counter into the NPC details row
- add a short spring bump whenever the live group count increases
- keep historical counters static and respect the existing reduced-motion mode

## Why

Grouped NPC messages exposed two similar counters, which made the row harder to understand. The total `xN` count is now the single indicator and reacts as sequential reports arrive.

## Animation fix

The first implementation placed the badge inside nested `overflow-hidden` containers, clipping most of the scale change. Its separate white highlight layer therefore became the dominant visible effect. The animation now has unclipped space, scales from the right edge, and no longer uses the white overlay.

## User impact

- `x1` remains hidden
- `x2`, `x3`, and later live increments are visually acknowledged
- opening chat history or switching guilds does not replay the animation
- NPC grouping rules and the 60-second grouping window are unchanged

## Validation

- `pnpm --filter @lootlog/game-client test` — 226 files, 1171 tests passed
- `pnpm --filter @lootlog/game-client check-types`
- `pnpm --filter @lootlog/game-client lint`
- browser-level animation repro — full `1.22x` visible scale, no overlay
- changed-file formatting and `git diff --check`