### PR TITLE
Fix NPC chat count bump visibility

### DIFF
--- a/apps/game-client/src/features/chat/components/chat-npc-message-view.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-message-view.test.tsx
@@ -68,6 +68,10 @@ describe("ChatNpcMessageView", () => {
 
     expect(npcName).toBeInTheDocument();
     expect(npcName.parentElement?.parentElement).toContainElement(countBadge);
+    expect(countBadge.parentElement).not.toHaveClass("ll:overflow-hidden");
+    expect(countBadge.parentElement?.parentElement).not.toHaveClass(
+      "ll:overflow-hidden",
+    );
     expect(screen.getByText("(120m)")).toBeInTheDocument();
     expect(screen.getByText("Old Ruins")).toBeInTheDocument();
     expect(screen.getByText("(42, 18)")).toBeInTheDocument();

--- a/apps/game-client/src/features/chat/components/chat-npc-message-view.tsx
+++ b/apps/game-client/src/features/chat/components/chat-npc-message-view.tsx
@@ -119,12 +119,12 @@ export const ChatNpcMessageView: FC<ChatNpcMessageViewProps> = ({
 
         <div
           className={cn(
-            "ll:flex ll:min-w-0 ll:max-w-full ll:flex-1 ll:flex-col ll:overflow-hidden ll:leading-tight",
+            "ll:flex ll:min-w-0 ll:max-w-full ll:flex-1 ll:flex-col ll:leading-tight",
             appearance.npcLayout === "inline" &&
-              "ll:flex-row ll:flex-wrap ll:items-baseline ll:gap-x-[var(--ll-chat-space-sm)] ll:overflow-visible",
+              "ll:flex-row ll:flex-wrap ll:items-baseline ll:gap-x-[var(--ll-chat-space-sm)]",
           )}
         >
-          <div className="ll:flex ll:w-full ll:min-w-0 ll:max-w-full ll:items-baseline ll:gap-[var(--ll-chat-space-sm)] ll:overflow-hidden">
+          <div className="ll:flex ll:w-full ll:min-w-0 ll:max-w-full ll:items-baseline ll:gap-[var(--ll-chat-space-sm)]">
             <div className="ll:flex ll:min-w-0 ll:flex-1 ll:items-baseline ll:gap-[var(--ll-chat-space-sm)] ll:overflow-hidden">
               <span
                 className={cn(

--- a/apps/game-client/src/index.css
+++ b/apps/game-client/src/index.css
@@ -264,32 +264,9 @@ body.si > #lootlog-root .checkbox-custom [type="checkbox"] + label {
   }
 }
 
-@keyframes ll-chat-npc-count-highlight {
-  0%,
-  100% {
-    opacity: 0;
-  }
-  35% {
-    opacity: 0.18;
-  }
-}
-
 #lootlog-root .ll-chat-npc-count-bump {
-  position: relative;
-  overflow: hidden;
   animation: ll-chat-npc-count-bump 340ms cubic-bezier(0.16, 1, 0.3, 1) both;
-  transform-origin: center;
-}
-
-#lootlog-root .ll-chat-npc-count-bump::after {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: rgb(255 255 255 / 100%);
-  content: "";
-  pointer-events: none;
-  animation: ll-chat-npc-count-highlight 340ms cubic-bezier(0.16, 1, 0.3, 1)
-    both;
+  transform-origin: right center;
 }
 
 @keyframes ll-npc-detection-flash {


### PR DESCRIPTION
## Summary

- allow the NPC count pill to scale outside its text rows instead of clipping the bump
- anchor the scale animation at the pill's right edge
- remove the white highlight pseudo-element that could visually cover the pill
- add a regression assertion for unclipped badge ancestors

## Root cause

The pill was nested inside two `overflow-hidden` containers. Chromium applied the intended `scale(1.22)`, but only about `1.11x` remained visible after clipping, so the separate white highlight became the dominant visible effect.

## Validation

- browser-level repro: visible peak changed from `1.11x` to the full `1.22x`; no overlay pseudo-element remains
- `pnpm --filter @lootlog/game-client test` — 226 files, 1171 tests passed
- `pnpm --filter @lootlog/game-client check-types`
- `pnpm --filter @lootlog/game-client lint`
- changed-file formatting and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC chat message layout so count badges remain visible across different display styles.
  * Prevented overflow handling from unintentionally clipping NPC metadata and quantity indicators.

* **Style**
  * Simplified the count badge animation for a cleaner visual effect.
  * Adjusted the animation’s scaling direction to better align with the badge position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->