### PR TITLE
fix(ci): classify version merge groups

### DIFF
--- a/.changeset/merge-group-version-pr.md
+++ b/.changeset/merge-group-version-pr.md
@@ -1,0 +1,4 @@
+---
+---
+
+Resolve the Changesets release branch from merge queue refs before planning CI.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           INPUT_HEAD_SHA: ${{ inputs.head_sha }}
           INPUT_PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
           MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           PULL_REQUEST_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PULL_REQUEST_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -84,9 +85,14 @@ jobs:
             merge_group)
               base_sha="$MERGE_GROUP_BASE_SHA"
               head_sha="$MERGE_GROUP_HEAD_SHA"
+              pull_request_number="$(
+                node tools/ci/merge-group-pull-request.mjs \
+                  "$MERGE_GROUP_HEAD_REF"
+              )"
               pull_request_heads="$(
-                gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/pulls" \
-                  --jq '[.[].head.ref]'
+                gh pr view "$pull_request_number" \
+                  --json headRefName \
+                  --jq '[.headRefName]'
               )"
               ;;
             workflow_dispatch)

--- a/tools/ci/merge-group-pull-request.mjs
+++ b/tools/ci/merge-group-pull-request.mjs
@@ -1,0 +1,32 @@
+import { pathToFileURL } from "node:url";
+
+export function getMergeGroupPullRequestNumber(headRef) {
+  if (typeof headRef !== "string") {
+    throw new TypeError("Merge group head ref must be a string");
+  }
+
+  const matches = [...headRef.matchAll(/(?:^|\/)pr-(\d+)(?=-|$)/g)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `Merge group head ref must identify exactly one pull request: ${headRef}`,
+    );
+  }
+
+  const pullRequestNumber = Number(matches[0][1]);
+  if (!Number.isSafeInteger(pullRequestNumber) || pullRequestNumber < 1) {
+    throw new Error(
+      `Invalid pull request number in merge group ref: ${headRef}`,
+    );
+  }
+
+  return pullRequestNumber;
+}
+
+const isCommandLineInvocation =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCommandLineInvocation) {
+  process.stdout.write(
+    String(getMergeGroupPullRequestNumber(process.argv[2] ?? "")),
+  );
+}

--- a/tools/ci/merge-group-pull-request.test.mjs
+++ b/tools/ci/merge-group-pull-request.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getMergeGroupPullRequestNumber } from "./merge-group-pull-request.mjs";
+
+test("extracts the pull request number from a merge queue head ref", () => {
+  assert.equal(
+    getMergeGroupPullRequestNumber(
+      "gh-readonly-queue/main/pr-1225-1dc7910bb7f3d34a8a280a4fce57623a54a0d8fd",
+    ),
+    1225,
+  );
+});
+
+test("rejects a head ref that does not identify exactly one pull request", () => {
+  assert.throws(
+    () => getMergeGroupPullRequestNumber("gh-readonly-queue/main"),
+    /exactly one pull request/,
+  );
+});


### PR DESCRIPTION
## Summary

- resolve the queued pull request from `merge_group.head_ref`
- use its real head branch when classifying Changesets version PRs
- keep Docker smoke skipped for version PRs in merge queue

## Validation

- `node --test tools/ci/*.test.mjs tools/release/*.test.mjs apps/developer/server-handler.test.js`
- `pnpm format:check`
- `pnpm exec oxlint tools/ci/merge-group-pull-request.mjs tools/ci/merge-group-pull-request.test.mjs`
- `actionlint .github/workflows/ci.yml`
- replayed the observed merge queue ref and resolved `changeset-release/main`