### PR TITLE
fix: prevent duplicate events and lost loot submissions

### DIFF
--- a/.changeset/quiet-events-arrive.md
+++ b/.changeset/quiet-events-arrive.md
@@ -1,0 +1,6 @@
+---
+"@lootlog/api": patch
+"@lootlog/game-client": patch
+---
+
+Prevent duplicate game-event side effects when multiple client consumers mount, omit undefined fields from exported diagnostic logs, and keep concurrent loot submissions retryable while their distributed lock is held.

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -1,7 +1,11 @@
 import type { Mock } from "vitest";
 import { mockFn } from "src/test/mock-fn";
 import { Test, type TestingModule } from "@nestjs/testing";
-import { BadRequestException, ForbiddenException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ForbiddenException,
+  ServiceUnavailableException,
+} from "@nestjs/common";
 import { AmqpConnection } from "@golevelup/nestjs-rabbitmq";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import { LootsService } from "./loots.service";
@@ -19,6 +23,7 @@ import { LootCommentService } from "./services/loot-comment.service";
 import { LootStatsService } from "./services/loot-stats.service";
 import { RedisService } from "@lootlog/nest-shared/redis";
 import { RedlockService } from "src/lib/redlock/redlock.service";
+import { ExecutionError } from "redlock";
 import type { CreateLootDto } from "./dto/create-loot.dto";
 import type { UpdateLootDto } from "./dto/update-loot.dto";
 import type { CreateCommentDto } from "./dto/create-comment-dto";
@@ -380,7 +385,26 @@ describe("LootsService", () => {
           world: "testworld",
         },
       ]);
+      expect(service["redlock"].acquire).toHaveBeenCalledWith(
+        [expect.stringMatching(/^loot:lock:/)],
+        30_000,
+        {
+          retryCount: 100,
+          retryDelay: 100,
+          retryJitter: 50,
+        },
+      );
       expect(result).toEqual(expectedSuccessResponse);
+    });
+
+    it("should return a retryable error when loot lock contention outlasts the wait", async () => {
+      vi.spyOn(service["redlock"], "acquire").mockRejectedValue(
+        new ExecutionError("Lock contention", []),
+      );
+
+      await expect(
+        service.createLoot(discordId, userId, mockCreateLootDto),
+      ).rejects.toThrow(ServiceUnavailableException);
     });
 
     it("should return existing loot when it already exists", async () => {

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -4,6 +4,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  ServiceUnavailableException,
   type OnModuleInit,
 } from "@nestjs/common";
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
@@ -82,11 +83,17 @@ type CachedLootQueryResult = Omit<
 };
 
 const LOOTS_LIST_CACHE_TTL_SECONDS = 10;
