### PR TITLE
fix(ci): make automated PR dispatch authoritative

### DIFF
--- a/.changeset/bot-ci-dispatch-order.md
+++ b/.changeset/bot-ci-dispatch-order.md
@@ -1,0 +1,4 @@
+---
+---
+
+Ensure automated pull requests expose the authoritative CI result to the merge queue.

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -52,9 +52,4 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_SHA: ${{ steps.changeset.outputs.commit_sha }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh workflow run ci.yml \
-            --ref "$HEAD_REF" \
-            --field base_sha="$BASE_SHA" \
-            --field head_sha="$HEAD_SHA" \
-            --field pull_request_number="$PULL_REQUEST_NUMBER"
+        run: node tools/ci/dispatch-automated-pr-ci.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,10 @@ jobs:
           head_ref="$(jq -r '.headRefName' <<< "$pull_request")"
           head_sha="$(jq -r '.headRefOid' <<< "$pull_request")"
 
-          gh workflow run ci.yml \
-            --ref "$head_ref" \
-            --field base_sha="$base_sha" \
-            --field head_sha="$head_sha" \
-            --field pull_request_number="$PULL_REQUEST_NUMBER"
+          BASE_SHA="$base_sha" \
+            HEAD_REF="$head_ref" \
+            HEAD_SHA="$head_sha" \
+            node tools/ci/dispatch-automated-pr-ci.mjs
 
       - name: Prepare release plan
         id: plan

--- a/tools/ci/dispatch-automated-pr-ci.mjs
+++ b/tools/ci/dispatch-automated-pr-ci.mjs
@@ -1,0 +1,141 @@
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_MAX_POLL_ATTEMPTS = 30;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const GITHUB_API_VERSION = "2022-11-28";
+const WORKFLOW_FILE = "ci.yml";
+
+const wait = (milliseconds) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
+const requireValue = (value, name) => {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+
+  return value;
+};
+
+const readErrorMessage = async (response) => {
+  try {
+    const payload = await response.json();
+    return payload.message ?? response.statusText;
+  } catch {
+    return response.statusText;
+  }
+};
+
+export const dispatchAutomatedPullRequestCi = async ({
+  apiUrl = "https://api.github.com",
+  baseSha,
+  fetchImplementation = globalThis.fetch,
+  headRef,
+  headSha,
+  maxPollAttempts = DEFAULT_MAX_POLL_ATTEMPTS,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  pullRequestNumber,
+  repository,
+  sleep = wait,
+  token,
+}) => {
+  const normalizedApiUrl = apiUrl.replace(/\/$/, "");
+  const workflowPath = `${normalizedApiUrl}/repos/${repository}/actions/workflows/${WORKFLOW_FILE}`;
+  const headers = {
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+  const workflowRunsUrl = new URL(`${workflowPath}/runs`);
+  workflowRunsUrl.searchParams.set("event", "pull_request");
+  workflowRunsUrl.searchParams.set("head_sha", headSha);
+  workflowRunsUrl.searchParams.set("per_page", "1");
+
+  const waitForAutomaticRun = async (attempt) => {
+    const response = await fetchImplementation(workflowRunsUrl, {
+      headers,
+      method: "GET",
+    });
+
+    if (!response.ok) {
+      const message = await readErrorMessage(response);
+      throw new Error(
+        `Failed to inspect automatic CI runs (${response.status}): ${message}`,
+      );
+    }
+
+    const payload = await response.json();
+    const automaticRunFound = payload.workflow_runs?.some(
+      (workflowRun) =>
+        workflowRun.event === "pull_request" &&
+        workflowRun.head_sha === headSha,
+    );
+
+    if (automaticRunFound) {
+      return true;
+    }
+
+    if (attempt >= maxPollAttempts) {
+      return false;
+    }
+
+    await sleep(pollIntervalMs);
+    return waitForAutomaticRun(attempt + 1);
+  };
+
+  const automaticRunFound = await waitForAutomaticRun(1);
+
+  if (!automaticRunFound) {
+    throw new Error(
+      `The automatic pull_request run for ${headSha} did not appear before the CI dispatch timeout`,
+    );
+  }
+
+  const dispatchResponse = await fetchImplementation(
+    `${workflowPath}/dispatches`,
+    {
+      body: JSON.stringify({
+        inputs: {
+          base_sha: baseSha,
+          head_sha: headSha,
+          pull_request_number: pullRequestNumber,
+        },
+        ref: headRef,
+      }),
+      headers: {
+        ...headers,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    },
+  );
+
+  if (!dispatchResponse.ok) {
+    const message = await readErrorMessage(dispatchResponse);
+    throw new Error(
+      `CI workflow dispatch failed (${dispatchResponse.status}): ${message}`,
+    );
+  }
+};
+
+const isCliInvocation =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCliInvocation) {
+  await dispatchAutomatedPullRequestCi({
+    apiUrl: process.env.GITHUB_API_URL,
+    baseSha: requireValue(process.env.BASE_SHA, "BASE_SHA"),
+    headRef: requireValue(process.env.HEAD_REF, "HEAD_REF"),
+    headSha: requireValue(process.env.HEAD_SHA, "HEAD_SHA"),
+    pullRequestNumber: requireValue(
+      process.env.PULL_REQUEST_NUMBER,
+      "PULL_REQUEST_NUMBER",
+    ),
+    repository: requireValue(
+      process.env.GITHUB_REPOSITORY,
+      "GITHUB_REPOSITORY",
+    ),
+    token: requireValue(process.env.GH_TOKEN, "GH_TOKEN"),
+  });
+}

--- a/tools/ci/dispatch-automated-pr-ci.test.mjs
+++ b/tools/ci/dispatch-automated-pr-ci.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dispatchAutomatedPullRequestCi } from "./dispatch-automated-pr-ci.mjs";
+
+const baseInput = {
+  apiUrl: "https://api.github.test",
+  baseSha: "base-sha",
+  headRef: "changeset-release/main",
+  headSha: "head-sha",
+  pullRequestNumber: "1225",
+  repository: "lootlog/monorepo",
+  token: "test-token",
+};
+
+test("waits for the automatic pull request run before dispatching CI", async () => {
+  const requests = [];
+  const sleepCalls = [];
+  const responses = [
+    Response.json({ total_count: 0, workflow_runs: [] }),
+    Response.json({
+      total_count: 1,
+      workflow_runs: [{ id: 123, event: "pull_request", head_sha: "head-sha" }],
+    }),
+    new Response(null, { status: 204 }),
+  ];
+
+  await dispatchAutomatedPullRequestCi({
+    ...baseInput,
+    fetchImplementation: (url, options) => {
+      requests.push({ options, url: url.toString() });
+      return responses.shift();
+    },
+    pollIntervalMs: 1,
+    sleep: (milliseconds) => {
+      sleepCalls.push(milliseconds);
+      return Promise.resolve();
+    },
+  });
+
+  assert.equal(requests.length, 3);
+  assert.equal(
+    requests[0].url,
+    "https://api.github.test/repos/lootlog/monorepo/actions/workflows/ci.yml/runs?event=pull_request&head_sha=head-sha&per_page=1",
+  );
+  assert.equal(requests[0].options.method, "GET");
+  assert.deepEqual(sleepCalls, [1]);
+  assert.equal(
+    requests[2].url,
+    "https://api.github.test/repos/lootlog/monorepo/actions/workflows/ci.yml/dispatches",
+  );
+  assert.equal(requests[2].options.method, "POST");
+  assert.deepEqual(JSON.parse(requests[2].options.body), {
+    inputs: {
+      base_sha: "base-sha",
+      head_sha: "head-sha",
+      pull_request_number: "1225",
+    },
+    ref: "changeset-release/main",
+  });
+});
+
+test("fails without dispatching when the automatic run does not appear", async () => {
+  let requestCount = 0;
+
+  await assert.rejects(
+    dispatchAutomatedPullRequestCi({
+      ...baseInput,
+      fetchImplementation: () => {
+        requestCount += 1;
+        return Response.json({ total_count: 0, workflow_runs: [] });
+      },
+      maxPollAttempts: 2,
+      pollIntervalMs: 1,
+      sleep: () => Promise.resolve(),
+    }),
+    /automatic pull_request run/,
+  );
+
+  assert.equal(requestCount, 2);
+});
+
+test("reports a failed workflow dispatch", async () => {
+  const responses = [
+    Response.json({
+      total_count: 1,
+      workflow_runs: [{ id: 123, event: "pull_request", head_sha: "head-sha" }],
+    }),
+    Response.json({ message: "dispatch failed" }, { status: 422 }),
+  ];
+
+  await assert.rejects(
+    dispatchAutomatedPullRequestCi({
+      ...baseInput,
+      fetchImplementation: () => responses.shift(),
+      sleep: () => Promise.resolve(),
+    }),
+    /dispatch failed \(422\)/,
+  );
+});


### PR DESCRIPTION
## Summary

- wait for GitHub to register the automatic pull request run before dispatching CI
- share the ordering logic between Changesets and Dependabot workflows
- fail safely when the automatic run never appears or dispatching fails

## Validation

- 29 CI and release tooling tests
- full formatting check
- oxlint
- actionlint 1.7.12
- changeset status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated pull request CI dispatching so merge queues receive the authoritative CI result.
  * Added verification that the expected CI run is available before proceeding.
  * Added clearer error handling when CI runs cannot be found or dispatched.

* **Tests**
  * Added coverage for successful CI dispatches, polling timeouts, and failed workflow requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->