### PR TITLE
fix(ci): restore Cloudflare production promotion

### DIFF
--- a/.changeset/fix-cloudflare-frontend-release.md
+++ b/.changeset/fix-cloudflare-frontend-release.md
@@ -1,0 +1,6 @@
+---
+"@lootlog/game-client": patch
+"@lootlog/web": patch
+---
+
+Rebuild immutable frontend artifacts with reliable Cloudflare promotion handling.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,7 +396,12 @@ jobs:
             version="$(jq -r '.version' <<< "$item")"
             artifact_path="$(jq -r '.artifactPath' <<< "$item")"
             config_path="$(jq -r '.configPath // empty' <<< "$item")"
-            artifact_directory="$RUNNER_TEMP/cloudflare-artifacts/cloudflare-$project-$version-$GITHUB_SHA"
+            artifact_name="cloudflare-$project-$version-$GITHUB_SHA"
+            artifact_directory="$(
+              node tools/release/resolve-cloudflare-artifact-directory.mjs \
+                "$RUNNER_TEMP/cloudflare-artifacts" \
+                "$artifact_name"
+            )"
 
             (
               cd "$artifact_directory"

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Each released workspace owns its generated `CHANGELOG.md`. Use `pnpm changeset s
 
 Production images use both `prod-<semver>` and `sha-<release-commit>` tags and are never overwritten. To promote or roll back one service, run the **Promote an existing image to prod** workflow from `main` with the service and an existing semantic version. Rollbacks only change GitOps; they never rebuild an image.
 
+Cloudflare frontends use the same changeset, version PR, immutable artifact, and `prod` approval flow as backend services. They are not handled by the Docker image promotion workflow. A frontend production deployment always uses the checksummed artifact built by its release run; if no valid artifact exists, publish a new patch release instead of rebuilding an existing version.
+
 If an artifact matrix fails after versions have been created, use **Re-run failed jobs**. Do not rerun the entire workflow: successful immutable image jobs must not attempt to overwrite their existing tags.
 
 A successful deployment workflow means the GitOps change was accepted. ArgoCD remains the source of truth for the actual cluster rollout and health.

--- a/tools/release/resolve-cloudflare-artifact-directory.mjs
+++ b/tools/release/resolve-cloudflare-artifact-directory.mjs
@@ -1,0 +1,67 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const artifactFiles = [
+  "cloudflare-artifact.tar.gz",
+  "cloudflare-artifact.tar.gz.sha256",
+];
+
+async function containsArtifactFiles(directory) {
+  try {
+    await Promise.all(
+      artifactFiles.map((artifactFile) =>
+        access(path.join(directory, artifactFile)),
+      ),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveCloudflareArtifactDirectory(
+  downloadRoot,
+  artifactName,
+) {
+  const namedDirectory = path.join(downloadRoot, artifactName);
+  const [hasDirectArtifact, hasNamedArtifact] = await Promise.all([
+    containsArtifactFiles(downloadRoot),
+    containsArtifactFiles(namedDirectory),
+  ]);
+
+  if (hasDirectArtifact && hasNamedArtifact) {
+    throw new Error(
+      `Cloudflare artifact layout is ambiguous for ${artifactName}`,
+    );
+  }
+
+  if (hasNamedArtifact) {
+    return namedDirectory;
+  }
+
+  if (hasDirectArtifact) {
+    return downloadRoot;
+  }
+
+  throw new Error(
+    `Cloudflare artifact files were not found for ${artifactName}`,
+  );
+}
+
+const isCommandLineInvocation =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCommandLineInvocation) {
+  const [downloadRoot, artifactName] = process.argv.slice(2);
+
+  if (!downloadRoot || !artifactName) {
+    throw new Error(
+      "Usage: resolve-cloudflare-artifact-directory.mjs <download-root> <artifact-name>",
+    );
+  }
+
+  process.stdout.write(
+    await resolveCloudflareArtifactDirectory(downloadRoot, artifactName),
+  );
+}

--- a/tools/release/resolve-cloudflare-artifact-directory.test.mjs
+++ b/tools/release/resolve-cloudflare-artifact-directory.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveCloudflareArtifactDirectory } from "./resolve-cloudflare-artifact-directory.mjs";
+
+const artifactName = "cloudflare-lootlog-web-monorepo-1.2.4-0123456789abcdef";
+
+async function createArtifactFiles(directory) {
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "cloudflare-artifact.tar.gz"), "");
+  await writeFile(
+    path.join(directory, "cloudflare-artifact.tar.gz.sha256"),
+    "",
+  );
+}
+
+async function withTemporaryDirectory(callback) {
+  const directory = await mkdtemp(
+    path.join(tmpdir(), "cloudflare-artifact-test-"),
+  );
+
+  try {
+    await callback(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+test("resolves a single artifact extracted directly into the download root", async () => {
+  await withTemporaryDirectory(async (downloadRoot) => {
+    await createArtifactFiles(downloadRoot);
+
+    assert.equal(
+      await resolveCloudflareArtifactDirectory(downloadRoot, artifactName),
+      downloadRoot,
+    );
+  });
+});
+
+test("resolves an artifact extracted into its named directory", async () => {
+  await withTemporaryDirectory(async (downloadRoot) => {
+    const artifactDirectory = path.join(downloadRoot, artifactName);
+    await createArtifactFiles(artifactDirectory);
+
+    assert.equal(
+      await resolveCloudflareArtifactDirectory(downloadRoot, artifactName),
+      artifactDirectory,
+    );
+  });
+});
+
+test("rejects a missing artifact", async () => {
+  await withTemporaryDirectory(async (downloadRoot) => {
+    await assert.rejects(
+      resolveCloudflareArtifactDirectory(downloadRoot, artifactName),
+      /Cloudflare artifact files were not found/,
+    );
+  });
+});
+
+test("rejects an ambiguous direct and named artifact layout", async () => {
+  await withTemporaryDirectory(async (downloadRoot) => {
+    await createArtifactFiles(downloadRoot);
+    await createArtifactFiles(path.join(downloadRoot, artifactName));
+
+    await assert.rejects(
+      resolveCloudflareArtifactDirectory(downloadRoot, artifactName),
+      /Cloudflare artifact layout is ambiguous/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- resolve both single-artifact and multi-artifact layouts produced by `actions/download-artifact@v8`
- fail safely when Cloudflare artifacts are missing or the layout is ambiguous
- publish fresh patch releases for `@lootlog/web` and `@lootlog/game-client`
- document how frontend production deployments relate to the backend release flow

## Root cause

`actions/download-artifact@v8` extracts a single pattern match directly into the configured download path. The production job always expected an artifact-named child directory, so the checksum step could not locate the successfully built web artifact.

## Impact

Merging this PR only affects development and creates/updates the Changesets version PR. Production remains unchanged until the generated version PR is merged, both immutable Cloudflare artifacts build successfully, and the `prod` environment is approved.

## Validation

- `node --test tools/ci/*.test.mjs tools/release/*.test.mjs` (34/34 passing)
- `pnpm changeset status --verbose`
- `pnpm format:check`
- `git diff --check`
- release workflow YAML parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Improved Cloudflare frontend artifact handling during releases.
  * Releases now support artifacts extracted directly or into a named folder, with validation for missing or ambiguous files.
  * Added checksummed artifact requirements and documented the production approval workflow.
* **Documentation**
  * Documented when a new patch release is required for invalid or unavailable immutable artifacts.
* **Bug Fixes**
  * Improved reliability when promoting Cloudflare frontend releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->