### PR TITLE
fix(ci): stabilize delivery pipelines

### DIFF
--- a/.changeset/steady-pipelines-flow.md
+++ b/.changeset/steady-pipelines-flow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Stabilize automated CI dispatch, dependency changesets, release builds, and workflow documentation.

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -21,4 +21,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PULL_REQUEST_REF: refs/pull/${{ github.event.pull_request.number }}/merge
-        run: gh cache delete --all --succeed-on-no-caches --ref "$PULL_REQUEST_REF"
+        run: |
+          gh cache delete \
+            --all \
+            --succeed-on-no-caches \
+            --ref "$PULL_REQUEST_REF" \
+            --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
         type: string
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || inputs.pull_request_number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.merge_group.head_ref || inputs.pull_request_number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
               ;;
           esac
 
-          pnpm --filter="$PACKAGE_NAME" build
+          pnpm exec turbo run build --filter="$PACKAGE_NAME"
           test -d "$ARTIFACT_PATH"
           archive="$RUNNER_TEMP/cloudflare-artifact.tar.gz"
           tar -C "$ARTIFACT_PATH" -czf "$archive" .

--- a/README.md
+++ b/README.md
@@ -335,6 +335,16 @@ Pull request CI validates changesets against the PR base commit.
 
 ### Automated Release Workflow
 
+```mermaid
+flowchart LR
+  PR[Feature PR] --> Main[main]
+  Main --> Dev[Dev images and GitOps]
+  Main --> VersionPR[chore: release packages]
+  VersionPR --> Release[Versioned release artifacts]
+  Release --> Approval[prod approval]
+  Approval --> Prod[Cloudflare and production GitOps]
+```
+
 1. Merge feature pull requests through the merge queue into `main`. Affected services deploy automatically to dev, but no release artifacts are created.
 2. Changesets creates or updates the `chore: release packages` version PR against `main`.
 3. Review and merge the version PR. Do not edit versions or generated changelogs manually.
@@ -342,9 +352,13 @@ Pull request CI validates changesets against the PR base commit.
 5. Artifacts are built before the `prod` approval. Review the workflow summary and apply any listed Prisma or Drizzle migrations manually.
 6. Approving the `prod` environment deploys the prepared Cloudflare artifacts first, then writes every released Docker image version to the infra repository in one commit. ArgoCD performs the container rollout.
 
+The version PR is the release gate: it batches pending changesets and separates continuous dev deployment from an intentional production release. CI does not create any other delivery PRs. Dependabot may open dependency PRs, and trusted automation adds their required changesets.
+
 Each released workspace owns its generated `CHANGELOG.md`. Use `pnpm changeset status --verbose` to preview the pending release plan. The `pnpm version` and `pnpm release` commands are reserved for release automation.
 
 Production images use both `prod-<semver>` and `sha-<release-commit>` tags and are never overwritten. To promote or roll back one service, run the **Promote an existing image to prod** workflow from `main` with the service and an existing semantic version. Rollbacks only change GitOps; they never rebuild an image.
+
+If an artifact matrix fails after versions have been created, use **Re-run failed jobs**. Do not rerun the entire workflow: successful immutable image jobs must not attempt to overwrite their existing tags.
 
 A successful deployment workflow means the GitOps change was accepted. ArgoCD remains the source of truth for the actual cluster rollout and health.
 

