### PR TITLE
fix(auth): restore Discord OAuth registration

### DIFF
--- a/.changeset/calm-spiders-auth.md
+++ b/.changeset/calm-spiders-auth.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/auth": patch
+---
+
+Restore Discord OAuth registration after the Better Auth provider input validation change while keeping Discord identities immutable.

--- a/apps/auth/src/auth/better-auth.ts
+++ b/apps/auth/src/auth/better-auth.ts
@@ -5,6 +5,14 @@ import { DISCORD_AUTH_SCOPES } from "@lootlog/types";
 import { env } from "src/config/env";
 import { betterAuthSchema, db } from "src/database/drizzle";
 import { authRedisSecondaryStorage } from "./auth-redis-storage";
+import { createDiscordAuthOptions } from "./discord-auth-options";
+
+const discordAuthOptions = createDiscordAuthOptions({
+  clientId: env.DISCORD_CLIENT_ID,
+  clientSecret: env.DISCORD_CLIENT_SECRET,
+  redirectURI: `${env.APP_URL}/idp/callback/discord`,
+  scopes: DISCORD_AUTH_SCOPES,
+});
 
 export const auth = betterAuth({
   appName: "@lootlog/auth",
@@ -18,18 +26,7 @@ export const auth = betterAuth({
   account: {
     encryptOAuthTokens: true,
   },
-  user: {
-    additionalFields: {
-      discordId: {
-        type: "string",
-        required: true,
-        input: false,
-      },
-    },
-    deleteUser: {
-      enabled: true,
-    },
-  },
+  ...discordAuthOptions,
   secret: env.AUTH_SECRET,
   session: {
     storeSessionInDatabase: true,
@@ -74,20 +71,6 @@ export const auth = betterAuth({
     bearer(),
     admin({ adminUserIds: env.ADMIN_ACCOUNT_IDS }),
   ],
-  socialProviders: {
-    discord: {
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
-      redirectURI: `${env.APP_URL}/idp/callback/discord`,
-      prompt: "consent",
-      scopes: DISCORD_AUTH_SCOPES,
-      mapProfileToUser: (profile) => ({
-        firstName: profile.given_name,
-        lastName: profile.family_name,
-        discordId: profile.id,
-      }),
-    },
-  },
 });
 
 export type AppUserSession = typeof auth.$Infer.Session;

--- a/apps/auth/src/auth/discord-auth-options.spec.ts
+++ b/apps/auth/src/auth/discord-auth-options.spec.ts
@@ -1,0 +1,195 @@
+import type { DiscordProfile } from "better-auth/social-providers";
+import { getTestInstance } from "better-auth/test";
+import { createDiscordAuthOptions } from "./discord-auth-options";
+
+const DISCORD_ID = "123456789012345678";
+const DISCORD_EMAIL = "discord-user@example.com";
+
+const discordProfile = {
+  id: DISCORD_ID,
+  username: "discord-user",
+  discriminator: "0",
+  global_name: "Discord User",
+  avatar: null,
+  mfa_enabled: false,
+  banner: null,
+  accent_color: null,
+  locale: "en",
+  verified: true,
+  email: DISCORD_EMAIL,
+  flags: 0,
+  premium_type: 0,
+  public_flags: 0,
+  display_name: "Discord User",
+  avatar_decoration: null,
+  banner_color: null,
+  image_url: "",
+} satisfies DiscordProfile;
+
+const storeResponseCookies = (
+  requestHeaders: Headers,
+  responseHeaders: Headers,
+) => {
+  const cookies = new Map(
+    (requestHeaders.get("cookie") ?? "")
+      .split(";")
+      .map((cookie) => cookie.trim())
+      .filter(Boolean)
+      .map((cookie) => {
+        const separatorIndex = cookie.indexOf("=");
+
+        return [
+          cookie.slice(0, separatorIndex),
+          cookie.slice(separatorIndex + 1),
+        ];
+      }),
+  );
+
+  for (const setCookieHeader of responseHeaders.getSetCookie()) {
+    const [cookie] = setCookieHeader.split(";");
+
+    if (!cookie) {
+      continue;
+    }
+
+    const separatorIndex = cookie.indexOf("=");
+    cookies.set(
+      cookie.slice(0, separatorIndex),
+      cookie.slice(separatorIndex + 1),
+    );
+  }
+
+  requestHeaders.set(
+    "cookie",
+    [...cookies].map(([name, value]) => `${name}=${value}`).join("; "),
+  );
+};
+
+describe("Discord OAuth identity", async () => {
+  const { auth, client } = await getTestInstance(
+    createDiscordAuthOptions({
+      clientId: "test-client-id",
+      clientSecret: "test-client-secret",
+      redirectURI: "http://localhost:3000/api/auth/callback/discord",
+      scopes: ["identify", "email"],
+    }),
+    { disableTestUser: true },
+  );
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>((input) => {
+        const requestURL =
+          input instanceof Request ? input.url : input.toString();
+        const parsedRequestURL = new URL(requestURL);
+
+        if (requestURL === "https://discord.com/api/oauth2/token") {
+          return Promise.resolve(
+            Response.json({
+              access_token: "test-access-token",
+              refresh_token: "test-refresh-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+              scope: "identify email",
+            }),
+          );
+        }
+
+        if (
+          parsedRequestURL.origin === "https://discord.com" &&
+          decodeURIComponent(parsedRequestURL.pathname) === "/api/users/@me"
+        ) {
+          return Promise.resolve(Response.json(discordProfile));
+        }
+
+        return Promise.reject(
+          new Error(`Unexpected external request: ${requestURL}`),
+        );
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const signInWithDiscord = async () => {
+    const authHeaders = new Headers();
+    const signInResponse = await client.signIn.social({
+      provider: "discord",
+      callbackURL: "/",
+      fetchOptions: {
+        onSuccess: ({ response }) => {
+          storeResponseCookies(authHeaders, response.headers);
+        },
+      },
+    });
+    const authorizationURL = new URL(signInResponse.data?.url ?? "");
+    const state = authorizationURL.searchParams.get("state") ?? "";
+    let callbackLocation = "";
+
+    await client.$fetch("/callback/discord", {
+      method: "GET",
+      query: { code: "test-code", state },
+      headers: authHeaders,
+      onError: ({ response }) => {
+        callbackLocation = response.headers.get("location") ?? "";
+        storeResponseCookies(authHeaders, response.headers);
+      },
+    });
+
+    return { authHeaders, callbackLocation };
+  };
+
+  it("provisions a new user with the Discord profile id", async () => {
+    const { authHeaders, callbackLocation } = await signInWithDiscord();
+
+    expect(callbackLocation).not.toContain("discordId_is_required");
+
+    const sessionResponse = await auth.api.getSession({
+      headers: authHeaders,
+    });
+
+    expect(sessionResponse?.user.discordId).toBe(DISCORD_ID);
+  });
+
+  it("rejects attempts to change the Discord profile id", async () => {
+    const { authHeaders } = await signInWithDiscord();
+
+    let updateError: unknown;
+
+    try {
+      await auth.api.updateUser({
+        body: { discordId: "999999999999999999" },
+        headers: authHeaders,
+      });
+    } catch (error) {
+      updateError = error;
+    }
+
+    expect(updateError).toMatchObject({
+      body: { code: "DISCORD_ID_IMMUTABLE" },
+      status: "BAD_REQUEST",
+    });
+
+    const sessionResponse = await auth.api.getSession({
+      headers: authHeaders,
+    });
+
+    expect(sessionResponse?.user.discordId).toBe(DISCORD_ID);
+  });
+
+  it("signs in an existing Discord user without changing their identity", async () => {
+    await signInWithDiscord();
+    const { authHeaders, callbackLocation } = await signInWithDiscord();
+
+    expect(callbackLocation).not.toContain("error");
+
+    const sessionResponse = await auth.api.getSession({
+      headers: authHeaders,
+    });
+
+    expect(sessionResponse?.user.discordId).toBe(DISCORD_ID);
+  });
+});

--- a/apps/auth/src/auth/discord-auth-options.ts
+++ b/apps/auth/src/auth/discord-auth-options.ts
@@ -1,0 +1,63 @@
+import type { BetterAuthOptions } from "better-auth";
+import { APIError } from "better-auth/api";
+
+interface DiscordAuthOptionsInput {
+  clientId: string;
+  clientSecret: string;
+  redirectURI: string;
+  scopes: string[];
+}
+
+export const createDiscordAuthOptions = ({
+  clientId,
+  clientSecret,
+  redirectURI,
+  scopes,
+}: DiscordAuthOptionsInput) =>
+  ({
+    user: {
+      additionalFields: {
+        discordId: {
+          type: "string",
+          required: true,
+          input: true,
+        },
+      },
+      deleteUser: {
+        enabled: true,
+      },
+    },
+    databaseHooks: {
+      user: {
+        update: {
+          before: (user) => {
+            if (user.discordId !== undefined) {
+              throw new APIError("BAD_REQUEST", {
+                code: "DISCORD_ID_IMMUTABLE",
+                message: "Discord ID cannot be changed",
+              });
+            }
+
+            return Promise.resolve();
+          },
+        },
+      },
+    },
+    socialProviders: {
+      discord: {
+        clientId,
+        clientSecret,
+        redirectURI,
+        prompt: "consent",
+        scope: scopes,
+        mapProfileToUser: (profile) => ({
+          firstName: profile.given_name,
+          lastName: profile.family_name,
+          discordId: profile.id,
+        }),
+      },
+    },
+  }) satisfies Pick<
+    BetterAuthOptions,
+    "databaseHooks" | "socialProviders" | "user"
+  >;


### PR DESCRIPTION
## What changed

- allow Better Auth to accept the Discord ID produced by `mapProfileToUser`
- reject subsequent `discordId` updates with `DISCORD_ID_IMMUTABLE`
- share the Discord provider configuration between production and integration tests
- add OAuth regression coverage for new users, immutable identities, and repeat sign-ins
- add a patch changeset for `@lootlog/auth`

## Root cause

Better Auth 1.6.25 filters provider-mapped values declared with `input: false`. The required `discordId` was therefore removed before user creation and validation returned `discordId_is_required`.

## Impact

New Discord users can register again while the Discord identity used by sessions, JWTs, and service authorization remains immutable.

## Validation

- `pnpm --filter @lootlog/auth test` — 35 tests passed
- `pnpm --filter @lootlog/auth lint`
- `pnpm --filter @lootlog/auth build`
- pre-commit changed-package checks