### PR TITLE
fix(ci): classify GitHub Actions dependency updates

### DIFF
--- a/.changeset/dependabot-tooling-updates.md
+++ b/.changeset/dependabot-tooling-updates.md
@@ -1,0 +1,4 @@
+---
+---
+
+Safely classify Dependabot updates to GitHub Actions as tooling changes.

--- a/tools/release/create-dependabot-changeset.mjs
+++ b/tools/release/create-dependabot-changeset.mjs
@@ -13,6 +13,9 @@ const dependencyFields = [
   ...developmentDependencyFields,
 ];
 const workspaceManifestPattern = /^(apps|packages)\/[^/]+\/package\.json$/;
+const githubActionsWorkflowPattern = /^\.github\/workflows\/[^/]+\.ya?ml$/;
+const githubActionUsePattern =
+  /^(?<prefix>\s*(?:-\s*)?uses:\s*["']?)(?<action>[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_./-]+)?)@(?<ref>[^"'#\s]+)(?<suffix>["']?\s*(?:#.*)?)$/;
 
 function withoutDependencyFields(manifest) {
   return Object.fromEntries(
@@ -28,6 +31,7 @@ function changedAnyField(before, after, fields) {
 
 export function createDependabotChangeset({
   changedManifests,
+  hasToolingChanges = false,
   pullRequestNumber,
 }) {
   if (!Array.isArray(changedManifests)) {
@@ -36,7 +40,7 @@ export function createDependabotChangeset({
   if (!Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0) {
     throw new TypeError("Pull request number must be a positive integer");
   }
-  if (changedManifests.length === 0) {
+  if (changedManifests.length === 0 && !hasToolingChanges) {
     return null;
   }
 
@@ -106,7 +110,7 @@ export function createDependabotChangeset({
     };
   }
 
-  if (hasDevelopmentChanges) {
+  if (hasDevelopmentChanges || hasToolingChanges) {
     return {
       content: [
         "---",
@@ -151,17 +155,31 @@ async function requestGitHub(path, { body, method = "GET", token }) {
 }
 
 async function readRepositoryJson({ path, ref, repository, token }) {
+  const content = await readRepositoryContent({
+    path,
+    ref,
+    repository,
+    token,
+  });
+  return JSON.parse(content);
+}
+
+async function readRepositoryContent({ path, ref, repository, token }) {
   const encodedPath = encodeRepositoryPath(path);
   const result = await requestGitHub(
     `/repos/${repository}/contents/${encodedPath}?ref=${encodeURIComponent(ref)}`,
     { token },
   );
-  return JSON.parse(Buffer.from(result.content, "base64").toString("utf8"));
+  return Buffer.from(result.content, "base64").toString("utf8");
 }
 
-export function selectChangedManifestPaths({ filenames, pullRequestNumber }) {
+export function classifyChangedDependencyPaths({
+  filenames,
+  pullRequestNumber,
+}) {
   const ownChangeset = `.changeset/dependabot-pr-${pullRequestNumber}.md`;
   const manifestPaths = [];
+  const toolingPaths = [];
 
   for (const filename of filenames) {
     if (filename === "pnpm-lock.yaml" || filename === ownChangeset) {
@@ -174,11 +192,56 @@ export function selectChangedManifestPaths({ filenames, pullRequestNumber }) {
       manifestPaths.push(filename);
       continue;
     }
+    if (filename.match(githubActionsWorkflowPattern)) {
+      toolingPaths.push(filename);
+      continue;
+    }
 
     throw new Error(`Cannot classify Dependabot file ${filename}`);
   }
 
-  return [...new Set(manifestPaths)].sort();
+  return {
+    manifestPaths: [...new Set(manifestPaths)].sort(),
+    toolingPaths: [...new Set(toolingPaths)].sort(),
+  };
+}
+
+function parseGitHubActionUse(line) {
+  return line.match(githubActionUsePattern)?.groups;
+}
+
+export function validateGitHubActionsDependencyUpdate({ after, before, path }) {
+  const afterLines = after.split(/\r?\n/);
+  const beforeLines = before.split(/\r?\n/);
+  if (afterLines.length !== beforeLines.length) {
+    throw new Error(`Cannot classify Dependabot changes in ${path}`);
+  }
+
+  let changedActions = 0;
+  for (const [index, beforeLine] of beforeLines.entries()) {
+    const afterLine = afterLines[index];
+    if (beforeLine === afterLine) {
+      continue;
+    }
+
+    const beforeUse = parseGitHubActionUse(beforeLine);
+    const afterUse = parseGitHubActionUse(afterLine);
+    if (
+      !beforeUse ||
+      !afterUse ||
+      beforeUse.prefix !== afterUse.prefix ||
+      beforeUse.action !== afterUse.action ||
+      beforeUse.suffix !== afterUse.suffix ||
+      beforeUse.ref === afterUse.ref
+    ) {
+      throw new Error(`Cannot classify Dependabot changes in ${path}`);
+    }
+    changedActions += 1;
+  }
+
+  if (changedActions === 0) {
+    throw new Error(`Cannot classify Dependabot changes in ${path}`);
+  }
 }
 
 async function listChangedFiles({ pullRequestNumber, repository, token }) {
@@ -218,7 +281,7 @@ export async function automateDependabotChangeset({
     repository,
     token,
   });
-  const manifestPaths = selectChangedManifestPaths({
+  const { manifestPaths, toolingPaths } = classifyChangedDependencyPaths({
     filenames,
     pullRequestNumber,
   });
@@ -239,8 +302,27 @@ export async function automateDependabotChangeset({
       path,
     })),
   );
+  const changedToolingFiles = await Promise.all(
+    toolingPaths.map(async (path) => ({
+      after: await readRepositoryContent({
+        path,
+        ref: headSha,
+        repository,
+        token,
+      }),
+      before: await readRepositoryContent({
+        path,
+        ref: baseSha,
+        repository,
+        token,
+      }),
+      path,
+    })),
+  );
+  changedToolingFiles.forEach(validateGitHubActionsDependencyUpdate);
   const changeset = createDependabotChangeset({
     changedManifests,
+    hasToolingChanges: changedToolingFiles.length > 0,
     pullRequestNumber,
   });
 

--- a/tools/release/create-dependabot-changeset.test.mjs
+++ b/tools/release/create-dependabot-changeset.test.mjs
@@ -2,8 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  classifyChangedDependencyPaths,
   createDependabotChangeset,
-  selectChangedManifestPaths,
+  validateGitHubActionsDependencyUpdate,
 } from "./create-dependabot-changeset.mjs";
 
 test("creates patch releases for workspaces with runtime dependency updates", () => {
@@ -104,29 +105,104 @@ test("creates an empty changeset for root tooling dependency updates", () => {
   );
 });
 
-test("accepts only package manifests, the lockfile, and its own changeset", () => {
+test("creates an empty changeset for validated GitHub Actions updates", () => {
+  const result = createDependabotChangeset({
+    changedManifests: [],
+    hasToolingChanges: true,
+    pullRequestNumber: 1139,
+  });
+
+  assert.deepEqual(result, {
+    content: [
+      "---",
+      "---",
+      "",
+      "Update development and tooling dependencies.",
+      "",
+    ].join("\n"),
+    filename: ".changeset/dependabot-pr-1139.md",
+  });
+});
+
+test("classifies package manifests and GitHub Actions workflows", () => {
   assert.deepEqual(
-    selectChangedManifestPaths({
+    classifyChangedDependencyPaths({
       filenames: [
         "pnpm-lock.yaml",
         "apps/api/package.json",
         "package.json",
+        ".github/workflows/ci.yml",
         ".changeset/dependabot-pr-1225.md",
       ],
       pullRequestNumber: 1225,
     }),
-    ["apps/api/package.json", "package.json"],
+    {
+      manifestPaths: ["apps/api/package.json", "package.json"],
+      toolingPaths: [".github/workflows/ci.yml"],
+    },
   );
 });
 
 test("rejects unexpected Dependabot files as ambiguous", () => {
   assert.throws(
     () =>
-      selectChangedManifestPaths({
+      classifyChangedDependencyPaths({
         filenames: ["apps/api/package.json", "apps/api/src/main.ts"],
         pullRequestNumber: 1225,
       }),
     /Cannot classify Dependabot file/,
+  );
+});
+
+test("accepts only GitHub Action version changes in workflows", () => {
+  assert.doesNotThrow(() =>
+    validateGitHubActionsDependencyUpdate({
+      after: [
+        "jobs:",
+        "  test:",
+        "    steps:",
+        "      - uses: actions/checkout@v7",
+        '      - uses: "github/codeql-action/init@v4" # pinned major',
+        "",
+      ].join("\n"),
+      before: [
+        "jobs:",
+        "  test:",
+        "    steps:",
+        "      - uses: actions/checkout@v6",
+        '      - uses: "github/codeql-action/init@v3" # pinned major',
+        "",
+      ].join("\n"),
+      path: ".github/workflows/ci.yml",
+    }),
+  );
+});
+
+test("rejects other workflow changes as ambiguous", () => {
+  assert.throws(
+    () =>
+      validateGitHubActionsDependencyUpdate({
+        after: [
+          "jobs:",
+          "  test:",
+          "    permissions:",
+          "      contents: write",
+          "    steps:",
+          "      - uses: actions/checkout@v7",
+          "",
+        ].join("\n"),
+        before: [
+          "jobs:",
+          "  test:",
+          "    permissions:",
+          "      contents: read",
+          "    steps:",
+          "      - uses: actions/checkout@v6",
+          "",
+        ].join("\n"),
+        path: ".github/workflows/ci.yml",
+      }),
+    /Cannot classify Dependabot changes/,
   );
 });
 


### PR DESCRIPTION
## Summary
- classify GitHub Actions workflow version bumps as tooling-only Dependabot changes
- validate that every changed workflow line is only a `uses:` ref update
- keep rejecting any other workflow modification as ambiguous

## Validation
- `node --test tools/ci/*.test.mjs tools/release/*.test.mjs apps/developer/server-handler.test.js`
- `pnpm format:check`
- `node tools/release/validate-workspace-changesets.mjs origin/main`
- pre-commit checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependabot updates to GitHub Actions workflows are now recognized and included in release changesets.
  * Workflow updates are validated to ensure only action versions changed, preventing ambiguous releases.

* **Bug Fixes**
  * Improved handling of Dependabot updates that affect tooling without changing dependency manifests.

* **Chores**
  * Updated release automation and coverage for manifest and workflow-based Dependabot changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->