### PR TITLE
docs: simplify pull request template

### DIFF
--- a/.changeset/simplify-pr-template.md
+++ b/.changeset/simplify-pr-template.md
@@ -1,0 +1,4 @@
+---
+---
+
+Simplify the pull request template to focus on review-relevant information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,176 +1,27 @@
-## Description
+## Summary
 
-<!-- Provide a clear and concise description of your changes -->
+<!-- What changed and why? -->
 
-## Type of Change
+## Related issue
 
-<!-- Mark the relevant option with an "x" -->
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Refactoring (no functional changes)
-- [ ] Performance improvement
-- [ ] Test updates
-- [ ] Configuration/infrastructure changes
-
-## Related Issues
-
-<!-- Link related issues using #issue_number -->
-
-Closes #
-Related to #
-
-## Changes Made
-
-<!-- List the specific changes made in this PR -->
-
--
--
--
-
-## Affected Components
-
-<!-- Mark all that apply with an "x" -->
-
-- [ ] Web Dashboard (`apps/web`)
-- [ ] Game Client (`apps/game-client`)
-- [ ] API Service (`apps/api`)
-- [ ] Auth Service (`apps/auth`)
-- [ ] Battlelog Service (`apps/battlelog-service`)
-- [ ] Gateway (`apps/gateway`)
-- [ ] Discord Bot (`apps/discord-bot`)
-- [ ] Search Service (`apps/search`)
-- [ ] Landing Page (`apps/landing`)
-- [ ] Shared UI (`packages/ui`)
-- [ ] Shared Types (`packages/types`)
-- [ ] API Helpers (`packages/api-helpers`)
-- [ ] CLI (`packages/cli`)
-- [ ] Documentation
-- [ ] Infrastructure (Docker, CI/CD)
-
-## Database Changes
-
-<!-- Mark with an "x" if applicable -->
-
-- [ ] Includes database migrations
-- [ ] Requires running `pnpm api:migrate:dev`
-- [ ] Requires running `pnpm battlelog:migrate:dev`
-- [ ] Requires running `pnpm auth:migrate:dev`
-- [ ] No database changes
+<!-- Optional: Closes #123 -->
 
 ## Testing
 
-<!-- Describe the tests you've added or run -->
+<!-- List relevant automated checks and manual scenarios. -->
 
-### Test Coverage
+-
 
-- [ ] Unit tests added/updated
-- [ ] Integration tests added/updated
-- [ ] E2E tests added/updated
-- [ ] Manual testing performed
-- [ ] All existing tests pass
+## Screenshots or recordings
 
-### How to Test
+<!-- Add these only for user-facing visual changes. -->
 
-<!-- Provide step-by-step instructions for testing your changes -->
+## Risks and rollout
 
-1.
-2.
-3.
-
-### Test Environment
-
-<!-- Describe your test environment -->
-
-- Node version:
-- pnpm version:
-- OS:
-- Browser (if applicable):
-
-## Screenshots/Recordings
-
-<!-- If your changes affect the UI, please include screenshots or screen recordings -->
-
-## Performance Impact
-
-<!-- Describe any performance implications of your changes -->
-
-- [ ] No performance impact
-- [ ] Performance improvement (describe below)
-- [ ] Potential performance impact (describe below)
-
-## Breaking Changes
-
-<!-- If this is a breaking change, describe what breaks and migration steps -->
-
-- [ ] No breaking changes
-- [ ] Breaking changes (describe below)
-
-### Migration Guide
-
-<!-- If breaking changes exist, provide a migration guide -->
+<!-- Note migrations, environment variables, breaking changes, rollout steps, or rollback concerns. Write "None" when not applicable. -->
 
 ## Checklist
 
-<!-- Mark completed items with an "x" -->
-
-### Code Quality
-
-- [ ] My code follows the project's code style guidelines
-- [ ] I have run `pnpm lint` and fixed all issues
-- [ ] I have run `pnpm format` to format my code with Oxfmt
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings or errors
-
-### Documentation
-
-- [ ] I have updated the documentation (if applicable)
-- [ ] I have updated the CLAUDE.md file (if architecture changed)
-- [ ] I have added/updated JSDoc comments for new functions
-- [ ] I have updated types in `packages/types` (if applicable)
-
-### Testing
-
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] I have tested my changes in development environment
-- [ ] I have tested database migrations (if applicable)
-
-### Dependencies
-
-- [ ] I have checked that new dependencies are necessary
-- [ ] I have used the latest stable versions of dependencies
-- [ ] I have run `pnpm audit` to check for vulnerabilities
-- [ ] I have updated package.json files correctly
-
-### Environment Variables
-
-- [ ] I have updated `.env.example` files (if new env vars added)
-- [ ] I have documented all new environment variables
-- [ ] I have updated the CLI env generator (if needed)
-
-### Git
-
-- [ ] My commits follow the Conventional Commits specification
-- [ ] My pull request targets `main` and is ready for merge queue validation
-- [ ] I have resolved all merge conflicts
-
-## Additional Notes
-
-<!-- Add any additional notes, concerns, or context for reviewers -->
-
-## Reviewer Focus Areas
-
-<!-- Highlight specific areas you'd like reviewers to pay attention to -->
-
--
-- ***
-
-  **By submitting this pull request, I confirm that:**
-
-- [ ] I have read and understood the [Contributing Guidelines](../CONTRIBUTING.md)
-- [ ] I agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)
-- [ ] My contribution is my own original work and I have the right to submit it under the project's MIT License
+- [ ] A changeset is included, or this change does not require one
+- [ ] Relevant tests were added or run, or testing is not applicable
+- [ ] Migrations, environment variables, documentation, and breaking changes are covered when applicable


### PR DESCRIPTION
## Summary

- reduce the pull request template from 176 to 27 lines
- keep only summary, testing, visual evidence, and rollout risks
- replace repetitive CI and repository checklists with three actionable checks

## Testing

- `pnpm format:check`
- `node tools/release/validate-workspace-changesets.mjs origin/main`

## Risks and rollout

None. This changes contributor guidance only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the pull request template to focus on review-relevant information.
  * Added concise sections for summary, related issues, testing, optional visuals, risks and rollout, and a streamlined checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->