### PR TITLE
fix(game-client): polish server visibility states

### DIFF
--- a/.changeset/calm-server-selector.md
+++ b/.changeset/calm-server-selector.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/game-client": patch
+---
+
+Polish server selector states when one or all accessible servers are hidden.

--- a/apps/game-client/src/components/guild-switcher.test.tsx
+++ b/apps/game-client/src/components/guild-switcher.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GuildIdentity } from "@/lib/api/generated-helpers";
 import { useSettingsStore } from "@/store/settings.store";
 import { useGameStore } from "@/store/game.store";
+import { useWindowsStore } from "@/store/windows.store";
 import { GuildSwitcher } from "./guild-switcher";
 
 const mockUseAccessibleGuilds = vi.fn();
@@ -81,6 +82,13 @@ describe("GuildSwitcher", () => {
       world: "tempest",
     });
     useSettingsStore.setState({ guildIdByCharId: {} });
+    useWindowsStore.setState((state) => ({
+      settings: {
+        ...state.settings,
+        open: false,
+        state: {},
+      },
+    }));
 
     mockUseAccessibleGuilds.mockReturnValue({
       data: [
@@ -287,7 +295,24 @@ describe("GuildSwitcher", () => {
     await waitFor(() => expect(handleChange).toHaveBeenCalledWith("guild-1"));
   });
 
-  it("shows a settings action instead of the all option when every guild is hidden", () => {
+  it("does not render a server picker when only one guild is visible", () => {
+    mockUseUserPreferences.mockReturnValue({
+      data: {
+        guildsOrder: [],
+        hiddenGuildIds: ["guild-2", "guild-3"],
+      },
+      isFetched: true,
+    });
+
+    render(<GuildSwitcher allowAll value="all" />);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Wszystkie serwery są ukryte"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a full-width settings notice when every guild is hidden", () => {
     mockUseUserPreferences.mockReturnValue({
       data: {
         guildsOrder: [],
@@ -296,12 +321,28 @@ describe("GuildSwitcher", () => {
       isFetched: true,
     });
 
-    render(<GuildSwitcher allowAll value="all" />);
+    const { container } = render(<GuildSwitcher allowAll value="all" />);
 
     expect(screen.queryByText("*")).not.toBeInTheDocument();
     expect(screen.getByText("Wszystkie serwery są ukryte")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveClass(
+      "ll:h-7",
+      "ll:w-full",
+      "ll:border-gray-700/90",
+      "ll:bg-gray-900/60",
+    );
     expect(
-      screen.getByRole("button", { name: "Otwórz ustawienia" }),
-    ).toBeInTheDocument();
+      container.querySelector("[data-ll-scroll-area-viewport]"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Otwórz ustawienia" }));
+
+    expect(useWindowsStore.getState().settings).toMatchObject({
+      open: true,
+      state: {
+        activeTab: "servers",
+        activeSubsection: "visibility",
+      },
+    });
   });
 });

--- a/apps/game-client/src/components/guild-switcher.tsx
+++ b/apps/game-client/src/components/guild-switcher.tsx
@@ -1,22 +1,20 @@
 import { cn } from "@/lib/utils";
-import {
-  useUserPreferences,
-  useUpdateUserPreferences,
-} from "@/hooks/api/use-user-preferences";
+import { useUpdateUserPreferences } from "@/hooks/api/use-user-preferences";
 import { useSettingsStore } from "@/store/settings.store";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { AvatarFallback } from "@/components/ui/avatar";
 import { type FC, useEffect, useRef } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { formatChatUnreadBadge } from "@/features/chat/chat-unread.helpers";
 import { GuildButton } from "@/components/guild-button";
-import {
-  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey,
-  useUsersControllerGetCurrentUserAccessibleGuilds,
-} from "@lootlog/api-client/react-query/main/users";
 import { useTranslation } from "react-i18next";
-import { getVisibleLootlogGuilds } from "@/lib/selected-lootlog-guild";
 import { useCurrentCharacterId } from "@/hooks/use-selected-lootlog-guild";
+import { useVisibleLootlogGuilds } from "@/hooks/use-visible-lootlog-guilds";
 import { useShallow } from "zustand/react/shallow";
 import { AsyncStatusIndicator } from "@/components/async-status-indicator";
 import { useWindowsStore } from "@/store/windows.store";
@@ -56,26 +54,16 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
 }) => {
   const { t } = useTranslation("common");
   const characterId = useCurrentCharacterId();
-  const {
-    data: guilds,
-    error,
-    isFetched,
-    isLoading,
-    refetch,
-  } = useUsersControllerGetCurrentUserAccessibleGuilds({
-    query: {
-      queryKey: getUsersControllerGetCurrentUserAccessibleGuildsQueryKey(),
-      refetchOnMount: false,
-      staleTime: 1000 * 60 * 5,
-    },
-  });
+  const { guildsQuery, preferencesQuery, visibleGuilds } =
+    useVisibleLootlogGuilds();
+  const { data: guilds, error, isFetched, isLoading, refetch } = guildsQuery;
   const {
     data: userPreferences,
     error: preferencesError,
     isFetched: arePreferencesFetched,
     isLoading: arePreferencesLoading,
     refetch: refetchPreferences,
-  } = useUserPreferences();
+  } = preferencesQuery;
   const updatePreferences = useUpdateUserPreferences();
   const setOpen = useWindowsStore((state) => state.setOpen);
   const { setGuildId, guildId } = useSettingsStore(
@@ -84,15 +72,9 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
       guildId: characterId ? state.guildIdByCharId[characterId] : undefined,
     })),
   );
-  const guildsOrder = userPreferences?.guildsOrder;
   const hiddenGuildIds = userPreferences?.hiddenGuildIds;
   const latestHiddenGuildIds = useRef(hiddenGuildIds ?? []);
   latestHiddenGuildIds.current = hiddenGuildIds ?? [];
-  const visibleGuilds = getVisibleLootlogGuilds(
-    guilds ?? [],
-    guildsOrder,
-    hiddenGuildIds,
-  );
   useEffect(() => {
     if (!isFetched || !arePreferencesFetched || visibleGuilds.length === 0)
       return;
@@ -166,6 +148,61 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
     );
   };
 
+  if (
+    guilds &&
+    isFetched &&
+    arePreferencesFetched &&
+    visibleGuilds.length === 1
+  ) {
+    return null;
+  }
+
+  if (
+    guilds &&
+    isFetched &&
+    arePreferencesFetched &&
+    visibleGuilds.length === 0
+  ) {
+    return (
+      <TooltipProvider>
+        <div
+          className={cn(
+            "ll:mt-1 ll:flex ll:h-7 ll:w-full ll:items-center ll:justify-between ll:box-border ll:rounded-sm ll:border ll:border-gray-700/90 ll:bg-gray-900/60 ll:pl-2 ll:pr-0.5",
+            className,
+          )}
+          role="status"
+        >
+          <span className="ll:min-w-0 ll:flex-1 ll:truncate ll:text-[11px] ll:text-gray-300">
+            {t("guildSwitcher.allHidden")}
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                aria-label={t("actions.openSettings")}
+                onClick={() =>
+                  setOpen("settings", true, {
+                    activeTab: "servers",
+                    activeSubsection: "visibility",
+                  })
+                }
+                className="ll:size-6 ll:shrink-0 ll:border-gray-700/90 ll:bg-transparent ll:text-gray-400 hover:ll:bg-gray-800/70 hover:ll:text-gray-200"
+              >
+                <Settings className="ll:size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="ll:z-500">
+              <p className="ll:text-xs ll:font-semibold">
+                {t("actions.openSettings")}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+    );
+  }
+
   let content = (
     <>
       {allowAll && !multiple && visibleGuilds.length > 0 && (
@@ -223,33 +260,6 @@ export const GuildSwitcher: FC<GuildSwitcherProps> = ({
         }}
         retryLabel={t("actions.retry")}
       />
-    );
-  } else if (
-    guilds &&
-    isFetched &&
-    arePreferencesFetched &&
-    visibleGuilds.length === 0
-  ) {
-    content = (
-      <div className="ll:flex ll:items-center ll:gap-2 ll:rounded-md ll:border ll:border-gray-600 ll:bg-gray-900/70 ll:px-2 ll:py-1.5">
-        <span className="ll:text-[11px] ll:text-gray-300">
-          {t("guildSwitcher.allHidden")}
-        </span>
-        <Button
-          type="button"
-          variant="ghost"
-          aria-label={t("actions.openSettings")}
-          onClick={() =>
-            setOpen("settings", true, {
-              activeTab: "servers",
-              activeSubsection: "visibility",
-            })
-          }
-          className="ll:size-7"
-        >
-          <Settings className="ll:size-3.5" />
-        </Button>
-      </div>
     );
   }
 

--- a/apps/game-client/src/components/world-selector.test.tsx
+++ b/apps/game-client/src/components/world-selector.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GuildIdentity } from "@/lib/api/generated-helpers";
+import { useGameStore } from "@/store/game.store";
+import { useSettingsStore } from "@/store/settings.store";
+import { WorldSelector } from "./world-selector";
+
+const mockUseAccessibleGuilds = vi.fn();
+const mockUseUserPreferences = vi.fn();
+
+vi.mock("@lootlog/api-client/react-query/main/users", () => ({
+  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey: () => [
+    "accessible-guilds",
+  ],
+  useUsersControllerGetCurrentUserAccessibleGuilds: () =>
+    mockUseAccessibleGuilds(),
+}));
+
+vi.mock("@lootlog/api-client/react-query/main/guilds", () => ({
+  getGuildsControllerGetWorldsByGuildIdQueryKey: () => ["guild-worlds"],
+  useGuildsControllerGetWorldsByGuildId: () => ({
+    data: ["tempest"],
+    isFetched: true,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/hooks/api/use-user-preferences", () => ({
+  useUserPreferences: () => mockUseUserPreferences(),
+}));
+
+vi.mock("@/hooks/use-local-storage", () => ({
+  useLocalStorage: () => [[], vi.fn(), vi.fn()],
+}));
+
+vi.mock("@/components/ui/combobox", () => ({
+  Combobox: () => <div role="combobox">Wybierz świat</div>,
+}));
+
+const guild: GuildIdentity = {
+  id: "guild-1",
+  name: "Alpha",
+  icon: null,
+};
+
+describe("WorldSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGameStore.getState().replaceGame({
+      hero: {
+        accountId: "1",
+        characterId: "123",
+        currentHp: 1,
+        icon: "hero.gif",
+        level: 300,
+        maxHp: 1,
+        name: "Hero",
+        profession: "w",
+        x: 1,
+        y: 2,
+      },
+      interface: "ni",
+      map: { id: 1, name: "Map", visibility: 30 },
+      world: "tempest",
+    });
+    useSettingsStore.setState({
+      guildIdByCharId: { "123": "guild-1" },
+      worldByGuildId: { "guild-1": "tempest" },
+    });
+    mockUseAccessibleGuilds.mockReturnValue({
+      data: [guild],
+      isFetched: true,
+    });
+    mockUseUserPreferences.mockReturnValue({
+      data: {
+        guildsOrder: [],
+        hiddenGuildIds: [],
+      },
+      isFetched: true,
+    });
+  });
+
+  it("renders when the selected guild is visible", () => {
+    render(<WorldSelector />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("does not render when every accessible guild is hidden", () => {
+    mockUseUserPreferences.mockReturnValue({
+      data: {
+        guildsOrder: [],
+        hiddenGuildIds: ["guild-1"],
+      },
+      isFetched: true,
+    });
+
+    render(<WorldSelector />);
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+});

--- a/apps/game-client/src/components/world-selector.tsx
+++ b/apps/game-client/src/components/world-selector.tsx
@@ -12,6 +12,7 @@ import { storageKey } from "@/lib/storage-key";
 import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
 import { useDelayedVisibility } from "@/hooks/ui/use-delayed-visibility";
+import { useVisibleLootlogGuilds } from "@/hooks/use-visible-lootlog-guilds";
 
 const recentWorldsKey = (accountId: string, characterId: string) =>
   storageKey(`ll:recent-worlds:${accountId}:${characterId}`);
@@ -28,6 +29,8 @@ export const WorldSelector: FC<WorldSelectorProps> = ({
   className = "",
 }) => {
   const { t } = useTranslation("common");
+  const { guildsQuery, preferencesQuery, visibleGuilds } =
+    useVisibleLootlogGuilds();
   const characterId = useGameStore(
     (state) => state.game?.hero.characterId ?? "",
   );
@@ -133,6 +136,14 @@ export const WorldSelector: FC<WorldSelectorProps> = ({
 
     setWorld(guildId, newWorld);
   };
+
+  if (
+    !guildsQuery.isFetched ||
+    !preferencesQuery.isFetched ||
+    visibleGuilds.length === 0
+  ) {
+    return null;
+  }
 
   return (
     <Combobox

--- a/apps/game-client/src/features/chat/chat-view.tsx
+++ b/apps/game-client/src/features/chat/chat-view.tsx
@@ -8,10 +8,6 @@ import { ChatMessageList } from "@/features/chat/components/chat-message-list";
 import { ChatWindowActions } from "@/features/chat/components/chat-window-actions";
 import { useChatGuildData } from "@/features/chat/hooks/use-chat-guild-data";
 import { getGuildNamesById } from "@/lib/api/generated-helpers";
-import {
-  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey,
-  useUsersControllerGetCurrentUserAccessibleGuilds,
-} from "@lootlog/api-client/react-query/main/users";
 import type { ChatMessageResponseDtoOutput as ChatMessageType } from "@lootlog/api-client/models/main/chat-message-response-dto-output";
 import { cn } from "@/lib/utils";
 import { type ChatFilter, useChatStore } from "@/store/chat.store";
@@ -26,13 +22,12 @@ import {
 } from "./chat.helpers";
 import { canReplyToChatMessage } from "./chat-reply.helpers";
 import type { ChatUnreadCountByGuildId } from "./chat-unread.helpers";
-import { useUserPreferences } from "@/hooks/api/use-user-preferences";
 import { useNpcTypeColors } from "@/hooks/api/use-settings-documents";
 import { CHAT_APPEARANCE_READABLE_PRESET } from "@lootlog/types";
 import { AsyncContent } from "@/components/async-content";
 import { AsyncStatusIndicator } from "@/components/async-status-indicator";
 import { useSocket } from "@/contexts/socket-context";
-import { getVisibleLootlogGuilds } from "@/lib/selected-lootlog-guild";
+import { useVisibleLootlogGuilds } from "@/hooks/use-visible-lootlog-guilds";
 
 interface ChatViewProps {
   isOpen: boolean;
@@ -49,7 +44,12 @@ export const ChatView = ({
 }: ChatViewProps) => {
   const { t } = useTranslation("chat");
   const { connected, joined } = useSocket();
-  const preferences = useUserPreferences();
+  const {
+    areVisibleGuildsResolved,
+    guildsQuery,
+    preferencesQuery: preferences,
+    visibleGuilds: resolvedVisibleGuilds,
+  } = useVisibleLootlogGuilds();
   const { npcTypeColors } = useNpcTypeColors();
   const chatAppearance =
     preferences.data?.chatAppearance ?? CHAT_APPEARANCE_READABLE_PRESET;
@@ -77,26 +77,14 @@ export const ChatView = ({
   );
   const setOpen = useWindowsStore((state) => state.setOpen);
   const {
-    data: guilds,
     error: guildsError,
     isFetching: guildsFetching,
     isLoading: guildsLoading,
     refetch: refetchGuilds,
-  } = useUsersControllerGetCurrentUserAccessibleGuilds({
-    query: {
-      queryKey: getUsersControllerGetCurrentUserAccessibleGuildsQueryKey(),
-      refetchOnMount: false,
-      staleTime: 1000 * 60 * 5,
-    },
-  });
-  const visibleGuilds =
-    guilds && preferences.data
-      ? getVisibleLootlogGuilds(
-          guilds,
-          preferences.data.guildsOrder,
-          preferences.data.hiddenGuildIds,
-        )
-      : undefined;
+  } = guildsQuery;
+  const visibleGuilds = areVisibleGuildsResolved
+    ? resolvedVisibleGuilds
+    : undefined;
   const effectiveSelectedGuildId =
     visibleGuilds?.length === 0 ? "" : selectedGuildId;
   const currentCharacterNick = useGameStore(

--- a/apps/game-client/src/features/timers/components/add-timer-form.test.tsx
+++ b/apps/game-client/src/features/timers/components/add-timer-form.test.tsx
@@ -15,6 +15,7 @@ let mockGuilds = [
   { id: "guild-1", name: "Alpha", icon: null, ownerId: "owner-1" },
   { id: "guild-2", name: "Beta", icon: null, ownerId: "owner-1" },
 ];
+let mockHiddenGuildIds: string[] = [];
 
 let mockNpcResults: SearchTimersNpcResponseDtoOutput[] = [];
 let mockSelectedGuildIdsForTimersByCharId: Record<string, string[]> = {
@@ -35,8 +36,9 @@ vi.mock("@/hooks/api/use-user-preferences", () => ({
   useUserPreferences: () => ({
     data: {
       guildsOrder: [],
-      hiddenGuildIds: [],
+      hiddenGuildIds: mockHiddenGuildIds,
     },
+    isFetched: true,
   }),
 }));
 
@@ -64,6 +66,7 @@ vi.mock("@lootlog/api-client/react-query/main/users", () => ({
   ],
   useUsersControllerGetCurrentUserAccessibleGuilds: () => ({
     data: mockGuilds,
+    isFetched: true,
   }),
 }));
 
@@ -162,19 +165,21 @@ vi.mock("@/components/guild-switcher", () => ({
     onChange?: (guildId: string) => void;
     disabled?: boolean;
   }) => (
-    <select
-      aria-label="Serwer"
-      value={value}
-      disabled={disabled}
-      onChange={(event) => onChange?.(event.currentTarget.value)}
-    >
-      <option value="">--</option>
-      {mockGuilds.map((guild) => (
-        <option key={guild.id} value={guild.id}>
-          {guild.name}
-        </option>
-      ))}
-    </select>
+    <div data-testid="guild-switcher">
+      <select
+        aria-label="Serwer"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange?.(event.currentTarget.value)}
+      >
+        <option value="">--</option>
+        {mockGuilds.map((guild) => (
+          <option key={guild.id} value={guild.id}>
+            {guild.name}
+          </option>
+        ))}
+      </select>
+    </div>
   ),
 }));
 
@@ -235,6 +240,7 @@ describe("AddTimerForm", () => {
       { id: "guild-2", name: "Beta", icon: null, ownerId: "owner-1" },
     ];
     mockNpcResults = [];
+    mockHiddenGuildIds = [];
     mockSelectedGuildIdsForTimersByCharId = {
       "101": ["guild-2"],
     };
@@ -309,6 +315,39 @@ describe("AddTimerForm", () => {
 
     expect(screen.getByLabelText("Serwer")).toHaveValue("guild-1");
     expect(mockSetSelectedGuildIdsForTimers).not.toHaveBeenCalled();
+  });
+
+  it("uses the only visible guild without rendering a server picker", async () => {
+    const user = userEvent.setup();
+    mockHiddenGuildIds = ["guild-2"];
+
+    render(<AddTimerForm />);
+
+    expect(screen.queryByTestId("guild-switcher")).not.toBeInTheDocument();
+    expect(screen.queryByText("Serwer")).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Nazwa"), "Tanroth");
+    await user.type(screen.getByLabelText("Minimalny czas (max 300h)"), "1m");
+    await user.type(screen.getByLabelText("Maksymalny czas (max 300h)"), "2m");
+    await user.click(screen.getByRole("button", { name: "Dodaj" }));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildIds: ["guild-1"],
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("keeps the settings notice without a required error when no guild is visible", () => {
+    mockHiddenGuildIds = ["guild-1", "guild-2"];
+
+    render(<AddTimerForm />);
+
+    expect(screen.getByTestId("guild-switcher")).toBeInTheDocument();
+    expect(screen.queryByText("Serwer")).not.toBeInTheDocument();
+    expect(screen.queryByText("Wybierz serwer")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dodaj" })).toBeDisabled();
   });
 
   it("submits a manual level when provided", async () => {

--- a/apps/game-client/src/features/timers/components/add-timer-form.tsx
+++ b/apps/game-client/src/features/timers/components/add-timer-form.tsx
@@ -29,15 +29,10 @@ import {
   getTimersControllerSearchNpcsWithTimerDataQueryKey,
   useTimersControllerSearchNpcsWithTimerData,
 } from "@lootlog/api-client/react-query/main/timers";
-import {
-  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey,
-  useUsersControllerGetCurrentUserAccessibleGuilds,
-} from "@lootlog/api-client/react-query/main/users";
 import { AutocompleteSuggestions } from "@/components/ui/autocomplete-suggestions";
 import { NPC_NAMES } from "@/constants/margonem";
 import { useTranslation } from "react-i18next";
-import { useUserPreferences } from "@/hooks/api/use-user-preferences";
-import { getVisibleLootlogGuilds } from "@/lib/selected-lootlog-guild";
+import { useVisibleLootlogGuilds } from "@/hooks/use-visible-lootlog-guilds";
 
 const SECONDS_IN_HOUR = 3600;
 const SECONDS_IN_MINUTE = 60;
@@ -227,22 +222,7 @@ export const AddTimerForm: React.FC<AddTimerFormProps> = ({
   const { selectedGuildIdsForTimersByCharId, guildIdByCharId } =
     useSettingsStore();
   const setOpen = useWindowsStore((state) => state.setOpen);
-  const { data: guilds } = useUsersControllerGetCurrentUserAccessibleGuilds({
-    query: {
-      queryKey: getUsersControllerGetCurrentUserAccessibleGuildsQueryKey(),
-      refetchOnMount: false,
-      staleTime: 1000 * 60 * 5,
-    },
-  });
-  const { data: userPreferences } = useUserPreferences();
-  const visibleGuilds =
-    guilds && userPreferences
-      ? getVisibleLootlogGuilds(
-          guilds,
-          userPreferences.guildsOrder,
-          userPreferences.hiddenGuildIds,
-        )
-      : [];
+  const { visibleGuilds } = useVisibleLootlogGuilds();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [showSuggestions, setShowSuggestions] = useState(false);
@@ -281,7 +261,7 @@ export const AddTimerForm: React.FC<AddTimerFormProps> = ({
       ? selectedGuildSelection.guildId
       : preferredGuildId;
 
-  const searchGuildId = selectedGuildId || currentGuildId || "";
+  const searchGuildId = selectedGuildId;
 
   const {
     data: npcResults,
@@ -460,19 +440,16 @@ export const AddTimerForm: React.FC<AddTimerFormProps> = ({
       onSubmit={handleSubmit(onSubmit)}
       className="ll:flex ll:flex-col ll:h-full ll:box-border ll:overflow-hidden ll:w-full"
     >
-      <div className="ll:shrink-0 ll:pt-1 ll:pb-2">
-        <Label>{t("addForm.guildLabel")}</Label>
-        <GuildSwitcher
-          value={selectedGuildId}
-          onChange={handleGuildSelectionChange}
-          disabled={isPending}
-        />
-        {!selectedGuildId && (
-          <p className="ll:text-xs ll:text-red-500 ll:mt-1">
-            {t("addForm.guildRequired")}
-          </p>
-        )}
-      </div>
+      {visibleGuilds.length !== 1 && (
+        <div className="ll:shrink-0 ll:pt-1 ll:pb-2">
+          {visibleGuilds.length > 1 && <Label>{t("addForm.guildLabel")}</Label>}
+          <GuildSwitcher
+            value={selectedGuildId}
+            onChange={handleGuildSelectionChange}
+            disabled={isPending}
+          />
+        </div>
+      )}
 
       <div className="ll:min-h-0 ll:flex-1 ll:overflow-hidden">
         <ScrollArea

--- a/apps/game-client/src/hooks/use-visible-lootlog-guilds.ts
+++ b/apps/game-client/src/hooks/use-visible-lootlog-guilds.ts
@@ -1,0 +1,30 @@
+import { useUserPreferences } from "@/hooks/api/use-user-preferences";
+import { getVisibleLootlogGuilds } from "@/lib/selected-lootlog-guild";
+import {
+  getUsersControllerGetCurrentUserAccessibleGuildsQueryKey,
+  useUsersControllerGetCurrentUserAccessibleGuilds,
+} from "@lootlog/api-client/react-query/main/users";
+
+export const useVisibleLootlogGuilds = () => {
+  const guildsQuery = useUsersControllerGetCurrentUserAccessibleGuilds({
+    query: {
+      queryKey: getUsersControllerGetCurrentUserAccessibleGuildsQueryKey(),
+      refetchOnMount: false,
+      staleTime: 1000 * 60 * 5,
+    },
+  });
+  const preferencesQuery = useUserPreferences();
+  const visibleGuilds = getVisibleLootlogGuilds(
+    guildsQuery.data ?? [],
+    preferencesQuery.data?.guildsOrder,
+    preferencesQuery.data?.hiddenGuildIds,
+  );
+
+  return {
+    areVisibleGuildsResolved:
+      guildsQuery.data !== undefined && preferencesQuery.data !== undefined,
+    guildsQuery,
+    preferencesQuery,
+    visibleGuilds,
+  };
+};


### PR DESCRIPTION
## Description

Polish the in-game server selector states before the server visibility release reaches `main`.

## What Changed

- Hide the server picker everywhere when exactly one server is visible and keep that server selected automatically.
- Replace the all-hidden state with a compact, full-width, neutral notice outside the horizontal scroll area.
- Keep the settings gear as the only action, with a tooltip and accessible label leading to server visibility settings.
- Hide the world selector when no server is visible.
- Hide the redundant server label and picker in the manual timer form when only one server is available.
- Keep the all-hidden notice and disable timer submission without showing a misleading required-server error.
- Centralize visible-guild query state so chat, timers, online players, the world selector, and the timer form use the same ordered and filtered guild collection.

## Why

The previous empty state inherited the switcher's horizontal content sizing, so it appeared narrow and visually inconsistent with adjacent controls. The selector also remained visible when there was no meaningful choice, and dependent controls could remain on screen after all servers were hidden.

## User Impact

Users with one visible server see less UI chrome. Users with all servers hidden get a smaller, full-width notice that matches the game client's neutral controls and provides a direct settings action.

## Validation

- `pnpm --filter @lootlog/game-client test` — 234 files, 1228 tests passed
- `pnpm --filter @lootlog/game-client lint`
- `pnpm --filter @lootlog/game-client check-types`
- `pnpm --filter @lootlog/game-client build`
- `git diff --check`

After this PR is merged into `develop`, release PR #1194 will include the fix automatically.