+const LOOT_LOCK_TTL_MS = 30_000;
+const LOOT_LOCK_RETRY_OPTIONS = {
+  retryCount: 100,
+  retryDelay: 100,
+  retryJitter: 50,
+} as const;
 
 @Injectable()
 export class LootsService implements OnModuleInit {
   private redlock: ReturnType<RedlockService["createInstance"]>;
-  private readonly lockTtl = 10000;
+  private readonly lockTtl = LOOT_LOCK_TTL_MS;
 
   constructor(
     private readonly amqpConnection: AmqpConnection,
@@ -108,9 +115,7 @@ export class LootsService implements OnModuleInit {
   ) {}
 
   onModuleInit() {
-    this.redlock = this.redlockService.createInstance({
-      automaticExtensionThreshold: 5000,
-    });
+    this.redlock = this.redlockService.createInstance();
   }
 
   private createRejectedGuild(
@@ -355,7 +360,11 @@ export class LootsService implements OnModuleInit {
     let lock: Awaited<ReturnType<typeof this.redlock.acquire>> | null = null;
 
     try {
-      lock = await this.redlock.acquire([lockKey], this.lockTtl);
+      lock = await this.redlock.acquire(
+        [lockKey],
+        this.lockTtl,
+        LOOT_LOCK_RETRY_OPTIONS,
+      );
 
       const existingLoot = await this.prisma.loot.findUnique({
         where: { uniqueId },
@@ -642,7 +651,7 @@ export class LootsService implements OnModuleInit {
           message: "Lock acquisition failed for createLoot",
           uniqueId,
         });
-        throw new BadRequestException("Failed to acquire lock");
+        throw new ServiceUnavailableException("Failed to acquire loot lock");
       }
 
       throw error;

--- a/apps/game-client/src/hooks/game-events/use-game-event-handlers.test.tsx
+++ b/apps/game-client/src/hooks/game-events/use-game-event-handlers.test.tsx
@@ -84,4 +84,20 @@ describe("useGameEventHandlers", () => {
 
     expect(mockCleanup).toHaveBeenCalledTimes(1);
   });
+
+  it("shares one dispatcher when the client is mounted more than once", () => {
+    gameInitialized = true;
+    const firstClient = renderHook(() => useGameEventHandlers());
+    const secondClient = renderHook(() => useGameEventHandlers());
+
+    expect(mockEventDispatcherConstructor).toHaveBeenCalledTimes(1);
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+    expect(mockHandleInitialEvents).toHaveBeenCalledTimes(1);
+
+    firstClient.unmount();
+    expect(mockCleanup).not.toHaveBeenCalled();
+
+    secondClient.unmount();
+    expect(mockCleanup).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/game-client/src/hooks/game-events/use-game-event-handlers.ts
+++ b/apps/game-client/src/hooks/game-events/use-game-event-handlers.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { useGlobalStore } from "@/store/global.store";
 import { EventDispatcher } from "@/lib/event-dispatcher";
 import { useCharacterTooltipCatchingGuilds } from "./use-character-tooltip-catching-guilds";
@@ -6,6 +6,40 @@ import { useCharacterTooltipGameEvents } from "./use-character-tooltip-game-even
 import { useOnlineCharacterOwners } from "./use-online-character-owners";
 import { useOtherCatchingGuildGlow } from "./use-other-catching-guild-glow";
 import { useWhoIsHereLootlogHighlight } from "./use-who-is-here-lootlog-highlight";
+
+let activeDispatcher: EventDispatcher | null = null;
+let activeDispatcherConsumers = 0;
+let initialEventsHandled = false;
+
+const acquireEventDispatcher = () => {
+  if (!activeDispatcher) {
+    activeDispatcher = new EventDispatcher();
+    activeDispatcher.register();
+  }
+
+  activeDispatcherConsumers += 1;
+  let released = false;
+
+  return () => {
+    if (released) return;
+
+    released = true;
+    activeDispatcherConsumers -= 1;
+    if (activeDispatcherConsumers > 0) return;
+
+    activeDispatcher?.cleanup();
+    activeDispatcher = null;
+    activeDispatcherConsumers = 0;
+    initialEventsHandled = false;
+  };
+};
+
+const handleInitialEventsOnce = () => {
+  if (!activeDispatcher || initialEventsHandled) return;
+
+  initialEventsHandled = true;
+  activeDispatcher.handleInitialEvents();
+};
 
 export const useGameEventHandlers = () => {
   useCharacterTooltipCatchingGuilds();
@@ -15,27 +49,12 @@ export const useGameEventHandlers = () => {
   useWhoIsHereLootlogHighlight();
 
   const gameInitialized = useGlobalStore((s) => s.gameState.gameInitialized);
-  const [initialized, setInitialized] = useState(false);
-  const dispatcherRef = useRef<EventDispatcher | null>(null);
+
+  useEffect(() => acquireEventDispatcher(), []);
 
   useEffect(() => {
-    if (initialized) return;
+    if (!gameInitialized) return;
 
-    const dispatcher = new EventDispatcher();
-    dispatcherRef.current = dispatcher;
-    dispatcher.register();
-    setInitialized(true);
-  }, [initialized]);
-
-  useEffect(() => {
-    if (!gameInitialized || !initialized) return;
-
-    dispatcherRef.current?.handleInitialEvents();
-  }, [gameInitialized, initialized]);
-
-  useEffect(() => {
-    return () => {
-      dispatcherRef.current?.cleanup();
-    };
-  }, []);
+    handleInitialEventsOnce();
+  }, [gameInitialized]);
 };

--- a/apps/game-client/src/lib/logs/log-actions.test.ts
+++ b/apps/game-client/src/lib/logs/log-actions.test.ts
@@ -192,6 +192,18 @@ describe("log actions retry", () => {
 });
 
 describe("log value retention", () => {
+  it("omits undefined object fields instead of exporting them as strings", () => {
+    expect(
+      serializeLogValue({
+        partyGathering: undefined,
+        respBaseSeconds: 561,
+        respawnRandomness: undefined,
+      }),
+    ).toEqual({
+      respBaseSeconds: 561,
+    });
+  });
+
   it("serializes cyclic and oversized values into a bounded diagnostic", () => {
     const payload: Record<string, unknown> = {
       events: Array.from({ length: 1_100 }, (_, index) => ({

--- a/apps/game-client/src/lib/logs/log-actions.ts
+++ b/apps/game-client/src/lib/logs/log-actions.ts
@@ -218,11 +218,12 @@ const serializeLogValueWithinBudget = (
     context.ancestors.add(value);
     consumeSerializationBudget(context, 2);
     const serializedRecord: Record<string, SerializableValue> = {};
+    const serializableEntries = Object.entries(value).filter(
+      ([, nestedValue]) => nestedValue !== undefined,
+    );
 
     try {
-      for (const [index, [key, nestedValue]] of Object.entries(
-        value,
-      ).entries()) {
+      for (const [index, [key, nestedValue]] of serializableEntries.entries()) {
         if (index > 0) {
           consumeSerializationBudget(context, 1);
         }


### PR DESCRIPTION
## Summary

- share one game event dispatcher across multiple game-client mounts to prevent duplicate event processing
- omit undefined fields from exported diagnostic logs
- let contended loot locks wait longer, use a safer TTL, and return a retryable HTTP 503 when the lock remains unavailable

## Root cause

Party members can submit the same loot identifier at nearly the same time. The API lock retried for less than half a second and mapped lock exhaustion to HTTP 400, so the client treated a transient contention failure as permanent. Separately, multiple mounted event-handler hooks could create duplicate dispatchers and duplicate submissions.

## Validation

- API: 100 test files, 980 tests passed
- API build: 549 files compiled, TypeScript found 0 issues
- Game client: 231 test files, 1207 tests passed
- Game client TypeScript check passed
- Pre-commit formatting and lint checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate game-event side effects when multiple consumers are active.
  * Diagnostic logs now omit undefined fields for cleaner, smaller output.
  * Loot submissions remain retryable during temporary lock contention.
  * Lock contention now reports a temporary service-unavailable error instead of a bad-request error.
* **Tests**
  * Added coverage for shared event handling, log serialization, and loot lock-retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->