--- a/tools/ci/dispatch-automated-pr-ci.mjs
+++ b/tools/ci/dispatch-automated-pr-ci.mjs
@@ -86,10 +86,8 @@ export const dispatchAutomatedPullRequestCi = async ({
 
   const automaticRunFound = await waitForAutomaticRun(1);
 
-  if (!automaticRunFound) {
-    throw new Error(
-      `The automatic pull_request run for ${headSha} did not appear before the CI dispatch timeout`,
-    );
+  if (automaticRunFound) {
+    return;
   }
 
   const dispatchResponse = await fetchImplementation(

--- a/tools/ci/dispatch-automated-pr-ci.test.mjs
+++ b/tools/ci/dispatch-automated-pr-ci.test.mjs
@@ -13,7 +13,7 @@ const baseInput = {
   token: "test-token",
 };
 
-test("waits for the automatic pull request run before dispatching CI", async () => {
+test("does not dispatch CI when the automatic pull request run appears", async () => {
   const requests = [];
   const sleepCalls = [];
   const responses = [
@@ -22,7 +22,6 @@ test("waits for the automatic pull request run before dispatching CI", async () 
       total_count: 1,
       workflow_runs: [{ id: 123, event: "pull_request", head_sha: "head-sha" }],
     }),
-    new Response(null, { status: 204 }),
   ];
 
   await dispatchAutomatedPullRequestCi({
@@ -38,13 +37,39 @@ test("waits for the automatic pull request run before dispatching CI", async () 
     },
   });
 
-  assert.equal(requests.length, 3);
+  assert.equal(requests.length, 2);
   assert.equal(
     requests[0].url,
     "https://api.github.test/repos/lootlog/monorepo/actions/workflows/ci.yml/runs?event=pull_request&head_sha=head-sha&per_page=1",
   );
   assert.equal(requests[0].options.method, "GET");
   assert.deepEqual(sleepCalls, [1]);
+  assert.deepEqual(
+    requests.map(({ options }) => options.method),
+    ["GET", "GET"],
+  );
+});
+
+test("dispatches CI when the automatic pull request run does not appear", async () => {
+  const requests = [];
+  const responses = [
+    Response.json({ total_count: 0, workflow_runs: [] }),
+    Response.json({ total_count: 0, workflow_runs: [] }),
+    new Response(null, { status: 204 }),
+  ];
+
+  await dispatchAutomatedPullRequestCi({
+    ...baseInput,
+    fetchImplementation: (url, options) => {
+      requests.push({ options, url: url.toString() });
+      return responses.shift();
+    },
+    maxPollAttempts: 2,
+    pollIntervalMs: 1,
+    sleep: () => Promise.resolve(),
+  });
+
+  assert.equal(requests.length, 3);
   assert.equal(
     requests[2].url,
     "https://api.github.test/repos/lootlog/monorepo/actions/workflows/ci.yml/dispatches",
@@ -60,32 +85,9 @@ test("waits for the automatic pull request run before dispatching CI", async () 
   });
 });
 
-test("fails without dispatching when the automatic run does not appear", async () => {
-  let requestCount = 0;
-
-  await assert.rejects(
-    dispatchAutomatedPullRequestCi({
-      ...baseInput,
-      fetchImplementation: () => {
-        requestCount += 1;
-        return Response.json({ total_count: 0, workflow_runs: [] });
-      },
-      maxPollAttempts: 2,
-      pollIntervalMs: 1,
-      sleep: () => Promise.resolve(),
-    }),
-    /automatic pull_request run/,
-  );
-
-  assert.equal(requestCount, 2);
-});
-
 test("reports a failed workflow dispatch", async () => {
   const responses = [
-    Response.json({
-      total_count: 1,
-      workflow_runs: [{ id: 123, event: "pull_request", head_sha: "head-sha" }],
-    }),
+    Response.json({ total_count: 0, workflow_runs: [] }),
     Response.json({ message: "dispatch failed" }, { status: 422 }),
   ];
 
@@ -93,6 +95,7 @@ test("reports a failed workflow dispatch", async () => {
     dispatchAutomatedPullRequestCi({
       ...baseInput,
       fetchImplementation: () => responses.shift(),
+      maxPollAttempts: 1,
       sleep: () => Promise.resolve(),
     }),
     /dispatch failed \(422\)/,

--- a/tools/release/create-dependabot-changeset.mjs
+++ b/tools/release/create-dependabot-changeset.mjs
@@ -30,6 +30,10 @@ function changedAnyField(before, after, fields) {
 }
 
 export function createDependabotChangeset({
+  catalogChanges = {
+    hasDevelopmentChanges: false,
+    runtimePackages: [],
+  },
   changedManifests,
   hasToolingChanges = false,
   pullRequestNumber,
@@ -40,12 +44,23 @@ export function createDependabotChangeset({
   if (!Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0) {
     throw new TypeError("Pull request number must be a positive integer");
   }
-  if (changedManifests.length === 0 && !hasToolingChanges) {
+  if (
+    !Array.isArray(catalogChanges.runtimePackages) ||
+    typeof catalogChanges.hasDevelopmentChanges !== "boolean"
+  ) {
+    throw new TypeError("Catalog changes must contain classified dependencies");
+  }
+  if (
+    changedManifests.length === 0 &&
+    catalogChanges.runtimePackages.length === 0 &&
+    !catalogChanges.hasDevelopmentChanges &&
+    !hasToolingChanges
+  ) {
     return null;
   }
 
-  const runtimePackages = new Set();
-  let hasDevelopmentChanges = false;
+  const runtimePackages = new Set(catalogChanges.runtimePackages);
+  let hasDevelopmentChanges = catalogChanges.hasDevelopmentChanges;
 
   for (const { after, before, path } of changedManifests) {
     const isRootManifest = path === "package.json";
@@ -126,6 +141,143 @@ export function createDependabotChangeset({
   return null;
 }
 
+function readCatalogEntries(contents, path) {
+  const entries = new Map();
+  const lines = contents.split(/\r?\n/);
+  let catalogFound = false;
+  let insideCatalog = false;
+
+  for (const [index, line] of lines.entries()) {
+    if (line === "catalog:") {
+      if (catalogFound) {
+        throw new Error(`Cannot classify Dependabot changes in ${path}`);
+      }
+      catalogFound = true;
+      insideCatalog = true;
+      continue;
+    }
+
+    if (!insideCatalog) {
+      continue;
+    }
+    if (line.length > 0 && !line.startsWith(" ")) {
+      insideCatalog = false;
+      continue;
+    }
+    if (line.trim() === "" || line.trimStart().startsWith("#")) {
+      continue;
+    }
+
+    const entry = line.match(
+      /^ {2}(?:"([^"]+)"|'([^']+)'|([^"'#:][^:]*)):\s*(\S.*)$/,
+    );
+    if (!entry) {
+      throw new Error(`Cannot classify Dependabot changes in ${path}`);
+    }
+    entries.set(index, {
+      dependency: (entry[1] ?? entry[2] ?? entry[3]).trim(),
+      value: entry[4].trim(),
+    });
+  }
+
+  if (!catalogFound) {
+    throw new Error(`Cannot classify Dependabot changes in ${path}`);
+  }
+
+  return { entries, lines };
+}
+
+function usesCatalogDependency(manifest, field, dependency) {
+  return manifest[field]?.[dependency] === "catalog:";
+}
+
+export function classifyCatalogDependencyUpdate({
+  after,
+  before,
+  workspaceManifests,
+}) {
+  if (
+    typeof after !== "string" ||
+    typeof before !== "string" ||
+    !Array.isArray(workspaceManifests)
+  ) {
+    throw new TypeError(
+      "Catalog contents and workspace manifests are required",
+    );
+  }
+
+  const path = "pnpm-workspace.yaml";
+  const afterCatalog = readCatalogEntries(after, path);
+  const beforeCatalog = readCatalogEntries(before, path);
+  if (afterCatalog.lines.length !== beforeCatalog.lines.length) {
+    throw new Error(`Cannot classify Dependabot changes in ${path}`);
+  }
+
+  const changedDependencies = new Set();
+  for (const [index, beforeLine] of beforeCatalog.lines.entries()) {
+    const afterLine = afterCatalog.lines[index];
+    if (beforeLine === afterLine) {
+      continue;
+    }
+
+    const beforeEntry = beforeCatalog.entries.get(index);
+    const afterEntry = afterCatalog.entries.get(index);
+    if (
+      !beforeEntry ||
+      !afterEntry ||
+      beforeEntry.dependency !== afterEntry.dependency ||
+      beforeEntry.value === afterEntry.value
+    ) {
+      throw new Error(`Cannot classify Dependabot changes in ${path}`);
+    }
+    changedDependencies.add(afterEntry.dependency);
+  }
+
+  if (changedDependencies.size === 0) {
+    throw new Error(`Cannot classify Dependabot changes in ${path}`);
+  }
+
+  const runtimePackages = new Set();
+  let hasDevelopmentChanges = false;
+  const classifiedDependencies = new Set();
+
+  for (const manifest of workspaceManifests) {
+    if (!manifest?.name) {
+      throw new Error(`Cannot classify Dependabot changes in ${path}`);
+    }
+
+    for (const dependency of changedDependencies) {
+      const hasRuntimeChanges = runtimeDependencyFields.some((field) =>
+        usesCatalogDependency(manifest, field, dependency),
+      );
+      const hasDevChanges = developmentDependencyFields.some((field) =>
+        usesCatalogDependency(manifest, field, dependency),
+      );
+
+      if (hasRuntimeChanges) {
+        if (!manifest.name.startsWith("@lootlog/")) {
+          throw new Error(`Cannot classify Dependabot changes in ${path}`);
+        }
+        runtimePackages.add(manifest.name);
+        classifiedDependencies.add(dependency);
+      }
+      if (hasDevChanges) {
+        hasDevelopmentChanges = true;
+        classifiedDependencies.add(dependency);
+      }
+    }
+  }
+
+  if (classifiedDependencies.size !== changedDependencies.size) {
+    throw new Error(`Cannot classify Dependabot changes in ${path}`);
+  }
+
+  return {
+    hasDevelopmentChanges,
+    runtimePackages: [...runtimePackages].sort(),
+  };
+}
+
 function encodeRepositoryPath(path) {
   return path.split("/").map(encodeURIComponent).join("/");
 }
@@ -180,9 +332,14 @@ export function classifyChangedDependencyPaths({
   const ownChangeset = `.changeset/dependabot-pr-${pullRequestNumber}.md`;
   const manifestPaths = [];
   const toolingPaths = [];
+  let catalogPath;
 
   for (const filename of filenames) {
     if (filename === "pnpm-lock.yaml" || filename === ownChangeset) {
+      continue;
+    }
+    if (filename === "pnpm-workspace.yaml") {
+      catalogPath = filename;
       continue;
     }
     if (
@@ -201,6 +358,7 @@ export function classifyChangedDependencyPaths({
   }
 
   return {
+    catalogPath,
     manifestPaths: [...new Set(manifestPaths)].sort(),
     toolingPaths: [...new Set(toolingPaths)].sort(),
   };
@@ -260,6 +418,27 @@ async function listChangedFiles({ pullRequestNumber, repository, token }) {
   }
 }
 
+async function listRepositoryManifestPaths({ ref, repository, token }) {
+  const tree = await requestGitHub(
+    `/repos/${repository}/git/trees/${encodeURIComponent(ref)}?recursive=1`,
+    { token },
+  );
+  if (tree.truncated) {
+    throw new Error(`Repository tree for ${ref} is truncated`);
+  }
+
+  return [
+    "package.json",
+    ...tree.tree
+      .filter(
+        ({ path, type }) =>
+          type === "blob" && path.match(workspaceManifestPattern),
+      )
+      .map(({ path }) => path)
+      .sort(),
+  ];
+}
+
 function writeOutput(outputPath, values) {
   const output = Object.entries(values)
     .map(([key, value]) => `${key}=${value}`)
@@ -281,10 +460,11 @@ export async function automateDependabotChangeset({
     repository,
     token,
   });
-  const { manifestPaths, toolingPaths } = classifyChangedDependencyPaths({
-    filenames,
-    pullRequestNumber,
-  });
+  const { catalogPath, manifestPaths, toolingPaths } =
+    classifyChangedDependencyPaths({
+      filenames,
+      pullRequestNumber,
+    });
   const changedManifests = await Promise.all(
     manifestPaths.map(async (path) => ({
       after: await readRepositoryJson({
@@ -320,7 +500,45 @@ export async function automateDependabotChangeset({
     })),
   );
   changedToolingFiles.forEach(validateGitHubActionsDependencyUpdate);
+  let catalogChanges;
+  if (catalogPath) {
+    const [after, before, repositoryManifestPaths] = await Promise.all([
+      readRepositoryContent({
+        path: catalogPath,
+        ref: headSha,
+        repository,
+        token,
+      }),
+      readRepositoryContent({
+        path: catalogPath,
+        ref: baseSha,
+        repository,
+        token,
+      }),
+      listRepositoryManifestPaths({
+        ref: headSha,
+        repository,
+        token,
+      }),
+    ]);
+    const workspaceManifests = await Promise.all(
+      repositoryManifestPaths.map((path) =>
+        readRepositoryJson({
+          path,
+          ref: headSha,
+          repository,
+          token,
+        }),
+      ),
+    );
+    catalogChanges = classifyCatalogDependencyUpdate({
+      after,
+      before,
+      workspaceManifests,
+    });
+  }
   const changeset = createDependabotChangeset({
+    catalogChanges,
     changedManifests,
     hasToolingChanges: changedToolingFiles.length > 0,
     pullRequestNumber,

--- a/tools/release/create-dependabot-changeset.test.mjs
+++ b/tools/release/create-dependabot-changeset.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  classifyCatalogDependencyUpdate,
   classifyChangedDependencyPaths,
   createDependabotChangeset,
   validateGitHubActionsDependencyUpdate,
@@ -124,22 +125,106 @@ test("creates an empty changeset for validated GitHub Actions updates", () => {
   });
 });
 
-test("classifies package manifests and GitHub Actions workflows", () => {
+test("classifies package manifests, the workspace catalog, and workflows", () => {
   assert.deepEqual(
     classifyChangedDependencyPaths({
       filenames: [
         "pnpm-lock.yaml",
         "apps/api/package.json",
         "package.json",
+        "pnpm-workspace.yaml",
         ".github/workflows/ci.yml",
         ".changeset/dependabot-pr-1225.md",
       ],
       pullRequestNumber: 1225,
     }),
     {
+      catalogPath: "pnpm-workspace.yaml",
       manifestPaths: ["apps/api/package.json", "package.json"],
       toolingPaths: [".github/workflows/ci.yml"],
     },
+  );
+});
+
+test("creates patch releases for runtime consumers of changed catalog entries", () => {
+  const catalogChanges = classifyCatalogDependencyUpdate({
+    after: [
+      "packages:",
+      '  - "apps/*"',
+      "catalog:",
+      '  "@hookform/resolvers": ^5.5.7',
+      '  "@swc/core": ^1.15.47',
+      "",
+    ].join("\n"),
+    before: [
+      "packages:",
+      '  - "apps/*"',
+      "catalog:",
+      '  "@hookform/resolvers": ^5.4.2',
+      '  "@swc/core": ^1.15.46',
+      "",
+    ].join("\n"),
+    workspaceManifests: [
+      {
+        dependencies: { "@hookform/resolvers": "catalog:" },
+        name: "@lootlog/web",
+      },
+      {
+        devDependencies: { "@swc/core": "catalog:" },
+        name: "@lootlog/gateway",
+      },
+    ],
+  });
+  const result = createDependabotChangeset({
+    catalogChanges,
+    changedManifests: [],
+    pullRequestNumber: 1237,
+  });
+
+  assert.deepEqual(catalogChanges, {
+    hasDevelopmentChanges: true,
+    runtimePackages: ["@lootlog/web"],
+  });
+  assert.match(result?.content ?? "", /"@lootlog\/web": patch/);
+  assert.doesNotMatch(result?.content ?? "", /"@lootlog\/gateway": patch/);
+});
+
+test("creates an empty changeset for development-only catalog updates", () => {
+  const catalogChanges = classifyCatalogDependencyUpdate({
+    after: ["catalog:", '  "@swc/core": ^1.15.47', ""].join("\n"),
+    before: ["catalog:", '  "@swc/core": ^1.15.46', ""].join("\n"),
+    workspaceManifests: [
+      {
+        devDependencies: { "@swc/core": "catalog:" },
+        name: "@lootlog/gateway",
+      },
+    ],
+  });
+  const result = createDependabotChangeset({
+    catalogChanges,
+    changedManifests: [],
+    pullRequestNumber: 1237,
+  });
+
+  assert.deepEqual(catalogChanges, {
+    hasDevelopmentChanges: true,
+    runtimePackages: [],
+  });
+  assert.match(
+    result?.content ?? "",
+    /Update development and tooling dependencies/,
+  );
+});
+
+test("rejects workspace changes outside catalog version entries", () => {
+  assert.throws(
+    () =>
+      classifyCatalogDependencyUpdate({
+        after: ["packages:", '  - "services/*"', "catalog:", ""].join("\n"),
+        before: ["packages:", '  - "apps/*"', "catalog:", ""].join("\n"),
+        workspaceManifests: [],
+      }),
+    /Cannot classify Dependabot changes/,
   );
 });
 


### PR DESCRIPTION
## Summary

- prevent automated CI dispatches from racing with existing pull request runs
- fix closed-PR cache cleanup by selecting the repository explicitly
- build Cloudflare release artifacts through Turbo with their workspace dependencies
- classify `pnpm-workspace.yaml` catalog updates for Dependabot changesets
- document the main-to-dev and version-PR-to-production delivery flow

## Root cause

The main-only delivery migration left several independent orchestration gaps. Automated version PRs could start duplicate CI runs sharing one concurrency group, cache cleanup invoked `gh` outside a checkout without an explicit repository, Cloudflare release jobs built applications without their workspace dependency graph, and Dependabot rejected central catalog updates as ambiguous.

## Impact

Feature PR merges continue to deploy affected services to development and update the single Changesets version PR. Merging that version PR still creates immutable release artifacts and waits for the protected `prod` approval. The change removes false-red workflow noise and makes release builds and dependency changesets consistent with the monorepo graph.

## Validation

- `node --test tools/ci/*.test.mjs tools/release/*.test.mjs apps/developer/server-handler.test.js` (34 tests)
- `pnpm format:check`
- `git diff --check`
- workflow YAML syntax validation
- Turbo dry-run build graphs for all five Cloudflare targets
- catalog classification against the dependency changes from Dependabot PR #1237

## Rollout notes

Do not merge release PR #1239 until this PR is merged and Changesets updates it to a new SHA. Production remains gated by the existing `prod` environment approval.