### PR TITLE
refactor(ui): migrate Radix components to Base UI

### DIFF
--- a/.changeset/calm-pandas-migrate.md
+++ b/.changeset/calm-pandas-migrate.md
@@ -1,0 +1,8 @@
+---
+"@lootlog/ui": major
+"@lootlog/web": patch
+"@lootlog/wiki": patch
+"@lootlog/landing": patch
+---
+
+Migrate the shared UI primitives and their consumers from Radix UI and Vaul to Base UI while preserving the existing visual design.

--- a/apps/landing/src/components/landing/closing-cta.tsx
+++ b/apps/landing/src/components/landing/closing-cta.tsx
@@ -41,24 +41,28 @@ export function ClosingCta() {
             <Button
               size="lg"
               className="h-14 rounded-xl bg-[#07111f] px-6 text-base font-bold text-white shadow-[8px_12px_28px_rgba(67,19,15,0.2)] transition-[background-color,transform] hover:bg-[#10233f] motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#c8f135] focus-visible:ring-offset-4 focus-visible:ring-offset-[#ff665b]"
-              asChild
-            >
-              <a href={ADDON_URL} target="_blank" rel="noopener noreferrer">
-                <Download className="size-4" />
-                {t("landing.closingCta.install")}
-              </a>
-            </Button>
+
+              render={
+                <a href={ADDON_URL} target="_blank" rel="noopener noreferrer">
+                  <Download className="size-4" />
+                  {t("landing.closingCta.install")}
+                </a>
+              }
+              nativeButton={false}
+            />
             <Button
               size="lg"
               variant="outline"
               className="h-14 rounded-xl border-2 border-[#07111f] bg-transparent px-6 text-base font-bold text-[#07111f] transition-[background-color,color,transform] hover:bg-[#07111f] hover:text-white motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#c8f135] focus-visible:ring-offset-4 focus-visible:ring-offset-[#ff665b]"
-              asChild
-            >
-              <a href={links.docs}>
-                {t("landing.closingCta.guide")}
-                <ArrowUpRight className="size-4" />
-              </a>
-            </Button>
+
+              render={
+                <a href={links.docs}>
+                  {t("landing.closingCta.guide")}
+                  <ArrowUpRight className="size-4" />
+                </a>
+              }
+              nativeButton={false}
+            />
           </div>
         </div>
       </div>

--- a/apps/landing/src/components/landing/faq-panel.tsx
+++ b/apps/landing/src/components/landing/faq-panel.tsx
@@ -16,9 +16,7 @@ export function FaqPanel() {
   return (
     <div className="w-full">
       <Accordion
-        type="single"
-        collapsible
-        defaultValue="item-0"
+        defaultValue={["item-0"]}
         className="w-full border-t border-[#31425b]"
       >
         {faqKeys.map((key, index) => (

--- a/apps/landing/src/components/landing/header.tsx
+++ b/apps/landing/src/components/landing/header.tsx
@@ -109,16 +109,20 @@ export function LandingHeader() {
               size="sm"
               variant="outline"
               className="h-11 rounded-xl border-[#3b4d67] bg-transparent px-3 font-bold text-[#e6edf7] transition-[background-color,transform] hover:bg-[#14233a] hover:text-white motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#c8f135] focus-visible:ring-offset-4 focus-visible:ring-offset-[#07111f] md:hidden"
-              asChild
-            >
-              <a href={links.dashboard}>
-                <span className="sm:hidden">{t("landing.header.lootlog")}</span>
-                <span className="hidden sm:inline">
-                  {t("landing.header.goToLootlog")}
-                </span>
-                <ArrowUpRight className="size-3.5" />
-              </a>
-            </Button>
+
+              render={
+                <a href={links.dashboard}>
+                  <span className="sm:hidden">
+                    {t("landing.header.lootlog")}
+                  </span>
+                  <span className="hidden sm:inline">
+                    {t("landing.header.goToLootlog")}
+                  </span>
+                  <ArrowUpRight className="size-3.5" />
+                </a>
+              }
+              nativeButton={false}
+            />
           ) : (
             <Button
               size="sm"
@@ -144,31 +148,35 @@ export function LandingHeader() {
             size="sm"
             variant="outline"
             className="h-11 rounded-xl border-[#ff665b]/35 bg-[#ff665b]/10 px-3 font-bold text-[#ff9a92] transition-[background-color,color,transform] hover:border-[#ff665b]/55 hover:bg-[#ff665b]/20 hover:text-[#ffc1bc] motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#ff665b] focus-visible:ring-offset-4 focus-visible:ring-offset-[#07111f]"
-            asChild
-          >
-            <a
-              href={links.support}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={t("landing.header.support")}
-            >
-              <Heart className="size-4 fill-current" />
-              <span className="hidden sm:inline">
-                {t("landing.header.support")}
-              </span>
-            </a>
-          </Button>
+
+            render={
+              <a
+                href={links.support}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={t("landing.header.support")}
+              >
+                <Heart className="size-4 fill-current" />
+                <span className="hidden sm:inline">
+                  {t("landing.header.support")}
+                </span>
+              </a>
+            }
+            nativeButton={false}
+          />
 
           <Button
             size="sm"
             className="hidden h-11 rounded-xl bg-[#c8f135] px-4 font-bold text-[#07111f] shadow-none transition-[background-color,transform] hover:bg-[#d8ff5a] motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#35d3e4] focus-visible:ring-offset-4 focus-visible:ring-offset-[#07111f] md:inline-flex"
-            asChild
-          >
-            <a href={links.dashboard}>
-              {t("landing.header.goToLootlog")}
-              <ArrowUpRight className="size-4" />
-            </a>
-          </Button>
+
+            render={
+              <a href={links.dashboard}>
+                {t("landing.header.goToLootlog")}
+                <ArrowUpRight className="size-4" />
+              </a>
+            }
+            nativeButton={false}
+          />
         </div>
       </div>
 

--- a/apps/landing/src/components/landing/hero-section.tsx
+++ b/apps/landing/src/components/landing/hero-section.tsx
@@ -51,23 +51,27 @@ export function HeroSection() {
             <Button
               size="lg"
               className="h-14 rounded-xl bg-[#f7f8f2] px-6 text-base font-bold text-[#07111f] shadow-[8px_12px_28px_rgba(0,0,0,0.24)] transition-[background-color,transform] hover:bg-white motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#c8f135] focus-visible:ring-offset-4 focus-visible:ring-offset-[#07111f]"
-              asChild
-            >
-              <a href={ADDON_URL} target="_blank" rel="noopener noreferrer">
-                <Download className="size-4" />
-                {t("landing.hero.installAddon")}
-              </a>
-            </Button>
+
+              render={
+                <a href={ADDON_URL} target="_blank" rel="noopener noreferrer">
+                  <Download className="size-4" />
+                  {t("landing.hero.installAddon")}
+                </a>
+              }
+              nativeButton={false}
+            />
             <Button
               size="lg"
               className="h-14 rounded-xl bg-[#3157f6] px-6 text-base font-bold text-white shadow-[8px_12px_28px_rgba(0,0,0,0.2)] transition-[background-color,transform] hover:bg-[#4168ff] motion-safe:hover:-translate-y-0.5 motion-safe:active:translate-y-0 focus-visible:ring-2 focus-visible:ring-[#35d3e4] focus-visible:ring-offset-4 focus-visible:ring-offset-[#07111f]"
-              asChild
-            >
-              <a href={links.dashboard}>
-                {t("landing.hero.openDashboard")}
-                <ArrowUpRight className="size-4" />
-              </a>
-            </Button>
+
+              render={
+                <a href={links.dashboard}>
+                  {t("landing.hero.openDashboard")}
+                  <ArrowUpRight className="size-4" />
+                </a>
+              }
+              nativeButton={false}
+            />
           </div>
 
           <p className="mt-5 text-sm leading-6 text-[#91a4bf] sm:mt-6">

--- a/apps/web/src/components/battle/battle-metadata.tsx
+++ b/apps/web/src/components/battle/battle-metadata.tsx
@@ -50,50 +50,58 @@ export const BattleMetadata: FC<BattleMetadataProps> = ({
         )}
       >
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-2 cursor-help whitespace-nowrap">
-              <Calendar size="14" />
-              {battle && format(battle.createdAt, "dd.MM.yyyy HH:mm")}
-            </div>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div className="flex items-center gap-2 cursor-help whitespace-nowrap">
+                <Calendar size="14" />
+                {battle && format(battle.createdAt, "dd.MM.yyyy HH:mm")}
+              </div>
+            }
+          />
           <TooltipContent side="top" sideOffset={8}>
             <p>{t("battleUi.metadata.startTime")}</p>
           </TooltipContent>
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
-              <Clock size="14" />
-              {formatSeconds(battle.duration)}
-            </div>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
+                <Clock size="14" />
+                {formatSeconds(battle.duration)}
+              </div>
+            }
+          />
           <TooltipContent side="top" sideOffset={8}>
             <p>{t("battleUi.metadata.duration")}</p>
           </TooltipContent>
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
-              <Users size="14" />
-              {battle.type}
-            </div>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
+                <Users size="14" />
+                {battle.type}
+              </div>
+            }
+          />
           <TooltipContent side="top" sideOffset={8}>
             <p>{t("battleUi.metadata.battleType")}</p>
           </TooltipContent>
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
-              {battle.public ? <Unlock size="14" /> : <Lock size="14" />}
-              {battle.public
-                ? t("battleUi.metadata.public")
-                : t("battleUi.metadata.private")}
-            </div>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
+                {battle.public ? <Unlock size="14" /> : <Lock size="14" />}
+                {battle.public
+                  ? t("battleUi.metadata.public")
+                  : t("battleUi.metadata.private")}
+              </div>
+            }
+          />
           <TooltipContent side="top" sideOffset={8}>
             <p>
               {battle.public
@@ -104,11 +112,13 @@ export const BattleMetadata: FC<BattleMetadataProps> = ({
         </Tooltip>
 
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
-              <Earth size={14} /> {capitalizeFirstLetter(battle.world)}
-            </div>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
+                <Earth size={14} /> {capitalizeFirstLetter(battle.world)}
+              </div>
+            }
+          />
           <TooltipContent side="top" sideOffset={8}>
             <p>{t("battleUi.metadata.world")}</p>
           </TooltipContent>
@@ -116,14 +126,16 @@ export const BattleMetadata: FC<BattleMetadataProps> = ({
 
         {warrior?.ph !== 0 && warrior?.ph !== undefined && (
           <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
-                <Award size={14} />{" "}
-                {t("battleUi.metadata.honorPointsLabel", {
-                  value: warrior?.ph,
-                })}
-              </div>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
+                  <Award size={14} />{" "}
+                  {t("battleUi.metadata.honorPointsLabel", {
+                    value: warrior?.ph,
+                  })}
+                </div>
+              }
+            />
             <TooltipContent side="top" sideOffset={8}>
               <p>{t("battleUi.metadata.honorPointsTooltip")}</p>
             </TooltipContent>
@@ -132,11 +144,13 @@ export const BattleMetadata: FC<BattleMetadataProps> = ({
 
         {battle.hasFlee && (
           <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
-                <EmergencyExitIcon size={14} /> {t("battleUi.metadata.flee")}
-              </div>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <div className="flex items-center gap-1 cursor-help whitespace-nowrap">
+                  <EmergencyExitIcon size={14} /> {t("battleUi.metadata.flee")}
+                </div>
+              }
+            />
             <TooltipContent side="top" sideOffset={8}>
               <p>{t("battleUi.metadata.fleeTooltip")}</p>
             </TooltipContent>
@@ -145,16 +159,18 @@ export const BattleMetadata: FC<BattleMetadataProps> = ({
 
         {battle.matchmaking && (
           <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className={cn(
-                  "flex items-center gap-1 cursor-help whitespace-nowrap",
-                  BATTLE_TEXT_COLORS.metric.secondary,
-                )}
-              >
-                <Swords size={14} /> {t("battleUi.metadata.matchmaking")}
-              </div>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <div
+                  className={cn(
+                    "flex items-center gap-1 cursor-help whitespace-nowrap",
+                    BATTLE_TEXT_COLORS.metric.secondary,
+                  )}
+                >
+                  <Swords size={14} /> {t("battleUi.metadata.matchmaking")}
+                </div>
+              }
+            />
             <TooltipContent side="top" sideOffset={8}>
               <p>{t("battleUi.metadata.matchmakingTooltip")}</p>
             </TooltipContent>

--- a/apps/web/src/components/battle/battle-overview-header.tsx
+++ b/apps/web/src/components/battle/battle-overview-header.tsx
@@ -71,11 +71,13 @@ export const BattleOverviewHeader: FC<BattleOverviewHeaderProps> = ({
                 </Button>
               )}
               <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button variant="destructive" disabled={isPending}>
-                    {t("battleUi.overviewHeader.delete")}
-                  </Button>
-                </AlertDialogTrigger>
+                <AlertDialogTrigger
+                  render={
+                    <Button variant="destructive" disabled={isPending}>
+                      {t("battleUi.overviewHeader.delete")}
+                    </Button>
+                  }
+                />
                 <AlertDialogContent>
                   <AlertDialogHeader>
                     <AlertDialogTitle>
@@ -89,11 +91,13 @@ export const BattleOverviewHeader: FC<BattleOverviewHeaderProps> = ({
                     <AlertDialogCancel>
                       {t("battleUi.overviewHeader.cancel")}
                     </AlertDialogCancel>
-                    <AlertDialogAction asChild>
-                      <Button variant="destructive" onClick={onDeleteClick}>
-                        {t("battleUi.overviewHeader.deleteBattle")}
-                      </Button>
-                    </AlertDialogAction>
+                    <AlertDialogAction
+                      render={
+                        <Button variant="destructive" onClick={onDeleteClick}>
+                          {t("battleUi.overviewHeader.deleteBattle")}
+                        </Button>
+                      }
+                    />
                   </AlertDialogFooter>
                 </AlertDialogContent>
               </AlertDialog>

--- a/apps/web/src/components/battle/one-vs-one-stats-table.tsx
+++ b/apps/web/src/components/battle/one-vs-one-stats-table.tsx
@@ -329,25 +329,27 @@ export function OneVsOneStatsTable({
                 />
                 {compact ? (
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={() => setHideZeros(!hideZeros)}
-                        aria-label={
-                          hideZeros
-                            ? t("battlePanel.single.statistics.showAll")
-                            : t("battlePanel.single.statistics.hideZeros")
-                        }
-                        className="size-8"
-                      >
-                        {hideZeros ? (
-                          <Eye className="h-4 w-4" />
-                        ) : (
-                          <EyeOff className="h-4 w-4" />
-                        )}
-                      </Button>
-                    </TooltipTrigger>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setHideZeros(!hideZeros)}
+                          aria-label={
+                            hideZeros
+                              ? t("battlePanel.single.statistics.showAll")
+                              : t("battlePanel.single.statistics.hideZeros")
+                          }
+                          className="size-8"
+                        >
+                          {hideZeros ? (
+                            <Eye className="h-4 w-4" />
+                          ) : (
+                            <EyeOff className="h-4 w-4" />
+                          )}
+                        </Button>
+                      }
+                    />
                     <TooltipContent>
                       {hideZeros
                         ? t("battlePanel.single.statistics.showAll")

--- a/apps/web/src/components/battle/player-tile.tsx
+++ b/apps/web/src/components/battle/player-tile.tsx
@@ -30,20 +30,22 @@ export const PlayerTile: FC<PlayerTileProps> = ({
   cdnBaseUrl = MARGONEM_CDN_CHARACTERS_URL,
 }) => {
   return (
-    <TooltipProvider key={id}>
-      <Tooltip delayDuration={100}>
-        <TooltipTrigger asChild>
-          <PlayerSpriteTile
-            icon={icon}
-            idx={idx}
-            color={color}
-            className={className}
-            cdnBaseUrl={cdnBaseUrl}
-            wrapperClassName="relative ring-0 outline-none"
-            tileClassName="bg-transparent transition-none hover:bg-transparent"
-            defaultBadgeColor="transparent"
-          />
-        </TooltipTrigger>
+    <TooltipProvider key={id} delay={100}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <PlayerSpriteTile
+              icon={icon}
+              idx={idx}
+              color={color}
+              className={className}
+              cdnBaseUrl={cdnBaseUrl}
+              wrapperClassName="relative ring-0 outline-none"
+              tileClassName="bg-transparent transition-none hover:bg-transparent"
+              defaultBadgeColor="transparent"
+            />
+          }
+        />
         <TooltipContent>
           <p>
             {name}

--- a/apps/web/src/components/battle/stats-customization/stats-customization-modal.tsx
+++ b/apps/web/src/components/battle/stats-customization/stats-customization-modal.tsx
@@ -102,13 +102,11 @@ export const StatsCustomizationModal = ({
     <Dialog open={open} onOpenChange={setOpen}>
       {compactTrigger ? (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <DialogTrigger asChild>{triggerButton}</DialogTrigger>
-          </TooltipTrigger>
+          <TooltipTrigger render={<DialogTrigger render={triggerButton} />} />
           <TooltipContent>{triggerLabel}</TooltipContent>
         </Tooltip>
       ) : (
-        <DialogTrigger asChild>{triggerButton}</DialogTrigger>
+        <DialogTrigger render={triggerButton} />
       )}
       <DialogContent className="max-sm:w-screen max-sm:h-dvh max-sm:max-w-none max-sm:rounded-none sm:max-w-2xl sm:h-[80vh] flex flex-col overflow-hidden">
         <DialogHeader className="flex-shrink-0 py-4">

--- a/apps/web/src/components/dev/dev-permission-override-panel.tsx
+++ b/apps/web/src/components/dev/dev-permission-override-panel.tsx
@@ -70,14 +70,16 @@ export const DevPermissionOverridePanel = ({ guildId }: Props) => {
 
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        <button
-          className="w-full rounded-md border border-border/70 bg-background/80 px-2 py-1.5 text-left text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
-          type="button"
-        >
-          {t("common.devPermissionOverride.trigger")}
-        </button>
-      </PopoverTrigger>
+      <PopoverTrigger
+        render={
+          <button
+            className="w-full rounded-md border border-border/70 bg-background/80 px-2 py-1.5 text-left text-xs font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+            type="button"
+          >
+            {t("common.devPermissionOverride.trigger")}
+          </button>
+        }
+      />
 
       <PopoverContent
         align="start"

--- a/apps/web/src/components/filters/character-selector.tsx
+++ b/apps/web/src/components/filters/character-selector.tsx
@@ -43,21 +43,23 @@ export function CharacterSelector({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          size={size}
-          className={cn("gap-2", className)}
-        >
-          <User className="h-4 w-4" />
-          {selectedCharacter
-            ? `${selectedCharacter.name} (${selectedCharacter.world})`
-            : allowAllCharacters
-              ? t("ui.characterSelector.allCharacters")
-              : t("ui.characterSelector.selectCharacter")}
-          <ChevronsUpDown className="h-4 w-4 opacity-50" />
-        </Button>
-      </PopoverTrigger>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            size={size}
+            className={cn("gap-2", className)}
+          >
+            <User className="h-4 w-4" />
+            {selectedCharacter
+              ? `${selectedCharacter.name} (${selectedCharacter.world})`
+              : allowAllCharacters
+                ? t("ui.characterSelector.allCharacters")
+                : t("ui.characterSelector.selectCharacter")}
+            <ChevronsUpDown className="h-4 w-4 opacity-50" />
+          </Button>
+        }
+      />
       <PopoverContent className="w-[250px] p-0">
         <Command>
           <CommandInput

--- a/apps/web/src/components/filters/mobile-filters-drawer.tsx
+++ b/apps/web/src/components/filters/mobile-filters-drawer.tsx
@@ -31,16 +31,18 @@ export const MobileFiltersDrawer = ({
   const iconClassName = trigger === "floating" ? "h-5 w-5" : "h-4 w-4";
 
   return (
-    <Drawer shouldScaleBackground={false}>
-      <DrawerTrigger asChild>
-        <Button
-          variant={trigger === "inline" ? "outline" : undefined}
-          size="icon"
-          className={triggerClassName}
-        >
-          <Filter className={iconClassName} />
-        </Button>
-      </DrawerTrigger>
+    <Drawer>
+      <DrawerTrigger
+        render={
+          <Button
+            variant={trigger === "inline" ? "outline" : undefined}
+            size="icon"
+            className={triggerClassName}
+          >
+            <Filter className={iconClassName} />
+          </Button>
+        }
+      />
       <DrawerContent className="flex max-h-[85vh] flex-col p-4">
         <DrawerHeader className="mb-4 shrink-0">
           <DrawerTitle>{title}</DrawerTitle>
@@ -49,11 +51,13 @@ export const MobileFiltersDrawer = ({
           <div className="space-y-4 pr-2">{children}</div>
         </ScrollArea>
         <div className="mt-6 shrink-0">
-          <DrawerClose asChild>
-            <Button variant="outline" className="w-full">
-              {closeLabel}
-            </Button>
-          </DrawerClose>
+          <DrawerClose
+            render={
+              <Button variant="outline" className="w-full">
+                {closeLabel}
+              </Button>
+            }
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/components/filters/warrior-search-filter.tsx
+++ b/apps/web/src/components/filters/warrior-search-filter.tsx
@@ -69,27 +69,32 @@ export const WarriorSearchFilter = ({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-controls={resultsListId}
-          aria-expanded={open}
-          className={cn("flex-1 min-w-[200px] justify-between h-10", className)}
-        >
-          <div className="flex items-center gap-2">
-            <Search className="h-4 w-4" />
-            <span className="text-sm">
-              {selectedWarriors.length > 0
-                ? t("ui.warriorSearch.selectedCount", {
-                    count: selectedWarriors.length,
-                  })
-                : (placeholder ?? t("ui.warriorSearch.defaultPlaceholder"))}
-            </span>
-          </div>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-controls={resultsListId}
+            aria-expanded={open}
+            className={cn(
+              "flex-1 min-w-[200px] justify-between h-10",
+              className,
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Search className="h-4 w-4" />
+              <span className="text-sm">
+                {selectedWarriors.length > 0
+                  ? t("ui.warriorSearch.selectedCount", {
+                      count: selectedWarriors.length,
+                    })
+                  : (placeholder ?? t("ui.warriorSearch.defaultPlaceholder"))}
+              </span>
+            </div>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        }
+      />
       <PopoverContent className="w-[300px] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInput

--- a/apps/web/src/components/layout/event-timers-list.tsx
+++ b/apps/web/src/components/layout/event-timers-list.tsx
@@ -70,38 +70,40 @@ const TimerItem: FC<TimerItemProps> = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Link
-          to="/$guildId/events/$eventId/heroes/$heroId"
-          params={{
-            guildId,
-            eventId,
-            heroId: timer.heroId ?? "",
-          }}
-          onClick={onNavigate}
-          className="group block"
-        >
-          <div className="flex items-center gap-2 px-2 py-1 rounded transition-[background-color,transform] duration-200 hover:translate-x-0.5 hover:bg-yellow-500/10">
-            <Clock
-              className={cn(
-                "h-3 w-3 shrink-0",
-                isCloseToRespawn ? "text-orange-400" : "text-green-400",
-              )}
-            />
-            <span className="text-xs truncate flex-1 text-muted-foreground">
-              {timer.npc.name}
-            </span>
-            <span
-              className={cn(
-                "text-xs font-mono font-medium",
-                isCloseToRespawn ? "text-orange-400" : "text-green-400",
-              )}
-            >
-              {parseMsToTime(timeLeftMilliseconds)}
-            </span>
-          </div>
-        </Link>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <Link
+            to="/$guildId/events/$eventId/heroes/$heroId"
+            params={{
+              guildId,
+              eventId,
+              heroId: timer.heroId ?? "",
+            }}
+            onClick={onNavigate}
+            className="group block"
+          >
+            <div className="flex items-center gap-2 px-2 py-1 rounded transition-[background-color,transform] duration-200 hover:translate-x-0.5 hover:bg-yellow-500/10">
+              <Clock
+                className={cn(
+                  "h-3 w-3 shrink-0",
+                  isCloseToRespawn ? "text-orange-400" : "text-green-400",
+                )}
+              />
+              <span className="text-xs truncate flex-1 text-muted-foreground">
+                {timer.npc.name}
+              </span>
+              <span
+                className={cn(
+                  "text-xs font-mono font-medium",
+                  isCloseToRespawn ? "text-orange-400" : "text-green-400",
+                )}
+              >
+                {parseMsToTime(timeLeftMilliseconds)}
+              </span>
+            </div>
+          </Link>
+        }
+      />
       <TooltipContent side="right" className="text-xs">
         <p className="font-medium">{timer.npc.name}</p>
         <p className="text-muted-foreground">

--- a/apps/web/src/components/layout/guild-nav-create.tsx
+++ b/apps/web/src/components/layout/guild-nav-create.tsx
@@ -17,15 +17,17 @@ export const GuildNavCreate: FC = () => {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          className="size-11 0"
-          variant="secondary"
-          onClick={() => dispatch({ type: "OPEN" })}
-        >
-          <PlusCircleIcon />
-        </Button>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <Button
+            className="size-11 0"
+            variant="secondary"
+            onClick={() => dispatch({ type: "OPEN" })}
+          >
+            <PlusCircleIcon />
+          </Button>
+        }
+      />
       <TooltipContent side="right">
         {t("ui.tooltips.createLootlog")}
       </TooltipContent>

--- a/apps/web/src/components/layout/guild-nav-item.tsx
+++ b/apps/web/src/components/layout/guild-nav-item.tsx
@@ -85,53 +85,57 @@ export const GuildNavItem: FC<GuildNavItemProps> = ({
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <div>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="relative mb-2 flex w-full items-center justify-center">
-                {isActive && !isRukiaTheme && (
-                  <div className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_6px_var(--primary)/0.4]" />
-                )}
-                <Link
-                  to={`/${guild.vanityUrl ?? guild.id}` as string}
-                  draggable={false}
-                  className="group/guild-item isolate block relative"
-                  onClick={handleClick}
-                  style={{ pointerEvents: isDragging ? "none" : "auto" }}
-                >
-                  <ThemeCircularFrame isActive={isActive}>
-                    {avatarElement}
-                  </ThemeCircularFrame>
-                  {isHidden ? (
-                    <EyeOff
-                      aria-hidden
-                      className="pointer-events-none absolute -bottom-1 -right-1 z-20 size-4 rounded-full border border-sidebar-border bg-sidebar p-0.5 text-muted-foreground"
-                    />
-                  ) : null}
-                  {unreadLootsCount > 0 && !isActive && (
-                    <Badge className="absolute -right-2 -top-2 z-20 h-5 min-w-5 justify-center px-1.5 text-[10px] leading-none shadow-md">
-                      {unreadLootsCount > 99
-                        ? t("layout.guildsSelector.unreadLootsOverflow")
-                        : unreadLootsCount}
-                    </Badge>
-                  )}
-                </Link>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="right" className="font-medium">
-              <div>{guild.name}</div>
-              {isHidden ? (
-                <div className="text-xs font-normal text-muted-foreground">
-                  {t("settings.servers.hiddenInGameClient")}
-                </div>
-              ) : null}
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </ContextMenuTrigger>
+      <ContextMenuTrigger
+        render={
+          <div>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <div className="relative mb-2 flex w-full items-center justify-center">
+                    {isActive && !isRukiaTheme && (
+                      <div className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_6px_var(--primary)/0.4]" />
+                    )}
+                    <Link
+                      to={`/${guild.vanityUrl ?? guild.id}` as string}
+                      draggable={false}
+                      className="group/guild-item isolate block relative"
+                      onClick={handleClick}
+                      style={{ pointerEvents: isDragging ? "none" : "auto" }}
+                    >
+                      <ThemeCircularFrame isActive={isActive}>
+                        {avatarElement}
+                      </ThemeCircularFrame>
+                      {isHidden ? (
+                        <EyeOff
+                          aria-hidden
+                          className="pointer-events-none absolute -bottom-1 -right-1 z-20 size-4 rounded-full border border-sidebar-border bg-sidebar p-0.5 text-muted-foreground"
+                        />
+                      ) : null}
+                      {unreadLootsCount > 0 && !isActive && (
+                        <Badge className="absolute -right-2 -top-2 z-20 h-5 min-w-5 justify-center px-1.5 text-[10px] leading-none shadow-md">
+                          {unreadLootsCount > 99
+                            ? t("layout.guildsSelector.unreadLootsOverflow")
+                            : unreadLootsCount}
+                        </Badge>
+                      )}
+                    </Link>
+                  </div>
+                }
+              />
+              <TooltipContent side="right" className="font-medium">
+                <div>{guild.name}</div>
+                {isHidden ? (
+                  <div className="text-xs font-normal text-muted-foreground">
+                    {t("settings.servers.hiddenInGameClient")}
+                  </div>
+                ) : null}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        }
+      />
       <ContextMenuContent>
-        <ContextMenuItem onSelect={onToggleHidden}>
+        <ContextMenuItem onClick={onToggleHidden}>
           {isHidden ? (
             <Eye className="mr-2 size-4" />
           ) : (

--- a/apps/web/src/components/layout/guild-sidebar-header.tsx
+++ b/apps/web/src/components/layout/guild-sidebar-header.tsx
@@ -158,26 +158,28 @@ export const GuildSidebarHeader = ({ guildId }: { guildId?: string }) => {
         </AnimatePresence>
       </div>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <span tabIndex={0}>
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label={canTriggerRefreshText}
-              className="size-8 border-primary/30 bg-primary/10 text-primary shadow-sm hover:border-primary/60 hover:bg-primary/15 disabled:border-border disabled:bg-muted/40 disabled:text-muted-foreground disabled:opacity-100"
-              onClick={handleRefreshPermissions}
-              disabled={!canTriggerRefresh || refreshMember.isPending}
-            >
-              <RefreshCcw
-                aria-hidden="true"
-                className={cn(
-                  "size-4",
-                  refreshMember.isPending && "animate-spin text-primary",
-                )}
-              />
-            </Button>
-          </span>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <span tabIndex={0}>
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label={canTriggerRefreshText}
+                className="size-8 border-primary/30 bg-primary/10 text-primary shadow-sm hover:border-primary/60 hover:bg-primary/15 disabled:border-border disabled:bg-muted/40 disabled:text-muted-foreground disabled:opacity-100"
+                onClick={handleRefreshPermissions}
+                disabled={!canTriggerRefresh || refreshMember.isPending}
+              >
+                <RefreshCcw
+                  aria-hidden="true"
+                  className={cn(
+                    "size-4",
+                    refreshMember.isPending && "animate-spin text-primary",
+                  )}
+                />
+              </Button>
+            </span>
+          }
+        />
         <TooltipContent className="z-50 mt-4">
           {canTriggerRefreshText}
         </TooltipContent>

--- a/apps/web/src/components/layout/install-button.tsx
+++ b/apps/web/src/components/layout/install-button.tsx
@@ -17,15 +17,17 @@ export const InstallButton: FC = () => {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          className="size-11"
-          onClick={() => dispatch({ type: "OPEN" })}
-        >
-          <Blocks color="#3E8667" className="!size-6" />
-        </Button>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <Button
+            variant="ghost"
+            className="size-11"
+            onClick={() => dispatch({ type: "OPEN" })}
+          >
+            <Blocks color="#3E8667" className="!size-6" />
+          </Button>
+        }
+      />
       <TooltipContent side="right">
         {t("ui.tooltips.installAddon")}
       </TooltipContent>

--- a/apps/web/src/components/layout/user-menu.tsx
+++ b/apps/web/src/components/layout/user-menu.tsx
@@ -48,38 +48,40 @@ export const UserMenu = () => {
       )}
       {user && !isPending && (
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              className="group flex h-full w-full cursor-pointer items-center gap-2.5 pl-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset data-[state=open]:bg-sidebar-accent/45"
-            >
-              <div className="relative shrink-0">
-                <Avatar className="size-8 rounded-full ring-1 ring-sidebar-border transition-[box-shadow] group-hover:ring-primary/45">
-                  <AvatarImage src={user.image ?? undefined} />
-                  <AvatarFallback>
-                    <User2 className="h-4 w-4" />
-                  </AvatarFallback>
-                </Avatar>
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
-                <span className="text-[11px] font-medium leading-none text-sidebar-foreground/55">
-                  {t("layout.userMenu.account")}
+          <DropdownMenuTrigger
+            render={
+              <button
+                type="button"
+                className="group flex h-full w-full cursor-pointer items-center gap-2.5 pl-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset data-[state=open]:bg-sidebar-accent/45"
+              >
+                <div className="relative shrink-0">
+                  <Avatar className="size-8 rounded-full ring-1 ring-sidebar-border transition-[box-shadow] group-hover:ring-primary/45">
+                    <AvatarImage src={user.image ?? undefined} />
+                    <AvatarFallback>
+                      <User2 className="h-4 w-4" />
+                    </AvatarFallback>
+                  </Avatar>
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+                  <span className="text-[11px] font-medium leading-none text-sidebar-foreground/55">
+                    {t("layout.userMenu.account")}
+                  </span>
+                  <span className="max-w-full truncate text-sm font-bold leading-none">
+                    {user.name}
+                  </span>
+                </div>
+                <span className="flex h-8 w-12 shrink-0 items-center justify-center border-l border-sidebar-border text-sidebar-foreground/55 transition-colors group-hover:text-sidebar-foreground">
+                  <ChevronUp className="size-4 transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none" />
                 </span>
-                <span className="max-w-full truncate text-sm font-bold leading-none">
-                  {user.name}
-                </span>
-              </div>
-              <span className="flex h-8 w-12 shrink-0 items-center justify-center border-l border-sidebar-border text-sidebar-foreground/55 transition-colors group-hover:text-sidebar-foreground">
-                <ChevronUp className="size-4 transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none" />
-              </span>
-            </button>
-          </DropdownMenuTrigger>
+              </button>
+            }
+          />
           <DropdownMenuContent
             align="start"
             alignOffset={8}
             side="top"
             sideOffset={10}
-            className="w-[calc(var(--radix-dropdown-menu-trigger-width)-1rem)] min-w-64 overflow-hidden rounded-xl border-border bg-popover p-0 shadow-[0_14px_34px_-18px_rgba(0,0,0,0.65)]"
+            className="w-[calc(var(--anchor-width)-1rem)] min-w-64 overflow-hidden rounded-xl border-border bg-popover p-0 shadow-[0_14px_34px_-18px_rgba(0,0,0,0.65)]"
           >
             <div className="px-3 py-2.5">
               <div className="flex items-center gap-3">
@@ -104,14 +106,14 @@ export const UserMenu = () => {
             <DropdownMenuSeparator className="m-0" />
             <div className="p-1.5">
               <DropdownMenuItem
-                onSelect={handleOpenAccountSettings}
+                onClick={handleOpenAccountSettings}
                 className="rounded-lg px-2.5 py-2"
               >
                 <Settings className="size-4" />
                 <span>{t("layout.navigation.settings")}</span>
               </DropdownMenuItem>
               <DropdownMenuItem
-                onSelect={logout}
+                onClick={logout}
                 className="rounded-lg px-2.5 py-2"
               >
                 <LogOut className="size-4" />

--- a/apps/web/src/components/layout/user-nav-item.tsx
+++ b/apps/web/src/components/layout/user-nav-item.tsx
@@ -42,22 +42,24 @@ export const UserNavItem = () => {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="relative h-10 flex items-center justify-center">
-          {isActive && !isRukiaTheme && (
-            <div className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_6px_var(--primary)/0.4]" />
-          )}
-          <Link
-            to={ROUTES.user.dashboard}
-            className="block"
-            onClick={handleClick}
-          >
-            <ThemeCircularFrame isActive={isActive}>
-              {avatarElement}
-            </ThemeCircularFrame>
-          </Link>
-        </div>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <div className="relative h-10 flex items-center justify-center">
+            {isActive && !isRukiaTheme && (
+              <div className="absolute left-0 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_6px_var(--primary)/0.4]" />
+            )}
+            <Link
+              to={ROUTES.user.dashboard}
+              className="block"
+              onClick={handleClick}
+            >
+              <ThemeCircularFrame isActive={isActive}>
+                {avatarElement}
+              </ThemeCircularFrame>
+            </Link>
+          </div>
+        }
+      />
       <TooltipContent side="right">{data?.user.name}</TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/components/tiles/player-tile.tsx
+++ b/apps/web/src/components/tiles/player-tile.tsx
@@ -12,6 +12,7 @@ import { useSharedTooltip } from "@lootlog/ui/components/shared-tooltip-provider
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@lootlog/ui/components/tooltip";
 import { cn } from "@lootlog/ui/lib/utils";
@@ -119,16 +120,18 @@ export const PlayerTile: FC<PlayerTileProps> = ({
 
   if (!sharedTooltip) {
     playerTrigger = (
-      <Tooltip delayDuration={100}>
-        <TooltipTrigger asChild>{triggerElement}</TooltipTrigger>
-        <TooltipContent className="border-border/50 bg-popover/95">
-          <PlayerTooltipContent
-            name={name}
-            lvl={lvl ?? undefined}
-            prof={prof ?? undefined}
-          />
-        </TooltipContent>
-      </Tooltip>
+      <TooltipProvider delay={100}>
+        <Tooltip>
+          <TooltipTrigger render={triggerElement} />
+          <TooltipContent className="border-border/50 bg-popover/95">
+            <PlayerTooltipContent
+              name={name}
+              lvl={lvl ?? undefined}
+              prof={prof ?? undefined}
+            />
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 
@@ -138,24 +141,26 @@ export const PlayerTile: FC<PlayerTileProps> = ({
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <span
-          className={cn(
-            "inline-flex cursor-context-menu rounded-lg outline-none",
-            !highlighted &&
-              "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-          )}
-          tabIndex={0}
-          aria-label={t("loots.list.playerActions.label", { name })}
-          onClick={(event) => event.stopPropagation()}
-        >
-          {playerTrigger}
-        </span>
-      </ContextMenuTrigger>
+      <ContextMenuTrigger
+        render={
+          <span
+            className={cn(
+              "inline-flex cursor-context-menu rounded-lg outline-none",
+              !highlighted &&
+                "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            )}
+            tabIndex={0}
+            aria-label={t("loots.list.playerActions.label", { name })}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {playerTrigger}
+          </span>
+        }
+      />
       <ContextMenuContent className="min-w-56 rounded-xl border-border bg-popover p-1.5 shadow-xl">
         <ContextMenuItem
           className="h-9 cursor-pointer gap-2 rounded-lg px-2.5"
-          onSelect={onShowLoots}
+          onClick={onShowLoots}
         >
           <ListFilter className="size-4 text-primary" />
           {t("loots.list.playerActions.showLoots")}
@@ -163,7 +168,7 @@ export const PlayerTile: FC<PlayerTileProps> = ({
         <ContextMenuItem
           className="h-9 cursor-pointer gap-2 rounded-lg px-2.5"
           disabled={!profileUrl}
-          onSelect={() => {
+          onClick={() => {
             if (profileUrl) {
               window.open(profileUrl, "_blank", "noopener,noreferrer");
             }

--- a/apps/web/src/components/tiles/watchable-item-tile.tsx
+++ b/apps/web/src/components/tiles/watchable-item-tile.tsx
@@ -197,44 +197,46 @@ export const WatchableItemTile = ({
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <span
-          className={cn(
-            "relative inline-flex rounded-lg transition-[opacity,filter] duration-200",
-            hasItemFilter && !isItemSelected && "opacity-35 grayscale-[0.45]",
-          )}
-          tabIndex={0}
-          role="button"
-        >
-          <ItemTile
-            item={item}
-            color={color}
-            shareIndex={shareIndex}
-            shareNickname={shareNickname}
-          />
-          {hasItemFilter && isItemSelected ? (
-            <span
-              aria-hidden="true"
-              className="pointer-events-none absolute -left-1 -top-1 z-10 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm ring-2 ring-background"
-            >
-              <Check className="size-2.5" />
-            </span>
-          ) : null}
-          {isWatchedInScope ? (
-            <span
-              aria-hidden="true"
-              title={t("settings.userNotifications.quickAdd.indicatorLabel")}
-              className="pointer-events-none absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-emerald-500 text-background shadow-sm ring-2 ring-background"
-            >
-              <Bell className="size-2.5" />
-            </span>
-          ) : null}
-        </span>
-      </ContextMenuTrigger>
+      <ContextMenuTrigger
+        render={
+          <span
+            className={cn(
+              "relative inline-flex rounded-lg transition-[opacity,filter] duration-200",
+              hasItemFilter && !isItemSelected && "opacity-35 grayscale-[0.45]",
+            )}
+            tabIndex={0}
+            role="button"
+          >
+            <ItemTile
+              item={item}
+              color={color}
+              shareIndex={shareIndex}
+              shareNickname={shareNickname}
+            />
+            {hasItemFilter && isItemSelected ? (
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute -left-1 -top-1 z-10 flex size-4 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-sm ring-2 ring-background"
+              >
+                <Check className="size-2.5" />
+              </span>
+            ) : null}
+            {isWatchedInScope ? (
+              <span
+                aria-hidden="true"
+                title={t("settings.userNotifications.quickAdd.indicatorLabel")}
+                className="pointer-events-none absolute -right-1 -top-1 flex size-4 items-center justify-center rounded-full bg-emerald-500 text-background shadow-sm ring-2 ring-background"
+              >
+                <Bell className="size-2.5" />
+              </span>
+            ) : null}
+          </span>
+        }
+      />
       <ContextMenuContent className="min-w-[15rem]">
         <ContextMenuItem
           className="gap-2"
-          onSelect={() => {
+          onClick={() => {
             void handleCopyItemId();
           }}
         >
@@ -244,7 +246,7 @@ export const WatchableItemTile = ({
         <ContextMenuItem
           className="gap-2"
           disabled={!effectiveGuildId}
-          onSelect={showLootsWithItem}
+          onClick={showLootsWithItem}
         >
           <ListFilter className="h-4 w-4 text-primary" />
           {t("loots.list.itemActions.showLoots")}
@@ -262,7 +264,7 @@ export const WatchableItemTile = ({
               {t("settings.userNotifications.quickAdd.loadError")}
             </ContextMenuItem>
             <ContextMenuSeparator />
-            <ContextMenuItem onSelect={openNotifications}>
+            <ContextMenuItem onClick={openNotifications}>
               {t("settings.userNotifications.quickAdd.openNotifications")}
             </ContextMenuItem>
           </>
@@ -273,7 +275,7 @@ export const WatchableItemTile = ({
               {t("settings.userNotifications.quickAdd.dmRequired")}
             </ContextMenuItem>
             <ContextMenuSeparator />
-            <ContextMenuItem onSelect={openNotifications}>
+            <ContextMenuItem onClick={openNotifications}>
               {t("settings.userNotifications.quickAdd.configureDm")}
             </ContextMenuItem>
           </>
@@ -282,7 +284,7 @@ export const WatchableItemTile = ({
           <>
             <ContextMenuItem
               className="gap-2"
-              onSelect={() => {
+              onClick={() => {
                 void handleRemove();
               }}
             >
@@ -290,7 +292,7 @@ export const WatchableItemTile = ({
               {t("settings.userNotifications.quickAdd.remove")}
             </ContextMenuItem>
             <ContextMenuSeparator />
-            <ContextMenuItem onSelect={openNotifications}>
+            <ContextMenuItem onClick={openNotifications}>
               {t("settings.userNotifications.quickAdd.openNotifications")}
             </ContextMenuItem>
           </>
@@ -304,14 +306,14 @@ export const WatchableItemTile = ({
                 })}
               </ContextMenuItem>
               <ContextMenuSeparator />
-              <ContextMenuItem onSelect={openNotifications}>
+              <ContextMenuItem onClick={openNotifications}>
                 {t("settings.userNotifications.quickAdd.openNotifications")}
               </ContextMenuItem>
             </>
           ) : (
             <ContextMenuItem
               className="gap-2"
-              onSelect={() => {
+              onClick={() => {
                 void handleQuickAdd();
               }}
             >

--- a/apps/web/src/components/ui/multi-select.tsx
+++ b/apps/web/src/components/ui/multi-select.tsx
@@ -276,108 +276,109 @@ export const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
         onOpenChange={handlePopoverStateChange}
         modal={modalPopover}
       >
-        <PopoverTrigger asChild>
-          <div
-            ref={ref}
-            {...props}
-            role="combobox"
-            aria-expanded={isPopoverOpen}
-            aria-disabled={disabled}
-            tabIndex={disabled ? -1 : (props.tabIndex ?? 0)}
-            onKeyDown={handleTriggerKeyDown}
-            className={cn(
-              "group flex min-h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-xl border border-border bg-background px-2.5 py-1.5 text-left text-sm text-foreground outline-none transition-[background-color,border-color,box-shadow]",
-              "hover:border-foreground/20 hover:bg-foreground/[0.04] hover:text-foreground",
-              "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-              "data-[state=open]:border-ring data-[state=open]:bg-foreground/[0.04] data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-ring",
-              "aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
-              className,
-            )}
-          >
-            {selectedValues.length > 0 ? (
-              <>
-                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
-                  {selectedValues.slice(0, maxCount).map((value) => {
-                    const currentOption = options.find(
-                      (option) => option.value === value,
-                    );
-                    const cachedOption = optionCacheRef.current.get(value);
-                    const label =
-                      currentOption?.label ?? cachedOption?.label ?? value;
+        <PopoverTrigger
+          render={
+            <div
+              ref={ref}
+              {...props}
+              role="combobox"
+              aria-expanded={isPopoverOpen}
+              aria-disabled={disabled}
+              tabIndex={disabled ? -1 : (props.tabIndex ?? 0)}
+              onKeyDown={handleTriggerKeyDown}
+              className={cn(
+                "group flex min-h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-xl border border-border bg-background px-2.5 py-1.5 text-left text-sm text-foreground outline-none transition-[background-color,border-color,box-shadow]",
+                "hover:border-foreground/20 hover:bg-foreground/[0.04] hover:text-foreground",
+                "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                "data-[state=open]:border-ring data-[state=open]:bg-foreground/[0.04] data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-ring",
+                "aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
+                className,
+              )}
+            >
+              {selectedValues.length > 0 ? (
+                <>
+                  <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+                    {selectedValues.slice(0, maxCount).map((value) => {
+                      const currentOption = options.find(
+                        (option) => option.value === value,
+                      );
+                      const cachedOption = optionCacheRef.current.get(value);
+                      const label =
+                        currentOption?.label ?? cachedOption?.label ?? value;
 
-                    return (
-                      <button
-                        type="button"
-                        key={value}
-                        aria-label={t("common.removeOption", { label })}
-                        className={multiSelectVariants({ variant })}
-                        onPointerDown={(event) => event.stopPropagation()}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          toggleOption(value, true);
-                        }}
+                      return (
+                        <button
+                          type="button"
+                          key={value}
+                          aria-label={t("common.removeOption", { label })}
+                          className={multiSelectVariants({ variant })}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            toggleOption(value, true);
+                          }}
+                        >
+                          <span className="max-w-28 truncate">{label}</span>
+                          <XIcon
+                            aria-hidden="true"
+                            className="size-3.5 shrink-0 opacity-60"
+                          />
+                        </button>
+                      );
+                    })}
+                    {selectedValues.length > maxCount ? (
+                      <span
+                        className={cn(
+                          multiSelectVariants({ variant }),
+                          "border-border bg-transparent text-muted-foreground",
+                        )}
                       >
-                        <span className="max-w-28 truncate">{label}</span>
-                        <XIcon
-                          aria-hidden="true"
-                          className="size-3.5 shrink-0 opacity-60"
-                        />
-                      </button>
-                    );
-                  })}
-                  {selectedValues.length > maxCount ? (
-                    <span
-                      className={cn(
-                        multiSelectVariants({ variant }),
-                        "border-border bg-transparent text-muted-foreground",
-                      )}
+                        +{selectedValues.length - maxCount}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="flex shrink-0 items-center self-stretch">
+                    <button
+                      type="button"
+                      aria-label={t("common.clear")}
+                      className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      onPointerDown={(event) => event.stopPropagation()}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleClear();
+                      }}
                     >
-                      +{selectedValues.length - maxCount}
-                    </span>
-                  ) : null}
-                </div>
-                <div className="flex shrink-0 items-center self-stretch">
-                  <button
-                    type="button"
-                    aria-label={t("common.clear")}
-                    className="flex size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    onPointerDown={(event) => event.stopPropagation()}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleClear();
-                    }}
-                  >
-                    <XIcon aria-hidden="true" className="size-4" />
-                  </button>
-                  <Separator
-                    orientation="vertical"
-                    className="mx-1 h-5 bg-border/80"
-                  />
+                      <XIcon aria-hidden="true" className="size-4" />
+                    </button>
+                    <Separator
+                      orientation="vertical"
+                      className="mx-1 h-5 bg-border/80"
+                    />
+                    <ChevronDown
+                      aria-hidden="true"
+                      className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                    {resolvedPlaceholder}
+                  </span>
                   <ChevronDown
                     aria-hidden="true"
                     className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
                   />
-                </div>
-              </>
-            ) : (
-              <>
-                <span className="min-w-0 flex-1 truncate text-muted-foreground">
-                  {resolvedPlaceholder}
-                </span>
-                <ChevronDown
-                  aria-hidden="true"
-                  className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
-                />
-              </>
-            )}
-          </div>
-        </PopoverTrigger>
+                </>
+              )}
+            </div>
+          }
+        />
         <PopoverContent
-          className="w-[var(--radix-popover-trigger-width)] min-w-64 max-w-[min(24rem,calc(100vw-2rem))] rounded-xl border-border bg-popover p-1 shadow-xl"
+          className="w-[var(--anchor-width)] min-w-64 max-w-[min(24rem,calc(100vw-2rem))] rounded-xl border-border bg-popover p-1 shadow-xl"
           align="start"
           sideOffset={6}
           onWheel={(event) => event.stopPropagation()}
-          onEscapeKeyDown={() => setIsPopoverOpen(false)}
         >
           <Command
             className="rounded-lg bg-transparent"

--- a/apps/web/src/components/ui/multi-select.tsx
+++ b/apps/web/src/components/ui/multi-select.tsx
@@ -290,7 +290,7 @@ export const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                 "group flex min-h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-xl border border-border bg-background px-2.5 py-1.5 text-left text-sm text-foreground outline-none transition-[background-color,border-color,box-shadow]",
                 "hover:border-foreground/20 hover:bg-foreground/[0.04] hover:text-foreground",
                 "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
-                "data-[state=open]:border-ring data-[state=open]:bg-foreground/[0.04] data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-ring",
+                "data-popup-open:border-ring data-popup-open:bg-foreground/[0.04] data-popup-open:ring-2 data-popup-open:ring-inset data-popup-open:ring-ring",
                 "aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
                 className,
               )}
@@ -356,7 +356,7 @@ export const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                     />
                     <ChevronDown
                       aria-hidden="true"
-                      className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
+                      className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-popup-open:rotate-180 motion-reduce:transition-none"
                     />
                   </div>
                 </>
@@ -367,7 +367,7 @@ export const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
                   </span>
                   <ChevronDown
                     aria-hidden="true"
-                    className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180 motion-reduce:transition-none"
+                    className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-popup-open:rotate-180 motion-reduce:transition-none"
                   />
                 </>
               )}

--- a/apps/web/src/features/guild/activity-logs/activity-logs.tsx
+++ b/apps/web/src/features/guild/activity-logs/activity-logs.tsx
@@ -84,7 +84,6 @@ export const ActivityLogs: FC = () => {
         <Drawer
           open={isMobileFiltersOpen}
           onOpenChange={setIsMobileFiltersOpen}
-          shouldScaleBackground={false}
         >
           <DrawerContent className="p-0 h-[85vh] max-h-[85vh] flex flex-col overflow-hidden">
             <DrawerHeader className="border-b px-4 py-3 shrink-0">

--- a/apps/web/src/features/guild/activity-logs/components/activity-logs-filters-header.tsx
+++ b/apps/web/src/features/guild/activity-logs/components/activity-logs-filters-header.tsx
@@ -49,8 +49,22 @@ export const ActivityLogsFiltersHeader = ({
             <Select
               value={selectedWorld || undefined}
               onValueChange={(value) =>
-                onWorldChange(value !== "all" ? value : "")
+                onWorldChange(value !== null && value !== "all" ? value : "")
               }
+              items={[
+                {
+                  value: null,
+                  label: <>{t("activityLogs.filters.allWorlds")}</>,
+                },
+                {
+                  value: "all",
+                  label: <>{t("activityLogs.filters.allWorlds")}</>,
+                },
+                ...worldOptions.map((option) => ({
+                  value: option.value,
+                  label: <>{capitalizeFirstLetter(option.label)}</>,
+                })),
+              ]}
             >
               <SelectTrigger className="h-9 w-48">
                 <SelectValue

--- a/apps/web/src/features/guild/activity-logs/components/activity-logs-filters-sidebar.tsx
+++ b/apps/web/src/features/guild/activity-logs/components/activity-logs-filters-sidebar.tsx
@@ -185,7 +185,7 @@ export const ActivityLogsFiltersSidebar: FC<
           <ScrollArea className="h-full">
             <div className="p-4 space-y-4">
               <Accordion
-                type="multiple"
+                multiple
                 defaultValue={["general", "type", "source", "date"]}
                 className="space-y-4"
               >

--- a/apps/web/src/features/guild/activity-logs/components/activity-logs-list-item.tsx
+++ b/apps/web/src/features/guild/activity-logs/components/activity-logs-list-item.tsx
@@ -31,7 +31,7 @@ type Props = {
 };
 
 export const ActivityLogsListItem: React.FC<Props> = ({ activity }) => {
-  const [isOpen, setIsOpen] = useState("");
+  const [openItems, setOpenItems] = useState<string[]>([]);
   const guildId = useGuildId();
   const { data: members } = useMembersControllerGetGuildMemberReferences(
     { guildId: guildId ?? "" },
@@ -87,7 +87,7 @@ export const ActivityLogsListItem: React.FC<Props> = ({ activity }) => {
 
   const handleCardClick = () => {
     if (hasAdditionalData) {
-      setIsOpen(isOpen === "details" ? "" : "details");
+      setOpenItems(openItems.includes("details") ? [] : ["details"]);
     }
   };
 
@@ -122,7 +122,7 @@ export const ActivityLogsListItem: React.FC<Props> = ({ activity }) => {
               {hasAdditionalData && (
                 <ChevronDown
                   className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${
-                    isOpen === "details" ? "rotate-180" : ""
+                    openItems.includes("details") ? "rotate-180" : ""
                   }`}
                 />
               )}
@@ -221,11 +221,9 @@ export const ActivityLogsListItem: React.FC<Props> = ({ activity }) => {
 
           {hasAdditionalData && (
             <Accordion
-              type="single"
-              collapsible
               className="w-full"
-              value={isOpen}
-              onValueChange={setIsOpen}
+              value={openItems}
+              onValueChange={setOpenItems}
             >
               <AccordionItem value="details" className="border-none">
                 <AccordionContent>

--- a/apps/web/src/features/guild/activity-logs/components/actor-name-selector.tsx
+++ b/apps/web/src/features/guild/activity-logs/components/actor-name-selector.tsx
@@ -71,41 +71,45 @@ export function ActorNameSelector({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-controls={suggestionsListId}
-          aria-expanded={open}
-          className={cn("justify-between gap-2", className)}
-        >
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className={cn("truncate", !value && "text-muted-foreground")}>
-              {value ? truncatedValue : displayValue}
-            </span>
-          </div>
-          <div className="flex items-center gap-1 shrink-0">
-            {value && (
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-controls={suggestionsListId}
+            aria-expanded={open}
+            className={cn("justify-between gap-2", className)}
+          >
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
               <span
-                role="button"
-                tabIndex={0}
-                onMouseDown={handleClear}
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    handleClear(e);
-                  }
-                }}
-                className="flex items-center justify-center"
+                className={cn("truncate", !value && "text-muted-foreground")}
               >
-                <X className="h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer transition-colors" />
+                {value ? truncatedValue : displayValue}
               </span>
-            )}
-            <ChevronsUpDown className="h-4 w-4 opacity-50" />
-          </div>
-        </Button>
-      </PopoverTrigger>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              {value && (
+                <span
+                  role="button"
+                  tabIndex={0}
+                  onMouseDown={handleClear}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      handleClear(e);
+                    }
+                  }}
+                  className="flex items-center justify-center"
+                >
+                  <X className="h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer transition-colors" />
+                </span>
+              )}
+              <ChevronsUpDown className="h-4 w-4 opacity-50" />
+            </div>
+          </Button>
+        }
+      />
       <PopoverContent className="w-[250px] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInputRaw

--- a/apps/web/src/features/guild/docs/editor/guild-doc-editor-toolbar.tsx
+++ b/apps/web/src/features/guild/docs/editor/guild-doc-editor-toolbar.tsx
@@ -576,26 +576,28 @@ export const GuildDocEditorToolbar = () => {
 
           return (
             <Tooltip key={control.label}>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className={cn(
-                    "relative h-8 w-8 border border-transparent text-muted-foreground transition-colors",
-                    "hover:bg-muted hover:text-foreground",
-                    isActive &&
-                      "border-primary/70 bg-primary/25 text-primary shadow-sm ring-1 ring-primary/30 hover:bg-primary/30 hover:text-primary after:absolute after:bottom-1 after:left-1/2 after:h-0.5 after:w-4 after:-translate-x-1/2 after:rounded-full after:bg-primary",
-                  )}
-                  aria-label={control.label}
-                  aria-pressed={
-                    control.active === undefined ? undefined : control.active
-                  }
-                  onClick={control.action}
-                >
-                  <Icon className="size-4" />
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className={cn(
+                      "relative h-8 w-8 border border-transparent text-muted-foreground transition-colors",
+                      "hover:bg-muted hover:text-foreground",
+                      isActive &&
+                        "border-primary/70 bg-primary/25 text-primary shadow-sm ring-1 ring-primary/30 hover:bg-primary/30 hover:text-primary after:absolute after:bottom-1 after:left-1/2 after:h-0.5 after:w-4 after:-translate-x-1/2 after:rounded-full after:bg-primary",
+                    )}
+                    aria-label={control.label}
+                    aria-pressed={
+                      control.active === undefined ? undefined : control.active
+                    }
+                    onClick={control.action}
+                  >
+                    <Icon className="size-4" />
+                  </Button>
+                }
+              />
               <TooltipContent side="bottom">
                 <p>{control.label}</p>
               </TooltipContent>

--- a/apps/web/src/features/guild/docs/guild-doc-editor-page.tsx
+++ b/apps/web/src/features/guild/docs/guild-doc-editor-page.tsx
@@ -255,35 +255,39 @@ export const GuildDocEditorPage = () => {
               {canWrite && (
                 <div className="flex flex-wrap items-center gap-2">
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        aria-label={t("docs.editor.history")}
-                        onClick={() => setHistoryOpen(true)}
-                      >
-                        <History className="size-4" />
-                      </Button>
-                    </TooltipTrigger>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          aria-label={t("docs.editor.history")}
+                          onClick={() => setHistoryOpen(true)}
+                        >
+                          <History className="size-4" />
+                        </Button>
+                      }
+                    />
                     <TooltipContent side="bottom">
                       {t("docs.editor.history")}
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        aria-label={t("docs.trash.move")}
-                        className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                        disabled={deleteDocument.isPending}
-                        onClick={() => setTrashConfirmOpen(true)}
-                      >
-                        <Trash2 className="size-4" />
-                      </Button>
-                    </TooltipTrigger>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          aria-label={t("docs.trash.move")}
+                          className="border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                          disabled={deleteDocument.isPending}
+                          onClick={() => setTrashConfirmOpen(true)}
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      }
+                    />
                     <TooltipContent side="bottom">
                       {t("docs.trash.move")}
                     </TooltipContent>

--- a/apps/web/src/features/guild/docs/guild-doc-editor-page.tsx
+++ b/apps/web/src/features/guild/docs/guild-doc-editor-page.tsx
@@ -369,7 +369,7 @@ export const GuildDocEditorPage = () => {
                 disabled={deleteDocument.isPending}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                 onClick={(event) => {
-                  event.preventDefault();
+                  event.preventBaseUIHandler();
                   void moveDocumentToTrash();
                 }}
               >

--- a/apps/web/src/features/guild/docs/guild-docs-list-page.tsx
+++ b/apps/web/src/features/guild/docs/guild-docs-list-page.tsx
@@ -334,7 +334,7 @@ export const GuildDocsListPage = () => {
               disabled={deleteDocument.isPending || !documentPendingTrash}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               onClick={(event) => {
-                event.preventDefault();
+                event.preventBaseUIHandler();
 
                 if (documentPendingTrash) {
                   void moveDocumentToTrash(documentPendingTrash);

--- a/apps/web/src/features/guild/docs/guild-docs-list-page.tsx
+++ b/apps/web/src/features/guild/docs/guild-docs-list-page.tsx
@@ -259,18 +259,19 @@ export const GuildDocsListPage = () => {
                     </p>
                     <div className="mt-1 flex gap-2">
                       <Button
-                        asChild
                         size="sm"
                         variant="secondary"
                         className="min-w-0 flex-1 justify-center"
-                      >
-                        <Link
-                          to="/$guildId/docs/$docId"
-                          params={{ guildId, docId: document.id }}
-                        >
-                          {t("docs.list.open")}
-                        </Link>
-                      </Button>
+                        render={
+                          <Link
+                            to="/$guildId/docs/$docId"
+                            params={{ guildId, docId: document.id }}
+                          >
+                            {t("docs.list.open")}
+                          </Link>
+                        }
+                        nativeButton={false}
+                      />
                       {canWrite && (
                         <Button
                           type="button"

--- a/apps/web/src/features/guild/events/components/coordination/event-coordination-hero-card.tsx
+++ b/apps/web/src/features/guild/events/components/coordination/event-coordination-hero-card.tsx
@@ -114,19 +114,25 @@ export const EventCoordinationHeroCard = ({
         </div>
 
         <div className="flex flex-wrap gap-2 lg:justify-end">
-          <Button asChild size="sm" variant="outline" className="shrink-0">
-            <Link
-              to="/$guildId/events/$eventId/heroes/$heroId"
-              params={{
-                guildId,
-                eventId,
-                heroId: hero.heroId,
-              }}
-            >
-              <ArrowRight className="size-3.5" />
-              {t("events.coordination.actions.openMaps")}
-            </Link>
-          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="shrink-0"
+            render={
+              <Link
+                to="/$guildId/events/$eventId/heroes/$heroId"
+                params={{
+                  guildId,
+                  eventId,
+                  heroId: hero.heroId,
+                }}
+              >
+                <ArrowRight className="size-3.5" />
+                {t("events.coordination.actions.openMaps")}
+              </Link>
+            }
+            nativeButton={false}
+          />
 
           {canWrite && targetGap && (
             <Button

--- a/apps/web/src/features/guild/events/components/dialogs/close-respawn-window-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/close-respawn-window-dialog.tsx
@@ -140,12 +140,14 @@ export const CloseRespawnWindowDialog = ({
                 name="createNewWindow"
                 render={({ field }) => (
                   <FormItem className="flex items-center gap-2 space-y-0">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      }
+                    />
                     <FormLabel className="cursor-pointer text-sm font-normal">
                       {t("events.respawn.createNewWindow")}
                     </FormLabel>
@@ -163,13 +165,15 @@ export const CloseRespawnWindowDialog = ({
                         <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                           {t("events.respawn.minSpawnTime")}
                         </FormLabel>
-                        <FormControl>
-                          <Input
-                            type="datetime-local"
-                            className="h-9 text-sm"
-                            {...field}
-                          />
-                        </FormControl>
+                        <FormControl
+                          render={
+                            <Input
+                              type="datetime-local"
+                              className="h-9 text-sm"
+                              {...field}
+                            />
+                          }
+                        />
                         <FormMessage />
                       </FormItem>
                     )}
@@ -183,13 +187,15 @@ export const CloseRespawnWindowDialog = ({
                         <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                           {t("events.respawn.maxSpawnTime")}
                         </FormLabel>
-                        <FormControl>
-                          <Input
-                            type="datetime-local"
-                            className="h-9 text-sm"
-                            {...field}
-                          />
-                        </FormControl>
+                        <FormControl
+                          render={
+                            <Input
+                              type="datetime-local"
+                              className="h-9 text-sm"
+                              {...field}
+                            />
+                          }
+                        />
                         <FormMessage />
                       </FormItem>
                     )}

--- a/apps/web/src/features/guild/events/components/dialogs/event-action-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/event-action-dialog.tsx
@@ -79,7 +79,7 @@ const EventActionDialogSimple = ({
           </AlertDialogCancel>
           <AlertDialogAction
             onClick={(e) => {
-              e.preventDefault();
+              e.preventBaseUIHandler();
               void handleConfirm();
             }}
             disabled={isPending}
@@ -170,7 +170,7 @@ const EventActionDialogWithConfirmation = ({
                 : undefined
             }
             onClick={(e) => {
-              e.preventDefault();
+              e.preventBaseUIHandler();
               void handleConfirm();
             }}
           >

--- a/apps/web/src/features/guild/events/components/dialogs/event-participation-confirmation-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/event-participation-confirmation-dialog.tsx
@@ -197,11 +197,17 @@ const EventParticipationConfirmationDialogContent = ({
   }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent
-        className="sm:max-w-xl p-5"
-        onInteractOutside={(event) => event.preventDefault()}
-      >
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen, eventDetails) => {
+        if (!nextOpen && eventDetails.reason === "outside-press") {
+          eventDetails.cancel();
+          return;
+        }
+        handleOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="sm:max-w-xl p-5">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <ShieldCheck className="size-4 text-primary" />

--- a/apps/web/src/features/guild/events/components/dialogs/map-chip.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/map-chip.tsx
@@ -34,10 +34,19 @@ export const MapChip = ({
       </span>
 
       {locations.length > 0 && (
-        <Select
+        <Select<string>
           open={showSelect}
           onOpenChange={setShowSelect}
-          onValueChange={(v) => onLocationChange(v === "none" ? null : v)}
+          onValueChange={(value) =>
+            onLocationChange(value === "none" ? null : value)
+          }
+          items={[
+            { value: "none", label: <>{t("events.locations.noLocation")}</> },
+            ...locations.map((loc) => ({
+              value: loc.id,
+              label: <>{loc.name}</>,
+            })),
+          ]}
         >
           <SelectTrigger className="h-4 w-4 p-0 border-0 bg-transparent hover:bg-primary/20 rounded">
             <GripVertical className="size-2.5 text-primary/60" />

--- a/apps/web/src/features/guild/events/components/dialogs/map-manage-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/map-manage-dialog.tsx
@@ -548,21 +548,23 @@ export const MapManageDialog = ({
                 <div className="flex flex-wrap gap-1.5">
                   {templates.map((template) => (
                     <Popover key={template.id}>
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-7 text-xs gap-1.5"
-                          disabled={addMap.isPending}
-                        >
-                          <FileText className="size-3" />
-                          {template.name}
-                          <span className="text-muted-foreground">
-                            ({template.maps.length})
-                          </span>
-                          <Plus className="size-3 ml-0.5" />
-                        </Button>
-                      </PopoverTrigger>
+                      <PopoverTrigger
+                        render={
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 text-xs gap-1.5"
+                            disabled={addMap.isPending}
+                          >
+                            <FileText className="size-3" />
+                            {template.name}
+                            <span className="text-muted-foreground">
+                              ({template.maps.length})
+                            </span>
+                            <Plus className="size-3 ml-0.5" />
+                          </Button>
+                        }
+                      />
                       <PopoverContent className="w-48 p-2" align="start">
                         <div className="space-y-1">
                           <p className="text-xs font-medium text-muted-foreground mb-2">
@@ -629,6 +631,16 @@ export const MapManageDialog = ({
                     onValueChange={(v) =>
                       setSelectedLocationId(v === "none" ? null : v)
                     }
+                    items={[
+                      {
+                        value: "none",
+                        label: <>{t("events.locations.noLocation")}</>,
+                      },
+                      ...hero.locations.map((loc) => ({
+                        value: loc.id,
+                        label: <>{loc.name}</>,
+                      })),
+                    ]}
                   >
                     <SelectTrigger className="h-7 text-xs w-[180px]">
                       <SelectValue />

--- a/apps/web/src/features/guild/events/components/dialogs/open-respawn-window-dialog.tsx
+++ b/apps/web/src/features/guild/events/components/dialogs/open-respawn-window-dialog.tsx
@@ -118,13 +118,15 @@ export const OpenRespawnWindowDialog = ({
                     <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                       {t("events.respawn.minSpawnTime")}
                     </FormLabel>
-                    <FormControl>
-                      <DateTimePicker
-                        value={field.value}
-                        onChange={field.onChange}
-                        className="w-full"
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <DateTimePicker
+                          value={field.value}
+                          onChange={field.onChange}
+                          className="w-full"
+                        />
+                      }
+                    />
                     <FormMessage />
                   </FormItem>
                 )}
@@ -138,13 +140,15 @@ export const OpenRespawnWindowDialog = ({
                     <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                       {t("events.respawn.maxSpawnTime")}
                     </FormLabel>
-                    <FormControl>
-                      <DateTimePicker
-                        value={field.value}
-                        onChange={field.onChange}
-                        className="w-full"
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <DateTimePicker
+                          value={field.value}
+                          onChange={field.onChange}
+                          className="w-full"
+                        />
+                      }
+                    />
                     <FormMessage />
                   </FormItem>
                 )}

--- a/apps/web/src/features/guild/events/components/heroes/event-heroes-table-columns.tsx
+++ b/apps/web/src/features/guild/events/components/heroes/event-heroes-table-columns.tsx
@@ -179,17 +179,19 @@ export const createEventHeroesTableColumns = ({
         return (
           <div className="flex justify-end">
             <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-9 shrink-0 text-muted-foreground"
-                  aria-label={t("events.heroes.actions")}
-                  title={t("events.heroes.actions")}
-                >
-                  <MoreVertical className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-9 shrink-0 text-muted-foreground"
+                    aria-label={t("events.heroes.actions")}
+                    title={t("events.heroes.actions")}
+                  >
+                    <MoreVertical className="size-4" />
+                  </Button>
+                }
+              />
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => onEditHero(hero)}>
                   <Pencil className="size-4" />

--- a/apps/web/src/features/guild/events/components/heroes/hero-timer-countdown.tsx
+++ b/apps/web/src/features/guild/events/components/heroes/hero-timer-countdown.tsx
@@ -68,22 +68,24 @@ const HeroTimerCountdownContent = ({ timer }: { timer: EventTimer }) => {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          tabIndex={0}
-          className={cn(
-            "flex items-center gap-1.5 px-2 py-1 rounded-md text-sm font-medium",
-            isWaiting
-              ? "bg-amber-500/10 text-amber-500"
-              : "bg-green-500/10 text-green-500",
-          )}
-        >
-          <Clock className="w-4 h-4" />
-          <span className="font-mono">
-            {parseMsToTime(countdownState.timeLeftMilliseconds)}
-          </span>
-        </div>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <div
+            tabIndex={0}
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-1 rounded-md text-sm font-medium",
+              isWaiting
+                ? "bg-amber-500/10 text-amber-500"
+                : "bg-green-500/10 text-green-500",
+            )}
+          >
+            <Clock className="w-4 h-4" />
+            <span className="font-mono">
+              {parseMsToTime(countdownState.timeLeftMilliseconds)}
+            </span>
+          </div>
+        }
+      />
       <TooltipContent>
         <div className="text-sm space-y-1">
           <p>

--- a/apps/web/src/features/guild/events/components/heroes/hero-timer-display.tsx
+++ b/apps/web/src/features/guild/events/components/heroes/hero-timer-display.tsx
@@ -94,22 +94,24 @@ const HeroTimerDisplayContent = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={cn(
-            "inline-flex items-center gap-1 text-[11px] font-medium whitespace-nowrap",
-            isOverdue
-              ? "text-orange-500"
-              : isClose
-                ? "text-orange-400"
-                : "text-green-400",
-            className,
-          )}
-        >
-          <Clock className="w-3 h-3" />
-          {displayTime}
-        </span>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 text-[11px] font-medium whitespace-nowrap",
+              isOverdue
+                ? "text-orange-500"
+                : isClose
+                  ? "text-orange-400"
+                  : "text-green-400",
+              className,
+            )}
+          >
+            <Clock className="w-3 h-3" />
+            {displayTime}
+          </span>
+        }
+      />
       <TooltipContent>
         <p className="text-sm">
           {label}:{" "}

--- a/apps/web/src/features/guild/events/components/kills/kill-detail-summary.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-detail-summary.tsx
@@ -112,18 +112,20 @@ export const KillDetailSummary = ({
         </div>
         {kill.isManualClose ? (
           <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 text-xs font-medium text-amber-500"
-                tabIndex={0}
-                aria-label={t("events.killDetail.manualCloseTitle")}
-              >
-                <Hand className="size-3.5" />
-                <span className="hidden sm:inline">
-                  {t("events.kills.manualCloseLabel")}
+            <TooltipTrigger
+              render={
+                <span
+                  className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 text-xs font-medium text-amber-500"
+                  tabIndex={0}
+                  aria-label={t("events.killDetail.manualCloseTitle")}
+                >
+                  <Hand className="size-3.5" />
+                  <span className="hidden sm:inline">
+                    {t("events.kills.manualCloseLabel")}
+                  </span>
                 </span>
-              </span>
-            </TooltipTrigger>
+              }
+            />
             <TooltipContent className="max-w-72">
               <p className="font-medium">
                 {t("events.killDetail.manualCloseTitle")}
@@ -154,34 +156,36 @@ export const KillDetailSummary = ({
           </dd>
         </div>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              className="min-w-0 cursor-help border-l border-border/70 px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-              tabIndex={0}
-              aria-label={respawnMetricLabel}
-            >
-              <dt className="truncate text-[11px] leading-tight text-muted-foreground">
-                {t("events.killDetail.respawnTime")}
-              </dt>
-              <dd className="mt-0.5 flex min-w-0 items-baseline gap-1.5 whitespace-nowrap leading-none tabular-nums">
-                <span className="min-w-0 truncate text-base font-semibold">
-                  {respawnDurationText}
-                </span>
-                {respawnDeltaText ? (
-                  <span
-                    aria-hidden="true"
-                    className={
-                      overdueDurationText
-                        ? "shrink-0 text-[10px] font-medium text-amber-500"
-                        : "shrink-0 text-[10px] font-medium text-muted-foreground"
-                    }
-                  >
-                    {respawnDeltaText}
+          <TooltipTrigger
+            render={
+              <div
+                className="min-w-0 cursor-help border-l border-border/70 px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                tabIndex={0}
+                aria-label={respawnMetricLabel}
+              >
+                <dt className="truncate text-[11px] leading-tight text-muted-foreground">
+                  {t("events.killDetail.respawnTime")}
+                </dt>
+                <dd className="mt-0.5 flex min-w-0 items-baseline gap-1.5 whitespace-nowrap leading-none tabular-nums">
+                  <span className="min-w-0 truncate text-base font-semibold">
+                    {respawnDurationText}
                   </span>
-                ) : null}
-              </dd>
-            </div>
-          </TooltipTrigger>
+                  {respawnDeltaText ? (
+                    <span
+                      aria-hidden="true"
+                      className={
+                        overdueDurationText
+                          ? "shrink-0 text-[10px] font-medium text-amber-500"
+                          : "shrink-0 text-[10px] font-medium text-muted-foreground"
+                      }
+                    >
+                      {respawnDeltaText}
+                    </span>
+                  ) : null}
+                </dd>
+              </div>
+            }
+          />
           <TooltipContent>
             <p className="font-medium">
               {t("events.killDetail.respawnTimeDescription")}
@@ -195,20 +199,22 @@ export const KillDetailSummary = ({
           </TooltipContent>
         </Tooltip>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              className="min-w-0 cursor-help border-t border-border/70 px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:border-l md:border-t-0"
-              tabIndex={0}
-              aria-label={`${t("events.killDetail.respawnWindowTime")}: ${windowDurationText}`}
-            >
-              <dt className="truncate text-[11px] leading-tight text-muted-foreground">
-                {t("events.killDetail.respawnWindowTime")}
-              </dt>
-              <dd className="mt-1 truncate text-base font-semibold leading-none tabular-nums">
-                {windowDurationText}
-              </dd>
-            </div>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div
+                className="min-w-0 cursor-help border-t border-border/70 px-3 py-2.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset md:border-l md:border-t-0"
+                tabIndex={0}
+                aria-label={`${t("events.killDetail.respawnWindowTime")}: ${windowDurationText}`}
+              >
+                <dt className="truncate text-[11px] leading-tight text-muted-foreground">
+                  {t("events.killDetail.respawnWindowTime")}
+                </dt>
+                <dd className="mt-1 truncate text-base font-semibold leading-none tabular-nums">
+                  {windowDurationText}
+                </dd>
+              </div>
+            }
+          />
           <TooltipContent>
             <p className="font-medium">
               {t("events.killDetail.respawnWindowTimeDescription")}

--- a/apps/web/src/features/guild/events/components/kills/kill-history-card.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-history-card.tsx
@@ -81,14 +81,16 @@ export const KillHistoryCard = ({
           <div className="flex items-center gap-3 text-sm shrink-0 sm:self-auto">
             {kill.isManualClose && (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    className="gap-1 text-yellow-600 border-yellow-600/50"
-                  >
-                    <Hand className="w-3 h-3" />
-                  </Badge>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Badge
+                      variant="outline"
+                      className="gap-1 text-yellow-600 border-yellow-600/50"
+                    >
+                      <Hand className="w-3 h-3" />
+                    </Badge>
+                  }
+                />
                 <TooltipContent>
                   <p>{t("events.kills.manualClose")}</p>
                 </TooltipContent>
@@ -97,12 +99,14 @@ export const KillHistoryCard = ({
 
             {respawnTime && (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge variant="outline" className="gap-1">
-                    <Clock className="w-3 h-3" />
-                    {respawnTime}
-                  </Badge>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Badge variant="outline" className="gap-1">
+                      <Clock className="w-3 h-3" />
+                      {respawnTime}
+                    </Badge>
+                  }
+                />
                 <TooltipContent>
                   <p>{t("events.kills.respawnTime")}</p>
                 </TooltipContent>
@@ -167,14 +171,16 @@ export const KillHistoryCard = ({
           <div className="flex items-center justify-between gap-3 text-sm shrink-0 sm:justify-end">
             {kill.isManualClose && (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Badge
-                    variant="outline"
-                    className="gap-1 text-yellow-600 border-yellow-600/50"
-                  >
-                    <Hand className="w-3 h-3" />
-                  </Badge>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Badge
+                      variant="outline"
+                      className="gap-1 text-yellow-600 border-yellow-600/50"
+                    >
+                      <Hand className="w-3 h-3" />
+                    </Badge>
+                  }
+                />
                 <TooltipContent>
                   <p>{t("events.kills.manualClose")}</p>
                 </TooltipContent>
@@ -242,15 +248,17 @@ export const KillHistoryCard = ({
         <div className="flex items-center gap-2 shrink-0">
           {kill.isManualClose && (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Badge
-                  variant="outline"
-                  className="gap-1 text-yellow-600 border-yellow-600/50"
-                >
-                  <Hand className="w-3 h-3" />
-                  {t("events.kills.manualClose")}
-                </Badge>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Badge
+                    variant="outline"
+                    className="gap-1 text-yellow-600 border-yellow-600/50"
+                  >
+                    <Hand className="w-3 h-3" />
+                    {t("events.kills.manualClose")}
+                  </Badge>
+                }
+              />
               <TooltipContent>
                 <p>{t("events.kills.manualCloseDescription")}</p>
               </TooltipContent>
@@ -259,12 +267,14 @@ export const KillHistoryCard = ({
 
           {respawnTime && (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Badge variant="outline" className="gap-1">
-                  <Clock className="w-3 h-3" />
-                  {respawnTime}
-                </Badge>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Badge variant="outline" className="gap-1">
+                    <Clock className="w-3 h-3" />
+                    {respawnTime}
+                  </Badge>
+                }
+              />
               <TooltipContent>
                 <p>{t("events.kills.respawnTime")}</p>
               </TooltipContent>

--- a/apps/web/src/features/guild/events/components/kills/kill-map-assignment-group.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-map-assignment-group.tsx
@@ -72,21 +72,23 @@ export const KillMapAssignmentGroup = ({
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger asChild>
-        <button
-          type="button"
-          className="flex min-h-11 w-full items-center gap-2 rounded-lg px-1 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label={t(
-            "events.killDetail.mapCoverage.assignmentPeriodsAccessible",
-            {
-              member: assignment.memberName,
-              count: assignment.periods.length,
-            },
-          )}
-        >
-          {rowContent}
-        </button>
-      </CollapsibleTrigger>
+      <CollapsibleTrigger
+        render={
+          <button
+            type="button"
+            className="flex min-h-11 w-full items-center gap-2 rounded-lg px-1 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={t(
+              "events.killDetail.mapCoverage.assignmentPeriodsAccessible",
+              {
+                member: assignment.memberName,
+                count: assignment.periods.length,
+              },
+            )}
+          >
+            {rowContent}
+          </button>
+        }
+      />
       <CollapsibleContent>
         <div className="ml-8 border-l border-border/60 pl-3">
           {assignment.periods.map((period) => (

--- a/apps/web/src/features/guild/events/components/kills/kill-participant-row.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-participant-row.tsx
@@ -217,15 +217,17 @@ export const KillParticipantRow = ({
         <div className="flex items-center justify-end gap-1">
           {hasManualAdjustment ? (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="inline-flex size-6 shrink-0 items-center justify-center text-amber-400"
-                  tabIndex={0}
-                  aria-label={t("events.points.modified")}
-                >
-                  <Info className="size-3.5" />
-                </span>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <span
+                    className="inline-flex size-6 shrink-0 items-center justify-center text-amber-400"
+                    tabIndex={0}
+                    aria-label={t("events.points.modified")}
+                  >
+                    <Info className="size-3.5" />
+                  </span>
+                }
+              />
               <TooltipContent>
                 <p>{t("events.points.modified")}</p>
               </TooltipContent>
@@ -239,19 +241,21 @@ export const KillParticipantRow = ({
         <div className="flex items-center justify-end gap-0 lg:gap-0.5">
           {canEdit ? (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  size="icon"
-                  variant="ghost"
-                  className="size-11 text-muted-foreground lg:size-9"
-                  onClick={() => setIsEditDialogOpen(true)}
-                  disabled={isEditPending}
-                  aria-label={t("events.points.edit")}
-                >
-                  <Pencil className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    className="size-11 text-muted-foreground lg:size-9"
+                    onClick={() => setIsEditDialogOpen(true)}
+                    disabled={isEditPending}
+                    aria-label={t("events.points.edit")}
+                  >
+                    <Pencil className="size-3.5" />
+                  </Button>
+                }
+              />
               <TooltipContent>
                 <p>{t("events.points.edit")}</p>
               </TooltipContent>

--- a/apps/web/src/features/guild/events/components/kills/kill-participants-list.tsx
+++ b/apps/web/src/features/guild/events/components/kills/kill-participants-list.tsx
@@ -50,17 +50,21 @@ export const KillParticipantsList = ({
           const mapNamesLabel = formatMapNamesFromMapData(participant.mapData);
           return (
             <Tooltip key={participant.id}>
-              <TooltipTrigger asChild>
-                <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-muted/50 text-xs">
-                  <Avatar className="w-4 h-4">
-                    <AvatarImage src={participant.member.avatar ?? undefined} />
-                    <AvatarFallback className="text-[8px]">
-                      {participant.member.name.charAt(0).toUpperCase()}
-                    </AvatarFallback>
-                  </Avatar>
-                  <span className="font-medium">{participant.points}</span>
-                </div>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <div className="flex items-center gap-1 px-2 py-1 rounded-full bg-muted/50 text-xs">
+                    <Avatar className="w-4 h-4">
+                      <AvatarImage
+                        src={participant.member.avatar ?? undefined}
+                      />
+                      <AvatarFallback className="text-[8px]">
+                        {participant.member.name.charAt(0).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="font-medium">{participant.points}</span>
+                  </div>
+                }
+              />
               <TooltipContent>
                 <p className="font-medium">{participant.member.name}</p>
                 <p className="text-xs text-muted-foreground">
@@ -114,14 +118,16 @@ export const KillParticipantsList = ({
 
             <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center gap-1">
-                    <Clock className="w-3 h-3" />
-                    <span>
-                      {formatDurationHuman(participant.timeOnMapSeconds)}
-                    </span>
-                  </div>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <div className="flex items-center gap-1">
+                      <Clock className="w-3 h-3" />
+                      <span>
+                        {formatDurationHuman(participant.timeOnMapSeconds)}
+                      </span>
+                    </div>
+                  }
+                />
                 <TooltipContent>
                   <p>{t("events.kills.timeOnMap")}</p>
                 </TooltipContent>
@@ -129,11 +135,13 @@ export const KillParticipantsList = ({
 
               {participant.afkPercentage > 0 && (
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="text-amber-500">
-                      {Math.round(participant.afkPercentage)}% AFK
-                    </span>
-                  </TooltipTrigger>
+                  <TooltipTrigger
+                    render={
+                      <span className="text-amber-500">
+                        {Math.round(participant.afkPercentage)}% AFK
+                      </span>
+                    }
+                  />
                   <TooltipContent>
                     <p>{t("events.kills.afkPercentage")}</p>
                   </TooltipContent>
@@ -144,11 +152,13 @@ export const KillParticipantsList = ({
             <div className="text-right shrink-0">
               <p className="font-bold text-primary">{participant.points}</p>
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <p className="text-xs text-muted-foreground cursor-help">
-                    {participant.basePoints} + {bonusPoints}
-                  </p>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <p className="text-xs text-muted-foreground cursor-help">
+                      {participant.basePoints} + {bonusPoints}
+                    </p>
+                  }
+                />
                 <TooltipContent>
                   <p>{`base: ${participant.basePoints}, bonus: ${bonusPoints}`}</p>
                 </TooltipContent>

--- a/apps/web/src/features/guild/events/components/maps/map-card.tsx
+++ b/apps/web/src/features/guild/events/components/maps/map-card.tsx
@@ -304,20 +304,22 @@ export const MapCard = ({
         >
           {canManage && (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    className="size-9"
-                    onClick={() => onManageClick?.(map.id)}
-                    disabled={!isAssignmentEnabled}
-                    aria-label={manageActionLabel}
-                  >
-                    <Users className="size-4" />
-                  </Button>
-                </span>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <span className="inline-flex">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="size-9"
+                      onClick={() => onManageClick?.(map.id)}
+                      disabled={!isAssignmentEnabled}
+                      aria-label={manageActionLabel}
+                    >
+                      <Users className="size-4" />
+                    </Button>
+                  </span>
+                }
+              />
               <TooltipContent>
                 {isAssignmentEnabled
                   ? manageActionLabel
@@ -328,35 +330,39 @@ export const MapCard = ({
 
           {isAssignedToMe ? (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  className="size-9 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  onClick={() => onSelfUnassignClick?.(map.id)}
-                  aria-label={t("events.maps.unassignSelf")}
-                >
-                  <X className="size-4" />
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="size-9 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onClick={() => onSelfUnassignClick?.(map.id)}
+                    aria-label={t("events.maps.unassignSelf")}
+                  >
+                    <X className="size-4" />
+                  </Button>
+                }
+              />
               <TooltipContent>{t("events.maps.unassignSelf")}</TooltipContent>
             </Tooltip>
           ) : (
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    className="size-9"
-                    onClick={() => onSelfAssignClick?.(map.id)}
-                    disabled={!isAssignmentEnabled}
-                    aria-label={t("events.maps.assignSelf")}
-                  >
-                    <UserPlus className="size-4" />
-                  </Button>
-                </span>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <span className="inline-flex">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className="size-9"
+                      onClick={() => onSelfAssignClick?.(map.id)}
+                      disabled={!isAssignmentEnabled}
+                      aria-label={t("events.maps.assignSelf")}
+                    >
+                      <UserPlus className="size-4" />
+                    </Button>
+                  </span>
+                }
+              />
               <TooltipContent>{assignmentTooltipContent}</TooltipContent>
             </Tooltip>
           )}

--- a/apps/web/src/features/guild/events/components/maps/map-coverage-timeline.tsx
+++ b/apps/web/src/features/guild/events/components/maps/map-coverage-timeline.tsx
@@ -37,20 +37,22 @@ export const MapCoverageTimeline = ({
         <Tooltip
           key={`${segment.type}-${segment.startTime.toISOString()}-${segment.endTime.toISOString()}`}
         >
-          <TooltipTrigger asChild>
-            <div
-              className={cn(
-                "absolute h-full cursor-pointer transition-opacity hover:opacity-80",
-                segment.type === "COVERED" && "bg-green-500",
-                segment.type === "UNCOVERED" && "bg-yellow-500",
-                segment.type === "UNASSIGNED" && "bg-destructive",
-              )}
-              style={{
-                left: `${segment.startPercent}%`,
-                width: `${Math.max(segment.widthPercent, 0.5)}%`,
-              }}
-            />
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <div
+                className={cn(
+                  "absolute h-full cursor-pointer transition-opacity hover:opacity-80",
+                  segment.type === "COVERED" && "bg-green-500",
+                  segment.type === "UNCOVERED" && "bg-yellow-500",
+                  segment.type === "UNASSIGNED" && "bg-destructive",
+                )}
+                style={{
+                  left: `${segment.startPercent}%`,
+                  width: `${Math.max(segment.widthPercent, 0.5)}%`,
+                }}
+              />
+            }
+          />
           <TooltipContent side="top" className="text-xs">
             <div className="flex flex-col gap-0.5">
               <span className="font-medium">

--- a/apps/web/src/features/guild/events/components/member-kills/member-kill-row.tsx
+++ b/apps/web/src/features/guild/events/components/member-kills/member-kill-row.tsx
@@ -164,15 +164,17 @@ export const MemberKillRow = ({
           <div className="flex items-center justify-end gap-1">
             {hasManualPointsAdjustment && (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <span
-                    className="inline-flex size-6 shrink-0 items-center justify-center text-amber-400"
-                    tabIndex={0}
-                    aria-label={t("events.points.modified")}
-                  >
-                    <Info className="size-3.5" />
-                  </span>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <span
+                      className="inline-flex size-6 shrink-0 items-center justify-center text-amber-400"
+                      tabIndex={0}
+                      aria-label={t("events.points.modified")}
+                    >
+                      <Info className="size-3.5" />
+                    </span>
+                  }
+                />
                 <TooltipContent>
                   <p>{t("events.points.modified")}</p>
                 </TooltipContent>

--- a/apps/web/src/features/guild/events/components/ranking/event-ranking-actions.tsx
+++ b/apps/web/src/features/guild/events/components/ranking/event-ranking-actions.tsx
@@ -60,18 +60,20 @@ export const EventRankingActions = ({
       <div className="flex justify-end">
         <div className="hidden items-center lg:flex">
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-8 text-muted-foreground hover:text-foreground"
-                onClick={() => setIsEditDialogOpen(true)}
-                disabled={isEditPending}
-                aria-label={t("events.points.edit")}
-              >
-                <Pencil className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-8 text-muted-foreground hover:text-foreground"
+                  onClick={() => setIsEditDialogOpen(true)}
+                  disabled={isEditPending}
+                  aria-label={t("events.points.edit")}
+                >
+                  <Pencil className="size-3.5" />
+                </Button>
+              }
+            />
             <TooltipContent>
               <p>{t("events.points.edit")}</p>
             </TooltipContent>
@@ -79,19 +81,21 @@ export const EventRankingActions = ({
         </div>
 
         <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              size="icon"
-              variant="ghost"
-              className="size-11 text-muted-foreground lg:hidden"
-              disabled={isEditPending}
-              aria-label={t("events.ranking.moreActions")}
-            >
-              <MoreHorizontal className="size-4" />
-            </Button>
-          </DropdownMenuTrigger>
+          <DropdownMenuTrigger
+            render={
+              <Button
+                size="icon"
+                variant="ghost"
+                className="size-11 text-muted-foreground lg:hidden"
+                disabled={isEditPending}
+                aria-label={t("events.ranking.moreActions")}
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            }
+          />
           <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuItem onSelect={() => setIsEditDialogOpen(true)}>
+            <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
               <Pencil className="size-4" />
               {t("events.points.edit")}
             </DropdownMenuItem>

--- a/apps/web/src/features/guild/events/components/ranking/event-ranking-points.tsx
+++ b/apps/web/src/features/guild/events/components/ranking/event-ranking-points.tsx
@@ -5,8 +5,8 @@ import { pl } from "date-fns/locale";
 import { ArrowRight, History, Info } from "lucide-react";
 import {
   Popover,
-  PopoverAnchor,
   PopoverContent,
+  PopoverTrigger,
 } from "@lootlog/ui/components/popover";
 import { ScrollArea } from "@lootlog/ui/components/scroll-area";
 import {
@@ -50,16 +50,18 @@ export const EventRankingPoints = ({
   if (!canViewHistory) {
     return (
       <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className="flex items-center justify-end gap-1 text-sm"
-            tabIndex={0}
-            aria-label={t("events.points.modified")}
-          >
-            <Info className="size-3.5 shrink-0 text-amber-400" />
-            {pointsValue}
-          </span>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <span
+              className="flex items-center justify-end gap-1 text-sm"
+              tabIndex={0}
+              aria-label={t("events.points.modified")}
+            >
+              <Info className="size-3.5 shrink-0 text-amber-400" />
+              {pointsValue}
+            </span>
+          }
+        />
         <TooltipContent>
           <p>{t("events.points.modified")}</p>
         </TooltipContent>
@@ -70,19 +72,22 @@ export const EventRankingPoints = ({
   return (
     <Popover open={isHistoryOpen} onOpenChange={setIsHistoryOpen}>
       <Tooltip>
-        <PopoverAnchor asChild>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={() => setIsHistoryOpen(true)}
-              aria-label={t("events.points.history")}
-              className="ml-auto flex min-h-9 items-center justify-end gap-1 rounded-md px-1 text-sm outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              <Info className="size-3.5 shrink-0 text-amber-400" />
-              {pointsValue}
-            </button>
-          </TooltipTrigger>
-        </PopoverAnchor>
+        <PopoverTrigger
+          render={
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label={t("events.points.history")}
+                  className="ml-auto flex min-h-9 items-center justify-end gap-1 rounded-md px-1 text-sm outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              }
+            />
+          }
+        >
+          <Info className="size-3.5 shrink-0 text-amber-400" />
+          {pointsValue}
+        </PopoverTrigger>
         <TooltipContent>
           <p>{t("events.points.history")}</p>
         </TooltipContent>

--- a/apps/web/src/features/guild/events/components/scoring/scoring-action-editor.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-action-editor.tsx
@@ -54,7 +54,16 @@ export const ScoringActionEditor = ({
           control={control}
           name={`scoringRules.rules.${ruleIndex}.action.type`}
           render={({ field }) => (
-            <Select value={field.value} onValueChange={field.onChange}>
+            <Select
+              value={field.value}
+              onValueChange={field.onChange}
+              items={[
+                ...EVENT_SCORING_ACTION_TYPES.map((actionTypeOption) => ({
+                  value: actionTypeOption,
+                  label: <>{getScoringActionTypeLabel(actionTypeOption, t)}</>,
+                })),
+              ]}
+            >
               <SelectTrigger size="sm" className="h-8 text-[12px]">
                 <SelectValue />
               </SelectTrigger>

--- a/apps/web/src/features/guild/events/components/scoring/scoring-condition-boolean.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-condition-boolean.tsx
@@ -53,6 +53,12 @@ export const ScoringConditionBoolean = ({
               <Select
                 value={field.value as string}
                 onValueChange={field.onChange}
+                items={[
+                  ...EVENT_SCORING_BOOLEAN_FACTORS.map((factor) => ({
+                    value: factor,
+                    label: <>{getScoringFactorLabel(factor, t)}</>,
+                  })),
+                ]}
               >
                 <SelectTrigger size="sm" className="h-8 text-[12px]">
                   <SelectValue />
@@ -66,9 +72,11 @@ export const ScoringConditionBoolean = ({
                 </SelectContent>
               </Select>
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <HelpCircle className="size-3.5 text-muted-foreground/30 shrink-0 cursor-help" />
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <HelpCircle className="size-3.5 text-muted-foreground/30 shrink-0 cursor-help" />
+                  }
+                />
                 <TooltipContent side="top" className="max-w-[220px]">
                   <p className="text-xs">
                     {getScoringFactorDescription(
@@ -95,6 +103,16 @@ export const ScoringConditionBoolean = ({
             <Select
               value={String(field.value)}
               onValueChange={(v) => field.onChange(v === "true")}
+              items={[
+                {
+                  value: "true",
+                  label: <>{t("events.scoring.booleanValue.true")}</>,
+                },
+                {
+                  value: "false",
+                  label: <>{t("events.scoring.booleanValue.false")}</>,
+                },
+              ]}
             >
               <SelectTrigger size="sm" className="h-8 text-[12px]">
                 <SelectValue />

--- a/apps/web/src/features/guild/events/components/scoring/scoring-condition-numeric.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-condition-numeric.tsx
@@ -63,6 +63,12 @@ export const ScoringConditionNumeric = ({
               <Select
                 value={field.value as string}
                 onValueChange={field.onChange}
+                items={[
+                  ...EVENT_SCORING_NUMERIC_FACTORS.map((factor) => ({
+                    value: factor,
+                    label: <>{getScoringFactorLabel(factor, t)}</>,
+                  })),
+                ]}
               >
                 <SelectTrigger size="sm" className="h-8 text-[12px]">
                   <SelectValue />
@@ -76,9 +82,11 @@ export const ScoringConditionNumeric = ({
                 </SelectContent>
               </Select>
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <HelpCircle className="size-3.5 text-muted-foreground/30 shrink-0 cursor-help" />
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <HelpCircle className="size-3.5 text-muted-foreground/30 shrink-0 cursor-help" />
+                  }
+                />
                 <TooltipContent side="top" className="max-w-[220px]">
                   <p className="text-xs">
                     {getScoringFactorDescription(
@@ -105,6 +113,12 @@ export const ScoringConditionNumeric = ({
             <Select
               value={field.value as string}
               onValueChange={field.onChange}
+              items={[
+                ...EVENT_SCORING_NUMERIC_OPERATORS.map((operator) => ({
+                  value: operator,
+                  label: <>{operator}</>,
+                })),
+              ]}
             >
               <SelectTrigger size="sm" className="h-8 text-[12px] font-mono">
                 <SelectValue />

--- a/apps/web/src/features/guild/events/components/scoring/scoring-condition-respawn.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-condition-respawn.tsx
@@ -80,6 +80,12 @@ export const ScoringConditionRespawn = ({
               <Select
                 value={field.value as string}
                 onValueChange={field.onChange}
+                items={[
+                  ...EVENT_SCORING_NUMERIC_OPERATORS.map((operator) => ({
+                    value: operator,
+                    label: <>{operator}</>,
+                  })),
+                ]}
               >
                 <SelectTrigger size="sm" className="h-8 text-[12px] font-mono">
                   <SelectValue />

--- a/apps/web/src/features/guild/events/components/scoring/scoring-conditions-editor.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-conditions-editor.tsx
@@ -181,6 +181,18 @@ const ConditionRow = ({
                     { shouldDirty: true, shouldValidate: true },
                   );
                 }}
+                items={[
+                  ...EVENT_SCORING_CONDITION_TYPES.map(
+                    (conditionTypeOption) => ({
+                      value: conditionTypeOption,
+                      label: (
+                        <>
+                          {getScoringConditionTypeLabel(conditionTypeOption, t)}
+                        </>
+                      ),
+                    }),
+                  ),
+                ]}
               >
                 <SelectTrigger
                   size="sm"

--- a/apps/web/src/features/guild/events/components/scoring/scoring-global-settings.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-global-settings.tsx
@@ -32,9 +32,11 @@ export const ScoringGlobalSettings = ({
             {t("events.scoring.hardCapPoints")}
           </Label>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <HelpCircle className="size-3 text-muted-foreground/30 cursor-help" />
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <HelpCircle className="size-3 text-muted-foreground/30 cursor-help" />
+              }
+            />
             <TooltipContent>
               <p className="text-xs">
                 {t("events.scoring.summary.cap", { points: "X" })}

--- a/apps/web/src/features/guild/events/components/scoring/scoring-rule-card.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-rule-card.tsx
@@ -71,57 +71,62 @@ export const ScoringRuleCard = ({
         )}
       >
         {/* Collapsed header / trigger */}
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              "flex w-full items-center gap-2.5 p-3 text-left transition-colors cursor-pointer",
-              "hover:bg-muted/30",
-            )}
-          >
-            <GripVertical className="size-3.5 text-muted-foreground/40 shrink-0" />
+        <CollapsibleTrigger
+          render={
+            <button
+              type="button"
+              className={cn(
+                "flex w-full items-center gap-2.5 p-3 text-left transition-colors cursor-pointer",
+                "hover:bg-muted/30",
+              )}
+            >
+              <GripVertical className="size-3.5 text-muted-foreground/40 shrink-0" />
 
-            <span className="flex items-center justify-center size-5 rounded-md bg-muted/60 text-[10px] font-mono font-bold text-muted-foreground shrink-0">
-              {ruleIndex + 1}
-            </span>
+              <span className="flex items-center justify-center size-5 rounded-md bg-muted/60 text-[10px] font-mono font-bold text-muted-foreground shrink-0">
+                {ruleIndex + 1}
+              </span>
 
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-medium truncate">
-                  {rule?.name || t("events.scoring.unnamedRule")}
-                </p>
-                {!open && conditionCount > 1 && (
-                  <span className="text-[10px] text-muted-foreground/60 shrink-0">
-                    {conditionCount}{" "}
-                    {t("events.scoring.conditionsCount", "war.")}
-                  </span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">
+                    {rule?.name || t("events.scoring.unnamedRule")}
+                  </p>
+                  {!open && conditionCount > 1 && (
+                    <span className="text-[10px] text-muted-foreground/60 shrink-0">
+                      {conditionCount}{" "}
+                      {t("events.scoring.conditionsCount", "war.")}
+                    </span>
+                  )}
+                </div>
+                {!open && rule && (
+                  <div className="mt-0.5">
+                    <ScoringRuleSummary rule={rule} />
+                  </div>
                 )}
               </div>
-              {!open && rule && (
-                <div className="mt-0.5">
-                  <ScoringRuleSummary rule={rule} />
-                </div>
-              )}
-            </div>
 
-            <div className="flex items-center gap-1.5 shrink-0">
-              {!isEnabled && (
-                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                  {t("events.scoring.ruleDisabledSuffix")}
-                </Badge>
-              )}
-              <ChevronDown
-                className={cn(
-                  "size-4 text-muted-foreground transition-transform duration-200",
-                  open && "rotate-180",
+              <div className="flex items-center gap-1.5 shrink-0">
+                {!isEnabled && (
+                  <Badge
+                    variant="secondary"
+                    className="text-[10px] px-1.5 py-0"
+                  >
+                    {t("events.scoring.ruleDisabledSuffix")}
+                  </Badge>
                 )}
-              />
-            </div>
-          </button>
-        </CollapsibleTrigger>
+                <ChevronDown
+                  className={cn(
+                    "size-4 text-muted-foreground transition-transform duration-200",
+                    open && "rotate-180",
+                  )}
+                />
+              </div>
+            </button>
+          }
+        />
 
         {/* Expanded editor */}
-        <CollapsibleContent forceMount className={cn(!open && "hidden")}>
+        <CollapsibleContent keepMounted className={cn(!open && "hidden")}>
           <div className="border-t border-border/60">
             {/* Rule name & enabled toggle */}
             <div className="px-3 pt-3 pb-2">
@@ -165,9 +170,11 @@ export const ScoringRuleCard = ({
                   {t("events.scoring.ifLabel")}
                 </span>
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info className="size-3 text-blue-400/50 cursor-help" />
-                  </TooltipTrigger>
+                  <TooltipTrigger
+                    render={
+                      <Info className="size-3 text-blue-400/50 cursor-help" />
+                    }
+                  />
                   <TooltipContent>
                     <p>{t("events.scoring.conditionAndHint")}</p>
                   </TooltipContent>

--- a/apps/web/src/features/guild/events/components/scoring/scoring-rule-templates-menu.tsx
+++ b/apps/web/src/features/guild/events/components/scoring/scoring-rule-templates-menu.tsx
@@ -21,12 +21,14 @@ export const ScoringRuleTemplatesMenu = ({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button type="button" variant="outline" size="sm">
-          <LayoutTemplate className="size-3.5 mr-1.5" />
-          {t("events.scoring.template.menuLabel")}
-        </Button>
-      </DropdownMenuTrigger>
+      <DropdownMenuTrigger
+        render={
+          <Button type="button" variant="outline" size="sm">
+            <LayoutTemplate className="size-3.5 mr-1.5" />
+            {t("events.scoring.template.menuLabel")}
+          </Button>
+        }
+      />
       <DropdownMenuContent align="start" className="w-72">
         {SCORING_RULE_TEMPLATES.map((template) => (
           <DropdownMenuItem

--- a/apps/web/src/features/guild/events/event-detail.tsx
+++ b/apps/web/src/features/guild/events/event-detail.tsx
@@ -559,17 +559,19 @@ export const EventDetail = () => {
                   </span>
 
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        type="button"
-                        className="inline-flex items-center gap-1.5 rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                      >
-                        <Clock className="size-3.5" />
-                        {t("events.header.assignmentTimeoutValue", {
-                          minutes: event.assignmentTimeoutMinutes ?? 5,
-                        })}
-                      </button>
-                    </TooltipTrigger>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1.5 rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                        >
+                          <Clock className="size-3.5" />
+                          {t("events.header.assignmentTimeoutValue", {
+                            minutes: event.assignmentTimeoutMinutes ?? 5,
+                          })}
+                        </button>
+                      }
+                    />
                     <TooltipContent>
                       <p>{t("events.header.assignmentTimeoutTooltip")}</p>
                     </TooltipContent>
@@ -582,51 +584,57 @@ export const EventDetail = () => {
                 </div>
               </div>
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    aria-label={pinActionLabel}
-                    aria-pressed={eventIsPinned}
-                    disabled={!eventId || isPinLoading}
-                    className={cn(
-                      "h-9 shrink-0 gap-2 px-3",
-                      eventIsPinned
-                        ? "border-yellow-500/35 bg-yellow-500/10 text-yellow-500 hover:border-yellow-500/50 hover:bg-yellow-500/15 hover:text-yellow-500"
-                        : "border-primary/30 bg-primary/5 text-primary hover:border-primary/50 hover:bg-primary/10 hover:text-primary",
-                    )}
-                    onClick={() => {
-                      if (eventId) {
-                        togglePin(eventId);
-                      }
-                    }}
-                  >
-                    <Star
-                      className={cn("size-4", eventIsPinned && "fill-current")}
-                    />
-                    <span className="hidden sm:inline">{pinActionLabel}</span>
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      aria-label={pinActionLabel}
+                      aria-pressed={eventIsPinned}
+                      disabled={!eventId || isPinLoading}
+                      className={cn(
+                        "h-9 shrink-0 gap-2 px-3",
+                        eventIsPinned
+                          ? "border-yellow-500/35 bg-yellow-500/10 text-yellow-500 hover:border-yellow-500/50 hover:bg-yellow-500/15 hover:text-yellow-500"
+                          : "border-primary/30 bg-primary/5 text-primary hover:border-primary/50 hover:bg-primary/10 hover:text-primary",
+                      )}
+                      onClick={() => {
+                        if (eventId) {
+                          togglePin(eventId);
+                        }
+                      }}
+                    >
+                      <Star
+                        className={cn(
+                          "size-4",
+                          eventIsPinned && "fill-current",
+                        )}
+                      />
+                      <span className="hidden sm:inline">{pinActionLabel}</span>
+                    </Button>
+                  }
+                />
                 <TooltipContent>{pinActionLabel}</TooltipContent>
               </Tooltip>
             </div>
 
             <div className="grid gap-1 border-t border-border bg-muted/20 p-1.5 sm:grid-cols-3">
               <Button
-                asChild
                 size="sm"
                 variant="ghost"
                 className="w-full min-w-0 justify-center text-muted-foreground hover:text-foreground"
-              >
-                <Link
-                  to="/$guildId/events/$eventId/coordination"
-                  params={{ guildId: guildId ?? "", eventId: eventId ?? "" }}
-                >
-                  <Crosshair className="size-3.5" />
-                  {t("events.coordination.trigger")}
-                </Link>
-              </Button>
+                render={
+                  <Link
+                    to="/$guildId/events/$eventId/coordination"
+                    params={{ guildId: guildId ?? "", eventId: eventId ?? "" }}
+                  >
+                    <Crosshair className="size-3.5" />
+                    {t("events.coordination.trigger")}
+                  </Link>
+                }
+                nativeButton={false}
+              />
               <Button
                 size="sm"
                 variant="ghost"

--- a/apps/web/src/features/guild/events/hero-detail.tsx
+++ b/apps/web/src/features/guild/events/hero-detail.tsx
@@ -625,36 +625,38 @@ export const HeroDetail = () => {
               </div>
               {canManage && (
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-9 shrink-0 px-2.5 lg:px-3"
-                      aria-label={t(
-                        heroTimer
-                          ? "events.respawn.closeWindow"
-                          : "events.respawn.openWindow",
-                      )}
-                      onClick={() =>
-                        heroTimer
-                          ? setCloseWindowOpen(true)
-                          : setOpenWindowOpen(true)
-                      }
-                    >
-                      {heroTimer ? (
-                        <X className="size-4" />
-                      ) : (
-                        <Timer className="size-4" />
-                      )}
-                      <span className="hidden lg:inline">
-                        {t(
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-9 shrink-0 px-2.5 lg:px-3"
+                        aria-label={t(
                           heroTimer
                             ? "events.respawn.closeWindow"
                             : "events.respawn.openWindow",
                         )}
-                      </span>
-                    </Button>
-                  </TooltipTrigger>
+                        onClick={() =>
+                          heroTimer
+                            ? setCloseWindowOpen(true)
+                            : setOpenWindowOpen(true)
+                        }
+                      >
+                        {heroTimer ? (
+                          <X className="size-4" />
+                        ) : (
+                          <Timer className="size-4" />
+                        )}
+                        <span className="hidden lg:inline">
+                          {t(
+                            heroTimer
+                              ? "events.respawn.closeWindow"
+                              : "events.respawn.openWindow",
+                          )}
+                        </span>
+                      </Button>
+                    }
+                  />
                   <TooltipContent>
                     {t(
                       heroTimer
@@ -692,42 +694,46 @@ export const HeroDetail = () => {
                   {canManage && (
                     <div className="ml-auto flex shrink-0 items-center gap-1.5">
                       <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              className="size-9 px-0 @2xl/maps:w-auto @2xl/maps:px-3"
-                              onClick={handleClearAllAssignments}
-                              disabled={uniqueMembers.length === 0}
-                              aria-label={t("events.maps.clearAll")}
-                            >
-                              <Eraser className="size-4" />
-                              <span className="hidden @2xl/maps:inline">
-                                {t("events.maps.clearAll")}
-                              </span>
-                            </Button>
-                          </span>
-                        </TooltipTrigger>
+                        <TooltipTrigger
+                          render={
+                            <span className="inline-flex">
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="size-9 px-0 @2xl/maps:w-auto @2xl/maps:px-3"
+                                onClick={handleClearAllAssignments}
+                                disabled={uniqueMembers.length === 0}
+                                aria-label={t("events.maps.clearAll")}
+                              >
+                                <Eraser className="size-4" />
+                                <span className="hidden @2xl/maps:inline">
+                                  {t("events.maps.clearAll")}
+                                </span>
+                              </Button>
+                            </span>
+                          }
+                        />
                         <TooltipContent>
                           {t("events.maps.clearAll")}
                         </TooltipContent>
                       </Tooltip>
                       <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="size-9 px-0 @2xl/maps:w-auto @2xl/maps:px-3"
-                            onClick={() => setMapManageOpen(true)}
-                            aria-label={t("events.maps.manage")}
-                          >
-                            <Plus className="size-4" />
-                            <span className="hidden @2xl/maps:inline">
-                              {t("events.maps.manage")}
-                            </span>
-                          </Button>
-                        </TooltipTrigger>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="size-9 px-0 @2xl/maps:w-auto @2xl/maps:px-3"
+                              onClick={() => setMapManageOpen(true)}
+                              aria-label={t("events.maps.manage")}
+                            >
+                              <Plus className="size-4" />
+                              <span className="hidden @2xl/maps:inline">
+                                {t("events.maps.manage")}
+                              </span>
+                            </Button>
+                          }
+                        />
                         <TooltipContent>
                           {t("events.maps.manage")}
                         </TooltipContent>

--- a/apps/web/src/features/guild/events/kill-detail.tsx
+++ b/apps/web/src/features/guild/events/kill-detail.tsx
@@ -92,18 +92,22 @@ export const KillDetail = () => {
         <p className="text-sm text-muted-foreground">
           {t("events.killDetail.notFound")}
         </p>
-        <Button variant="outline" asChild>
-          <Link
-            to="/$guildId/events/$eventId/heroes/$heroId"
-            params={{
-              guildId: guildId ?? "",
-              eventId: eventId ?? "",
-              heroId: heroId ?? "",
-            }}
-          >
-            {t("events.common.backToHero")}
-          </Link>
-        </Button>
+        <Button
+          variant="outline"
+          render={
+            <Link
+              to="/$guildId/events/$eventId/heroes/$heroId"
+              params={{
+                guildId: guildId ?? "",
+                eventId: eventId ?? "",
+                heroId: heroId ?? "",
+              }}
+            >
+              {t("events.common.backToHero")}
+            </Link>
+          }
+          nativeButton={false}
+        />
       </div>
     );
   }

--- a/apps/web/src/features/guild/loots-list/components/loots-filters/loot-filters-header.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-filters/loot-filters-header.tsx
@@ -137,55 +137,63 @@ export const LootFiltersHeader = ({
                   )}
                 >
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        onMouseEnter={() => setHoveredButton("list")}
-                        onMouseLeave={() => setHoveredButton(null)}
-                      >
-                        <ThemeInteractiveFrame
-                          isHovered={hoveredButton === "list"}
-                          isActive={viewMode === "list"}
+                    <TooltipTrigger
+                      render={
+                        <div
+                          onMouseEnter={() => setHoveredButton("list")}
+                          onMouseLeave={() => setHoveredButton(null)}
                         >
-                          <Button
-                            onClick={() => setViewMode("list")}
-                            variant={viewMode === "list" ? "default" : "ghost"}
-                            size="icon"
-                            aria-label={t("loots.header.listView")}
-                            aria-pressed={viewMode === "list"}
-                            className="h-8 w-8"
+                          <ThemeInteractiveFrame
+                            isHovered={hoveredButton === "list"}
+                            isActive={viewMode === "list"}
                           >
-                            <List className="h-4 w-4" />
-                          </Button>
-                        </ThemeInteractiveFrame>
-                      </div>
-                    </TooltipTrigger>
+                            <Button
+                              onClick={() => setViewMode("list")}
+                              variant={
+                                viewMode === "list" ? "default" : "ghost"
+                              }
+                              size="icon"
+                              aria-label={t("loots.header.listView")}
+                              aria-pressed={viewMode === "list"}
+                              className="h-8 w-8"
+                            >
+                              <List className="h-4 w-4" />
+                            </Button>
+                          </ThemeInteractiveFrame>
+                        </div>
+                      }
+                    />
                     <TooltipContent side="bottom">
                       <p>{t("loots.header.listView")}</p>
                     </TooltipContent>
                   </Tooltip>
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        onMouseEnter={() => setHoveredButton("grid")}
-                        onMouseLeave={() => setHoveredButton(null)}
-                      >
-                        <ThemeInteractiveFrame
-                          isHovered={hoveredButton === "grid"}
-                          isActive={viewMode === "grid"}
+                    <TooltipTrigger
+                      render={
+                        <div
+                          onMouseEnter={() => setHoveredButton("grid")}
+                          onMouseLeave={() => setHoveredButton(null)}
                         >
-                          <Button
-                            onClick={() => setViewMode("grid")}
-                            variant={viewMode === "grid" ? "default" : "ghost"}
-                            size="icon"
-                            aria-label={t("loots.header.gridView")}
-                            aria-pressed={viewMode === "grid"}
-                            className="h-8 w-8"
+                          <ThemeInteractiveFrame
+                            isHovered={hoveredButton === "grid"}
+                            isActive={viewMode === "grid"}
                           >
-                            <Grid2X2 className="h-4 w-4" />
-                          </Button>
-                        </ThemeInteractiveFrame>
-                      </div>
-                    </TooltipTrigger>
+                            <Button
+                              onClick={() => setViewMode("grid")}
+                              variant={
+                                viewMode === "grid" ? "default" : "ghost"
+                              }
+                              size="icon"
+                              aria-label={t("loots.header.gridView")}
+                              aria-pressed={viewMode === "grid"}
+                              className="h-8 w-8"
+                            >
+                              <Grid2X2 className="h-4 w-4" />
+                            </Button>
+                          </ThemeInteractiveFrame>
+                        </div>
+                      }
+                    />
                     <TooltipContent side="bottom">
                       <p>{t("loots.header.gridView")}</p>
                     </TooltipContent>

--- a/apps/web/src/features/guild/loots-list/components/loots-filters/loots-filters-sidebar.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-filters/loots-filters-sidebar.tsx
@@ -439,7 +439,7 @@ export const LootsFiltersSidebar: FC<LootsFiltersSidebarProps> = ({
                   </div>
                 </div>
 
-                <Accordion type="multiple" defaultValue={initiallyOpenSections}>
+                <Accordion multiple defaultValue={initiallyOpenSections}>
                   <AccordionItem
                     value="npc"
                     className="border-b border-border/70 px-3 sm:px-4"

--- a/apps/web/src/features/guild/loots-list/components/loots-list/loot-details-dialog.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-list/loot-details-dialog.tsx
@@ -164,7 +164,7 @@ export const LootDetailsDialog: FC = () => {
       <DialogContent
         className="max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] overflow-hidden rounded-2xl border-border bg-background p-0 sm:max-w-[36rem]"
         aria-describedby={undefined}
-        onOpenAutoFocus={(e) => e.preventDefault()}
+        initialFocus={false}
       >
         {renderContent()}
       </DialogContent>

--- a/apps/web/src/features/guild/loots-list/components/loots-list/loot-details.tsx
+++ b/apps/web/src/features/guild/loots-list/components/loots-list/loot-details.tsx
@@ -96,16 +96,18 @@ export const LootDetails: FC<LootDetailsProps> = ({ loot, ownerMap }) => {
       {showCollapsible && (
         <Collapsible open={open} onOpenChange={setOpen}>
           <CollapsibleContent>{hiddenItems.map(renderItem)}</CollapsibleContent>
-          <CollapsibleTrigger asChild>
-            <Button
-              variant="ghost"
-              className="my-2 w-full cursor-pointer text-muted-foreground hover:text-foreground"
-            >
-              {open
-                ? t("loots.details.showLess")
-                : t("loots.details.showMore", { count: hiddenItems.length })}
-            </Button>
-          </CollapsibleTrigger>
+          <CollapsibleTrigger
+            render={
+              <Button
+                variant="ghost"
+                className="my-2 w-full cursor-pointer text-muted-foreground hover:text-foreground"
+              >
+                {open
+                  ? t("loots.details.showLess")
+                  : t("loots.details.showMore", { count: hiddenItems.length })}
+              </Button>
+            }
+          />
         </Collapsible>
       )}
     </div>

--- a/apps/web/src/features/guild/loots-list/loots-list.tsx
+++ b/apps/web/src/features/guild/loots-list/loots-list.tsx
@@ -60,7 +60,6 @@ export const LootsListPage: React.FC = () => {
         <Drawer
           open={isMobileFiltersOpen}
           onOpenChange={setIsMobileFiltersOpen}
-          shouldScaleBackground={false}
         >
           <DrawerContent className="flex h-[92dvh] max-h-[92dvh] flex-col overflow-hidden p-0">
             <DrawerHeader className="shrink-0 border-b px-4 py-3">

--- a/apps/web/src/features/guild/notifications/components/notification-rule-card.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-rule-card.tsx
@@ -313,23 +313,25 @@ export const NotificationRuleCard = ({
         </div>
         <div className="flex gap-1">
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="secondary"
-                aria-label={t("settings.notifications.actions.testNow")}
-                disabled={
-                  isActionDisabled ||
-                  !rule.enabled ||
-                  !hasTestableTargets ||
-                  rule.testTrigger.remaining === 0
-                }
-                onClick={handleTriggerTest}
-              >
-                <FlaskConical className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="secondary"
+                  aria-label={t("settings.notifications.actions.testNow")}
+                  disabled={
+                    isActionDisabled ||
+                    !rule.enabled ||
+                    !hasTestableTargets ||
+                    rule.testTrigger.remaining === 0
+                  }
+                  onClick={handleTriggerTest}
+                >
+                  <FlaskConical className="h-4 w-4" />
+                </Button>
+              }
+            />
             <TooltipContent>
               <p>{t("settings.notifications.actions.testNow")}</p>
               <p className="text-muted-foreground">
@@ -342,82 +344,94 @@ export const NotificationRuleCard = ({
             </TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="outline"
-                aria-label={t("settings.notifications.actions.rebuildPending")}
-                disabled={isActionDisabled || !rule.enabled}
-                onClick={handleRebuildJobs}
-              >
-                <RefreshCw className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  aria-label={t(
+                    "settings.notifications.actions.rebuildPending",
+                  )}
+                  disabled={isActionDisabled || !rule.enabled}
+                  onClick={handleRebuildJobs}
+                >
+                  <RefreshCw className="h-4 w-4" />
+                </Button>
+              }
+            />
             <TooltipContent>
               {t("settings.notifications.actions.rebuildPending")}
             </TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="outline"
-                aria-label={t("settings.notifications.actions.edit")}
-                disabled={isActionDisabled}
-                asChild
-              >
-                <Link
-                  to={ROUTES.guild.notifications.rule(
-                    guildId ?? "",
-                    String(rule.id),
-                  )}
-                >
-                  <Pencil className="h-4 w-4" />
-                </Link>
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  aria-label={t("settings.notifications.actions.edit")}
+                  disabled={isActionDisabled}
+
+                  render={
+                    <Link
+                      to={ROUTES.guild.notifications.rule(
+                        guildId ?? "",
+                        String(rule.id),
+                      )}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Link>
+                  }
+                  nativeButton={false}
+                />
+              }
+            />
             <TooltipContent>
               {t("settings.notifications.actions.edit")}
             </TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <ConfirmDeleteDialog
-                  disabled={isActionDisabled}
-                  onConfirm={handleDelete}
-                  title={t("settings.notifications.deleteRuleDialog.title")}
-                  description={t(
-                    "settings.notifications.deleteRuleDialog.description",
-                    {
-                      name:
-                        rule.name ??
-                        t(
-                          getNotificationTriggerTranslationKey(
-                            rule.triggerType,
+            <TooltipTrigger
+              render={
+                <span className="inline-flex">
+                  <ConfirmDeleteDialog
+                    disabled={isActionDisabled}
+                    onConfirm={handleDelete}
+                    title={t("settings.notifications.deleteRuleDialog.title")}
+                    description={t(
+                      "settings.notifications.deleteRuleDialog.description",
+                      {
+                        name:
+                          rule.name ??
+                          t(
+                            getNotificationTriggerTranslationKey(
+                              rule.triggerType,
+                            ),
                           ),
-                        ),
-                    },
-                  )}
-                  confirmButtonLabel={t(
-                    "settings.notifications.actions.delete",
-                  )}
-                  cancelButtonLabel={t("settings.notifications.actions.cancel")}
-                  trigger={
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="destructive"
-                      aria-label={t("settings.notifications.actions.delete")}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  }
-                />
-              </span>
-            </TooltipTrigger>
+                      },
+                    )}
+                    confirmButtonLabel={t(
+                      "settings.notifications.actions.delete",
+                    )}
+                    cancelButtonLabel={t(
+                      "settings.notifications.actions.cancel",
+                    )}
+                    trigger={
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="destructive"
+                        aria-label={t("settings.notifications.actions.delete")}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    }
+                  />
+                </span>
+              }
+            />
             <TooltipContent>
               {t("settings.notifications.actions.delete")}
             </TooltipContent>

--- a/apps/web/src/features/guild/notifications/components/notification-target-card.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-target-card.tsx
@@ -144,62 +144,68 @@ export const NotificationTargetCard = ({
         </div>
         <div className="flex gap-1">
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                size="icon"
-                variant="outline"
-                aria-label={t("settings.notifications.actions.edit")}
-                disabled={isActionDisabled}
-                onClick={() => onEdit(target)}
-              >
-                <Pencil className="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="outline"
+                  aria-label={t("settings.notifications.actions.edit")}
+                  disabled={isActionDisabled}
+                  onClick={() => onEdit(target)}
+                >
+                  <Pencil className="h-4 w-4" />
+                </Button>
+              }
+            />
             <TooltipContent>
               {t("settings.notifications.actions.edit")}
             </TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <ConfirmDeleteDialog
-                  disabled={isActionDisabled}
-                  onConfirm={handleDelete}
-                  title={t("settings.notifications.deleteTargetDialog.title")}
-                  description={
-                    orphanedRuleCount > 0
-                      ? t(
-                          "settings.notifications.deleteTargetDialog.descriptionWithOrphanedRules",
-                          {
-                            name: getGuildNotificationTargetLabel(target),
-                            count: orphanedRuleCount,
-                          },
-                        )
-                      : t(
-                          "settings.notifications.deleteTargetDialog.description",
-                          {
-                            name: getGuildNotificationTargetLabel(target),
-                          },
-                        )
-                  }
-                  confirmButtonLabel={t(
-                    "settings.notifications.actions.delete",
-                  )}
-                  cancelButtonLabel={t("settings.notifications.actions.cancel")}
-                  trigger={
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="destructive"
-                      aria-label={t("settings.notifications.actions.delete")}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  }
-                />
-              </span>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <span className="inline-flex">
+                  <ConfirmDeleteDialog
+                    disabled={isActionDisabled}
+                    onConfirm={handleDelete}
+                    title={t("settings.notifications.deleteTargetDialog.title")}
+                    description={
+                      orphanedRuleCount > 0
+                        ? t(
+                            "settings.notifications.deleteTargetDialog.descriptionWithOrphanedRules",
+                            {
+                              name: getGuildNotificationTargetLabel(target),
+                              count: orphanedRuleCount,
+                            },
+                          )
+                        : t(
+                            "settings.notifications.deleteTargetDialog.description",
+                            {
+                              name: getGuildNotificationTargetLabel(target),
+                            },
+                          )
+                    }
+                    confirmButtonLabel={t(
+                      "settings.notifications.actions.delete",
+                    )}
+                    cancelButtonLabel={t(
+                      "settings.notifications.actions.cancel",
+                    )}
+                    trigger={
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="destructive"
+                        aria-label={t("settings.notifications.actions.delete")}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    }
+                  />
+                </span>
+              }
+            />
             <TooltipContent>
               {t("settings.notifications.actions.delete")}
             </TooltipContent>

--- a/apps/web/src/features/guild/notifications/components/notification-target-dialog.tsx
+++ b/apps/web/src/features/guild/notifications/components/notification-target-dialog.tsx
@@ -259,16 +259,32 @@ export const NotificationTargetDialog = ({
                       disabled={
                         isLoadingChannels || availableChannels.length === 0
                       }
+                      items={[
+                        {
+                          value: null,
+                          label: (
+                            <>
+                              {t("settings.notifications.placeholders.channel")}
+                            </>
+                          ),
+                        },
+                        ...availableChannels.map((channel) => ({
+                          value: channel.channelId,
+                          label: <>{channel.name}</>,
+                        })),
+                      ]}
                     >
-                      <FormControl>
-                        <SelectTrigger className="w-full">
-                          <SelectValue
-                            placeholder={t(
-                              "settings.notifications.placeholders.channel",
-                            )}
-                          />
-                        </SelectTrigger>
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <SelectTrigger className="w-full">
+                            <SelectValue
+                              placeholder={t(
+                                "settings.notifications.placeholders.channel",
+                              )}
+                            />
+                          </SelectTrigger>
+                        }
+                      />
                       <SelectContent>
                         {availableChannels.map((channel) => (
                           <SelectItem
@@ -305,14 +321,16 @@ export const NotificationTargetDialog = ({
                   <FormLabel className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                     {t("settings.notifications.fields.displayName")}
                   </FormLabel>
-                  <FormControl>
-                    <Input
-                      {...field}
-                      placeholder={t(
-                        "settings.notifications.placeholders.displayName",
-                      )}
-                    />
-                  </FormControl>
+                  <FormControl
+                    render={
+                      <Input
+                        {...field}
+                        placeholder={t(
+                          "settings.notifications.placeholders.displayName",
+                        )}
+                      />
+                    }
+                  />
                   <FormMessage />
                 </FormItem>
               )}
@@ -333,12 +351,14 @@ export const NotificationTargetDialog = ({
                           {t("settings.notifications.fields.activeDescription")}
                         </p>
                       </div>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        }
+                      />
                     </div>
                     {!field.value && target?.active ? (
                       <p className="text-xs text-amber-500">

--- a/apps/web/src/features/guild/notifications/components/notifications-actions-card.tsx
+++ b/apps/web/src/features/guild/notifications/components/notifications-actions-card.tsx
@@ -39,11 +39,15 @@ export const NotificationsActionsCard = ({
           {t("settings.notifications.actions.addTarget")}
         </Button>
         {hasRequiredPermissions && !isRuleLimitReached ? (
-          <Button size="sm" asChild>
-            <Link to={ROUTES.guild.notifications.create(guildId ?? "")}>
-              {t("settings.notifications.actions.addRule")}
-            </Link>
-          </Button>
+          <Button
+            size="sm"
+            render={
+              <Link to={ROUTES.guild.notifications.create(guildId ?? "")}>
+                {t("settings.notifications.actions.addRule")}
+              </Link>
+            }
+            nativeButton={false}
+          />
         ) : (
           <Button size="sm" disabled>
             {t("settings.notifications.actions.addRule")}

--- a/apps/web/src/features/guild/notifications/components/notifications-recent-history-card.tsx
+++ b/apps/web/src/features/guild/notifications/components/notifications-recent-history-card.tsx
@@ -99,13 +99,19 @@ export const NotificationsRecentHistoryCard = ({
               </div>
             </Card>
           ))}
-          <Button size="sm" variant="outline" className="w-full" asChild>
-            <Link to={ROUTES.guild.notifications.history(guildId ?? "")}>
-              {t("settings.notifications.actions.showAllHistory", {
-                count: historyJobs.length,
-              })}
-            </Link>
-          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full"
+            render={
+              <Link to={ROUTES.guild.notifications.history(guildId ?? "")}>
+                {t("settings.notifications.actions.showAllHistory", {
+                  count: historyJobs.length,
+                })}
+              </Link>
+            }
+            nativeButton={false}
+          />
         </div>
       ) : (
         <div className="rounded-xl border border-dashed border-border/80 bg-background p-6 text-sm text-muted-foreground">

--- a/apps/web/src/features/guild/notifications/notification-rule-form-page.tsx
+++ b/apps/web/src/features/guild/notifications/notification-rule-form-page.tsx
@@ -164,20 +164,50 @@ export const NotificationRuleFormPage = () => {
                                 form.setValue("scheduledAt", "");
                               }
                             }}
+                            items={[
+                              {
+                                value:
+                                  NotificationTriggerType.TIMER_BEFORE_SPAWN,
+                                label: (
+                                  <>
+                                    {t(
+                                      getNotificationTriggerTranslationKey(
+                                        NotificationTriggerType.TIMER_BEFORE_SPAWN,
+                                      ),
+                                    )}
+                                  </>
+                                ),
+                              },
+                              {
+                                value:
+                                  NotificationTriggerType.SCHEDULED_MESSAGE,
+                                label: (
+                                  <>
+                                    {t(
+                                      getNotificationTriggerTranslationKey(
+                                        NotificationTriggerType.SCHEDULED_MESSAGE,
+                                      ),
+                                    )}
+                                  </>
+                                ),
+                              },
+                            ]}
                           >
-                            <FormControl>
-                              <SelectTrigger className="w-full">
-                                <SelectValue>
-                                  {field.value
-                                    ? t(
-                                        getNotificationTriggerTranslationKey(
-                                          field.value,
-                                        ),
-                                      )
-                                    : null}
-                                </SelectValue>
-                              </SelectTrigger>
-                            </FormControl>
+                            <FormControl
+                              render={
+                                <SelectTrigger className="w-full">
+                                  <SelectValue>
+                                    {field.value
+                                      ? t(
+                                          getNotificationTriggerTranslationKey(
+                                            field.value,
+                                          ),
+                                        )
+                                      : null}
+                                  </SelectValue>
+                                </SelectTrigger>
+                              }
+                            />
                             <SelectContent>
                               <SelectItem
                                 value={
@@ -225,14 +255,16 @@ export const NotificationRuleFormPage = () => {
                           <FormLabel className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                             {t("settings.notifications.fields.name")}
                           </FormLabel>
-                          <FormControl>
-                            <Input
-                              {...field}
-                              placeholder={t(
-                                "settings.notifications.placeholders.name",
-                              )}
-                            />
-                          </FormControl>
+                          <FormControl
+                            render={
+                              <Input
+                                {...field}
+                                placeholder={t(
+                                  "settings.notifications.placeholders.name",
+                                )}
+                              />
+                            }
+                          />
                           <FormMessage />
                         </FormItem>
                       )}
@@ -254,16 +286,34 @@ export const NotificationRuleFormPage = () => {
                                   if (!value) return;
                                   field.onChange(value);
                                 }}
+                                items={[
+                                  {
+                                    value: ALL_WORLDS_VALUE,
+                                    label: (
+                                      <>
+                                        {t("settings.notifications.allWorlds")}
+                                      </>
+                                    ),
+                                  },
+                                  ...worldOptions.map((world) => ({
+                                    value: world,
+                                    label: <>{world}</>,
+                                  })),
+                                ]}
                               >
-                                <FormControl>
-                                  <SelectTrigger className="w-full">
-                                    <SelectValue>
-                                      {field.value === ALL_WORLDS_VALUE
-                                        ? t("settings.notifications.allWorlds")
-                                        : field.value}
-                                    </SelectValue>
-                                  </SelectTrigger>
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <SelectTrigger className="w-full">
+                                      <SelectValue>
+                                        {field.value === ALL_WORLDS_VALUE
+                                          ? t(
+                                              "settings.notifications.allWorlds",
+                                            )
+                                          : field.value}
+                                      </SelectValue>
+                                    </SelectTrigger>
+                                  }
+                                />
                                 <SelectContent>
                                   <SelectItem value={ALL_WORLDS_VALUE}>
                                     {t("settings.notifications.allWorlds")}
@@ -297,12 +347,14 @@ export const NotificationRuleFormPage = () => {
                                   )}
                                 </p>
                               </div>
-                              <FormControl>
-                                <Switch
-                                  checked={field.value}
-                                  onCheckedChange={handleManualNpcEntryChange}
-                                />
-                              </FormControl>
+                              <FormControl
+                                render={
+                                  <Switch
+                                    checked={field.value}
+                                    onCheckedChange={handleManualNpcEntryChange}
+                                  />
+                                }
+                              />
                             </FormItem>
                           )}
                         />
@@ -326,17 +378,19 @@ export const NotificationRuleFormPage = () => {
                                     },
                                   )}
                                 </p>
-                                <FormControl>
-                                  <Textarea
-                                    {...field}
-                                    value={field.value ?? ""}
-                                    rows={4}
-                                    placeholder={t(
-                                      "settings.notifications.placeholders.manualNpcIds",
-                                    )}
-                                    className="font-mono"
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <Textarea
+                                      {...field}
+                                      value={field.value ?? ""}
+                                      rows={4}
+                                      placeholder={t(
+                                        "settings.notifications.placeholders.manualNpcIds",
+                                      )}
+                                      className="font-mono"
+                                    />
+                                  }
+                                />
                                 <p className="text-xs text-muted-foreground">
                                   {t(
                                     "settings.notifications.manualNpcEntry.fieldHint",
@@ -363,27 +417,29 @@ export const NotificationRuleFormPage = () => {
                                     },
                                   )}
                                 </p>
-                                <FormControl>
-                                  <MultiSelect
-                                    options={npcOptions}
-                                    value={field.value ?? []}
-                                    onValueChange={field.onChange}
-                                    onClose={field.onChange}
-                                    placeholder={t(
-                                      "settings.notifications.placeholders.npcs",
-                                    )}
-                                    controlledSearch
-                                    searchValue={npcSearch}
-                                    onSearchChange={setNpcSearch}
-                                    loading={searchedNpcQuery.isFetching}
-                                    searchPlaceholder={t(
-                                      "settings.notifications.placeholders.searchNpcs",
-                                    )}
-                                    emptyMessage={t(
-                                      "settings.notifications.empty.npcs",
-                                    )}
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <MultiSelect
+                                      options={npcOptions}
+                                      value={field.value ?? []}
+                                      onValueChange={field.onChange}
+                                      onClose={field.onChange}
+                                      placeholder={t(
+                                        "settings.notifications.placeholders.npcs",
+                                      )}
+                                      controlledSearch
+                                      searchValue={npcSearch}
+                                      onSearchChange={setNpcSearch}
+                                      loading={searchedNpcQuery.isFetching}
+                                      searchPlaceholder={t(
+                                        "settings.notifications.placeholders.searchNpcs",
+                                      )}
+                                      emptyMessage={t(
+                                        "settings.notifications.empty.npcs",
+                                      )}
+                                    />
+                                  }
+                                />
                                 <FormMessage />
                               </FormItem>
                             )}
@@ -410,12 +466,60 @@ export const NotificationRuleFormPage = () => {
                                   if (!value) return;
                                   field.onChange(value);
                                 }}
+                                items={[
+                                  {
+                                    value:
+                                      NotificationScheduleIntervalType.ONCE,
+                                    label: (
+                                      <>
+                                        {t(
+                                          "settings.notifications.intervalTypes.once",
+                                        )}
+                                      </>
+                                    ),
+                                  },
+                                  {
+                                    value:
+                                      NotificationScheduleIntervalType.HOURLY,
+                                    label: (
+                                      <>
+                                        {t(
+                                          "settings.notifications.intervalTypes.hourly",
+                                        )}
+                                      </>
+                                    ),
+                                  },
+                                  {
+                                    value:
+                                      NotificationScheduleIntervalType.DAILY,
+                                    label: (
+                                      <>
+                                        {t(
+                                          "settings.notifications.intervalTypes.daily",
+                                        )}
+                                      </>
+                                    ),
+                                  },
+                                  {
+                                    value:
+                                      NotificationScheduleIntervalType.WEEKLY,
+                                    label: (
+                                      <>
+                                        {t(
+                                          "settings.notifications.intervalTypes.weekly",
+                                        )}
+                                      </>
+                                    ),
+                                  },
+                                ]}
                               >
-                                <FormControl>
-                                  <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <SelectTrigger className="w-full">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                  }
+                                />
                                 <SelectContent>
                                   <SelectItem
                                     value={
@@ -471,16 +575,18 @@ export const NotificationRuleFormPage = () => {
                                     "settings.notifications.fields.scheduleIntervalValue",
                                   )}
                                 </FormLabel>
-                                <FormControl>
-                                  <Input
-                                    {...field}
-                                    type="number"
-                                    inputMode="numeric"
-                                    min="1"
-                                    max="24"
-                                    step="1"
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <Input
+                                      {...field}
+                                      type="number"
+                                      inputMode="numeric"
+                                      min="1"
+                                      max="24"
+                                      step="1"
+                                    />
+                                  }
+                                />
                                 <FormMessage />
                               </FormItem>
                             )}
@@ -504,12 +610,26 @@ export const NotificationRuleFormPage = () => {
                                     if (!value) return;
                                     field.onChange(value);
                                   }}
+                                  items={[
+                                    ...[0, 1, 2, 3, 4, 5, 6].map((day) => ({
+                                      value: String(day),
+                                      label: (
+                                        <>
+                                          {t(
+                                            `settings.notifications.weekdays.${day}`,
+                                          )}
+                                        </>
+                                      ),
+                                    })),
+                                  ]}
                                 >
-                                  <FormControl>
-                                    <SelectTrigger className="w-full">
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                  </FormControl>
+                                  <FormControl
+                                    render={
+                                      <SelectTrigger className="w-full">
+                                        <SelectValue />
+                                      </SelectTrigger>
+                                    }
+                                  />
                                   <SelectContent>
                                     {[0, 1, 2, 3, 4, 5, 6].map((day) => (
                                       <SelectItem key={day} value={String(day)}>
@@ -537,15 +657,17 @@ export const NotificationRuleFormPage = () => {
                                     "settings.notifications.fields.scheduleTimeOfDay",
                                   )}
                                 </FormLabel>
-                                <FormControl>
-                                  <Input
-                                    {...field}
-                                    type="time"
-                                    placeholder={t(
-                                      "settings.notifications.placeholders.scheduleTimeOfDay",
-                                    )}
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <Input
+                                      {...field}
+                                      type="time"
+                                      placeholder={t(
+                                        "settings.notifications.placeholders.scheduleTimeOfDay",
+                                      )}
+                                    />
+                                  }
+                                />
                                 <FormMessage />
                               </FormItem>
                             )}
@@ -563,16 +685,18 @@ export const NotificationRuleFormPage = () => {
                                     "settings.notifications.fields.scheduledAt",
                                   )}
                                 </FormLabel>
-                                <FormControl>
-                                  <Input
-                                    {...field}
-                                    type="datetime-local"
-                                    min={formatDateTimeLocalInputValue(
-                                      new Date().toISOString(),
-                                      GUILD_NOTIFICATION_TIMEZONE,
-                                    )}
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <Input
+                                      {...field}
+                                      type="datetime-local"
+                                      min={formatDateTimeLocalInputValue(
+                                        new Date().toISOString(),
+                                        GUILD_NOTIFICATION_TIMEZONE,
+                                      )}
+                                    />
+                                  }
+                                />
                                 <FormMessage />
                               </FormItem>
                             )}
@@ -590,15 +714,17 @@ export const NotificationRuleFormPage = () => {
                                     "settings.notifications.fields.scheduledUntil",
                                   )}
                                 </FormLabel>
-                                <FormControl>
-                                  <Input
-                                    {...field}
-                                    type="datetime-local"
-                                    placeholder={t(
-                                      "settings.notifications.placeholders.scheduledUntil",
-                                    )}
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <Input
+                                      {...field}
+                                      type="datetime-local"
+                                      placeholder={t(
+                                        "settings.notifications.placeholders.scheduledUntil",
+                                      )}
+                                    />
+                                  }
+                                />
                                 <FormMessage />
                               </FormItem>
                             )}
@@ -615,17 +741,19 @@ export const NotificationRuleFormPage = () => {
                           <FormLabel className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                             {t("settings.notifications.fields.contentTemplate")}
                           </FormLabel>
-                          <FormControl>
-                            <NotificationTemplateEditor
-                              key={`${rule?.id ?? "create"}-${watchedTriggerType}-${formResetKey}`}
-                              value={field.value ?? ""}
-                              onChange={field.onChange}
-                              roles={guildRoles}
-                              triggerType={watchedTriggerType}
-                              disabled={isSubmitting}
-                              previewButtonClassName="lg:hidden"
-                            />
-                          </FormControl>
+                          <FormControl
+                            render={
+                              <NotificationTemplateEditor
+                                key={`${rule?.id ?? "create"}-${watchedTriggerType}-${formResetKey}`}
+                                value={field.value ?? ""}
+                                onChange={field.onChange}
+                                roles={guildRoles}
+                                triggerType={watchedTriggerType}
+                                disabled={isSubmitting}
+                                previewButtonClassName="lg:hidden"
+                              />
+                            }
+                          />
                           <FormMessage />
                         </FormItem>
                       )}
@@ -649,12 +777,36 @@ export const NotificationRuleFormPage = () => {
                                   if (!value) return;
                                   field.onChange(value);
                                 }}
+                                items={[
+                                  {
+                                    value: NotificationScheduleAnchor.MIN_SPAWN,
+                                    label: (
+                                      <>
+                                        {t(
+                                          "settings.notifications.scheduleAnchors.minSpawn",
+                                        )}
+                                      </>
+                                    ),
+                                  },
+                                  {
+                                    value: NotificationScheduleAnchor.MAX_SPAWN,
+                                    label: (
+                                      <>
+                                        {t(
+                                          "settings.notifications.scheduleAnchors.maxSpawn",
+                                        )}
+                                      </>
+                                    ),
+                                  },
+                                ]}
                               >
-                                <FormControl>
-                                  <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <SelectTrigger className="w-full">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                  }
+                                />
                                 <SelectContent>
                                   <SelectItem
                                     value={NotificationScheduleAnchor.MIN_SPAWN}
@@ -687,18 +839,20 @@ export const NotificationRuleFormPage = () => {
                                   "settings.notifications.fields.scheduleOffsetMinutes",
                                 )}
                               </FormLabel>
-                              <FormControl>
-                                <Input
-                                  {...field}
-                                  type="number"
-                                  inputMode="numeric"
-                                  min="0"
-                                  step="1"
-                                  placeholder={t(
-                                    "settings.notifications.placeholders.scheduleOffsetMinutes",
-                                  )}
-                                />
-                              </FormControl>
+                              <FormControl
+                                render={
+                                  <Input
+                                    {...field}
+                                    type="number"
+                                    inputMode="numeric"
+                                    min="0"
+                                    step="1"
+                                    placeholder={t(
+                                      "settings.notifications.placeholders.scheduleOffsetMinutes",
+                                    )}
+                                  />
+                                }
+                              />
                               <FormMessage />
                             </FormItem>
                           )}
@@ -731,24 +885,26 @@ export const NotificationRuleFormPage = () => {
                               {t("settings.notifications.actions.addTarget")}
                             </Button>
                           </div>
-                          <FormControl>
-                            <MultiSelect
-                              options={targetOptions}
-                              value={field.value}
-                              onValueChange={field.onChange}
-                              onClose={field.onChange}
-                              placeholder={t(
-                                "settings.notifications.placeholders.targets",
-                              )}
-                              searchPlaceholder={t(
-                                "settings.notifications.placeholders.searchTargets",
-                              )}
-                              emptyMessage={t(
-                                "settings.notifications.empty.targetsSelect",
-                              )}
-                              commandSearch
-                            />
-                          </FormControl>
+                          <FormControl
+                            render={
+                              <MultiSelect
+                                options={targetOptions}
+                                value={field.value}
+                                onValueChange={field.onChange}
+                                onClose={field.onChange}
+                                placeholder={t(
+                                  "settings.notifications.placeholders.targets",
+                                )}
+                                searchPlaceholder={t(
+                                  "settings.notifications.placeholders.searchTargets",
+                                )}
+                                emptyMessage={t(
+                                  "settings.notifications.empty.targetsSelect",
+                                )}
+                                commandSearch
+                              />
+                            }
+                          />
                           <FormMessage />
                         </FormItem>
                       )}
@@ -770,12 +926,14 @@ export const NotificationRuleFormPage = () => {
                                 )}
                               </p>
                             </div>
-                            <FormControl>
-                              <Switch
-                                checked={field.value}
-                                onCheckedChange={field.onChange}
-                              />
-                            </FormControl>
+                            <FormControl
+                              render={
+                                <Switch
+                                  checked={field.value}
+                                  onCheckedChange={field.onChange}
+                                />
+                              }
+                            />
                           </FormItem>
                         )}
                       />

--- a/apps/web/src/features/guild/notifications/notifications-settings.tsx
+++ b/apps/web/src/features/guild/notifications/notifications-settings.tsx
@@ -128,15 +128,17 @@ export const NotificationsSettings = () => {
               description={t("settings.notifications.description")}
               actions={
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      onClick={() => setIsInfoDialogOpen(true)}
-                    >
-                      <Info className="h-4 w-4" />
-                    </Button>
-                  </TooltipTrigger>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setIsInfoDialogOpen(true)}
+                      >
+                        <Info className="h-4 w-4" />
+                      </Button>
+                    }
+                  />
                   <TooltipContent>
                     {t("settings.notifications.info.title")}
                   </TooltipContent>

--- a/apps/web/src/features/guild/reservations/date-picker.tsx
+++ b/apps/web/src/features/guild/reservations/date-picker.tsx
@@ -141,61 +141,62 @@ export const DatePicker: FC<DatePickerProps> = ({
       <div className="flex flex-col gap-1 w-full">
         {label && <span className="text-xs font-semibold px-3">{label}</span>}
         <div className="relative" data-picker-root>
-          <PopoverTrigger asChild>
-            <div
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  setOpen(!open);
-                }
-              }}
-              className="w-full text-left flex h-9 items-center rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-            >
-              <span
-                className={`truncate text-sm ${date ? "text-foreground" : "text-muted-foreground"}`}
+          <PopoverTrigger
+            render={
+              <div
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setOpen(!open);
+                  }
+                }}
+                className="w-full text-left flex h-9 items-center rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
               >
-                {date
-                  ? display
-                  : placeholder || t("reservations.datePicker.placeholder")}
-              </span>
-              <div className="ml-auto flex items-center gap-1">
-                {date && onClear && (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onClear();
-                    }}
-                    className="p-0.5 text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
-                    title={t("reservations.datePicker.clear")}
-                  >
-                    <XCircle className="h-4 w-4" />
-                  </button>
-                )}
-                <svg
-                  className="h-4 w-4 shrink-0 opacity-50"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
+                <span
+                  className={`truncate text-sm ${date ? "text-foreground" : "text-muted-foreground"}`}
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 9l4 4 4-4"
-                  />
-                </svg>
+                  {date
+                    ? display
+                    : placeholder || t("reservations.datePicker.placeholder")}
+                </span>
+                <div className="ml-auto flex items-center gap-1">
+                  {date && onClear && (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onClear();
+                      }}
+                      className="p-0.5 text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+                      title={t("reservations.datePicker.clear")}
+                    >
+                      <XCircle className="h-4 w-4" />
+                    </button>
+                  )}
+                  <svg
+                    className="h-4 w-4 shrink-0 opacity-50"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8 9l4 4 4-4"
+                    />
+                  </svg>
+                </div>
               </div>
-            </div>
-          </PopoverTrigger>
+            }
+          />
 
           <PopoverContent
             align="start"
             sideOffset={8}
             collisionPadding={16}
-            avoidCollisions
             onClick={(e) => e.stopPropagation()}
             className="z-[100] w-80 p-3"
           >

--- a/apps/web/src/features/guild/reservations/reservations.tsx
+++ b/apps/web/src/features/guild/reservations/reservations.tsx
@@ -182,35 +182,39 @@ export const Reservations: React.FC = () => {
 
             <div className="flex items-center gap-1">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={() => setViewMode("list")}
-                    variant={viewMode === "list" ? "default" : "ghost"}
-                    size="icon"
-                    aria-label={t("reservations.view.list")}
-                    aria-pressed={viewMode === "list"}
-                    className="h-8 w-8"
-                  >
-                    <List className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      onClick={() => setViewMode("list")}
+                      variant={viewMode === "list" ? "default" : "ghost"}
+                      size="icon"
+                      aria-label={t("reservations.view.list")}
+                      aria-pressed={viewMode === "list"}
+                      className="h-8 w-8"
+                    >
+                      <List className="h-4 w-4" />
+                    </Button>
+                  }
+                />
                 <TooltipContent side="bottom">
                   <p>{t("reservations.view.list")}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={() => setViewMode("grid")}
-                    variant={viewMode === "grid" ? "default" : "ghost"}
-                    size="icon"
-                    aria-label={t("reservations.view.grid")}
-                    aria-pressed={viewMode === "grid"}
-                    className="h-8 w-8"
-                  >
-                    <Grid2X2 className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      onClick={() => setViewMode("grid")}
+                      variant={viewMode === "grid" ? "default" : "ghost"}
+                      size="icon"
+                      aria-label={t("reservations.view.grid")}
+                      aria-pressed={viewMode === "grid"}
+                      className="h-8 w-8"
+                    >
+                      <Grid2X2 className="h-4 w-4" />
+                    </Button>
+                  }
+                />
                 <TooltipContent side="bottom">
                   <p>{t("reservations.view.grid")}</p>
                 </TooltipContent>

--- a/apps/web/src/features/guild/reservations/schedule/reservation-segment-card.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-segment-card.tsx
@@ -102,24 +102,26 @@ export const ReservationSegmentCard: React.FC<ReservationSegmentCardProps> = ({
     >
       {isShortReservation ? (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex h-full items-center gap-2 w-full p-1">
-              <Avatar className="pointer-events-none size-5 shrink-0">
-                <AvatarImage src={avatarUrl} alt={memberName} />
-                <AvatarFallback>{fallbackInitial}</AvatarFallback>
-              </Avatar>
-              <div className="flex flex-col min-w-0 flex-1">
-                <span className="font-semibold leading-tight truncate text-[10px]">
-                  {memberName}
-                </span>
-                {!isVeryShortReservation && (
-                  <span className="text-[9px] text-muted-foreground truncate opacity-80">
-                    {displayStartLabel} - {displayEndLabel}
+          <TooltipTrigger
+            render={
+              <div className="flex h-full items-center gap-2 w-full p-1">
+                <Avatar className="pointer-events-none size-5 shrink-0">
+                  <AvatarImage src={avatarUrl} alt={memberName} />
+                  <AvatarFallback>{fallbackInitial}</AvatarFallback>
+                </Avatar>
+                <div className="flex flex-col min-w-0 flex-1">
+                  <span className="font-semibold leading-tight truncate text-[10px]">
+                    {memberName}
                   </span>
-                )}
+                  {!isVeryShortReservation && (
+                    <span className="text-[9px] text-muted-foreground truncate opacity-80">
+                      {displayStartLabel} - {displayEndLabel}
+                    </span>
+                  )}
+                </div>
               </div>
-            </div>
-          </TooltipTrigger>
+            }
+          />
           <TooltipContent
             side="top"
             sideOffset={12}
@@ -148,12 +150,14 @@ export const ReservationSegmentCard: React.FC<ReservationSegmentCardProps> = ({
 
             {hasComment && trimmedComment && (
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <MessageSquareText
-                    className="h-3 w-3 shrink-0 opacity-80"
-                    aria-hidden="true"
-                  />
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <MessageSquareText
+                      className="h-3 w-3 shrink-0 opacity-80"
+                      aria-hidden="true"
+                    />
+                  }
+                />
                 <TooltipContent
                   side="top"
                   align="end"
@@ -188,13 +192,13 @@ export const ReservationSegmentCard: React.FC<ReservationSegmentCardProps> = ({
   if (showContextMenu) {
     return (
       <ContextMenu>
-        <ContextMenuTrigger asChild>{segmentElement}</ContextMenuTrigger>
+        <ContextMenuTrigger render={segmentElement} />
         <ContextMenuContent className="min-w-[12rem]">
           {canCancelReservation && (
             <ContextMenuItem
               className="group gap-2 data-[highlighted]:bg-muted data-[highlighted]:text-foreground"
               disabled={isDeleting}
-              onSelect={() => {
+              onClick={() => {
                 onDeleteReservation(segment.reservation.id, "cancel");
               }}
             >
@@ -209,7 +213,7 @@ export const ReservationSegmentCard: React.FC<ReservationSegmentCardProps> = ({
             <ContextMenuItem
               className="gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive data-[highlighted]:bg-destructive/10 data-[highlighted]:text-destructive"
               disabled={isDeleting}
-              onSelect={() => {
+              onClick={() => {
                 onDeleteReservation(segment.reservation.id, "remove");
               }}
             >

--- a/apps/web/src/features/guild/settings/components/permission-category-tooltip.tsx
+++ b/apps/web/src/features/guild/settings/components/permission-category-tooltip.tsx
@@ -27,14 +27,19 @@ export const PermissionCategoryTooltip = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          className={cn("p-1.5 rounded-md transition-colors", category.bgColor)}
-          onClick={onClick}
-        >
-          <IconComponent className={cn("size-4", category.color)} />
-        </div>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <div
+            className={cn(
+              "p-1.5 rounded-md transition-colors",
+              category.bgColor,
+            )}
+            onClick={onClick}
+          >
+            <IconComponent className={cn("size-4", category.color)} />
+          </div>
+        }
+      />
       <TooltipContent side={side} className="max-w-xs">
         <div className="space-y-1">
           <p className="font-semibold text-sm">{category.name}</p>

--- a/apps/web/src/features/guild/settings/general/general-form.tsx
+++ b/apps/web/src/features/guild/settings/general/general-form.tsx
@@ -138,15 +138,17 @@ export const GeneralForm = () => {
                   name="vanityUrl"
                   render={({ field }) => (
                     <FormItem>
-                      <FormControl>
-                        <Input
-                          placeholder={t(
-                            "settings.general.vanityUrl.placeholder",
-                          )}
-                          className="h-9 max-w-xs"
-                          {...field}
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Input
+                            placeholder={t(
+                              "settings.general.vanityUrl.placeholder",
+                            )}
+                            className="h-9 max-w-xs"
+                            {...field}
+                          />
+                        }
+                      />
                       <FormDescription className="text-xs mt-2">
                         {t("settings.general.vanityUrl.example")}{" "}
                         <span className="text-foreground font-medium">

--- a/apps/web/src/features/guild/settings/general/stats-card-settings-card.tsx
+++ b/apps/web/src/features/guild/settings/general/stats-card-settings-card.tsx
@@ -110,13 +110,15 @@ export const StatsCardSettingsCard = ({
             name="publicStatsCardEnabled"
             render={({ field }) => (
               <FormItem>
-                <FormControl>
-                  <Switch
-                    checked={field.value}
-                    onCheckedChange={field.onChange}
-                    aria-label={t("settings.general.statsCard.toggleLabel")}
-                  />
-                </FormControl>
+                <FormControl
+                  render={
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      aria-label={t("settings.general.statsCard.toggleLabel")}
+                    />
+                  }
+                />
               </FormItem>
             )}
           />

--- a/apps/web/src/features/guild/settings/map-templates/map-template-form-dialog.tsx
+++ b/apps/web/src/features/guild/settings/map-templates/map-template-form-dialog.tsx
@@ -263,15 +263,17 @@ export const MapTemplateFormDialog = ({
                       <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                         {t("settings.mapTemplates.templateName")}
                       </FormLabel>
-                      <FormControl>
-                        <Input
-                          {...field}
-                          placeholder={t(
-                            "settings.mapTemplates.templateNamePlaceholder",
-                          )}
-                          className="h-9 text-sm"
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Input
+                            {...field}
+                            placeholder={t(
+                              "settings.mapTemplates.templateNamePlaceholder",
+                            )}
+                            className="h-9 text-sm"
+                          />
+                        }
+                      />
                       <FormMessage />
                     </FormItem>
                   )}

--- a/apps/web/src/features/guild/settings/members/components/member-deactivation-button.tsx
+++ b/apps/web/src/features/guild/settings/members/components/member-deactivation-button.tsx
@@ -69,19 +69,21 @@ export const MemberDeactivationButton = ({
 
   return (
     <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button
-          size="sm"
-          variant="destructive"
-          className={cn(className)}
-          disabled={!member.active || deactivateMemberMutation.isPending}
-        >
-          <UserX className="size-4" />
-          {deactivateMemberMutation.isPending
-            ? t("settings.members.deactivatePending")
-            : t("settings.members.deactivate")}
-        </Button>
-      </AlertDialogTrigger>
+      <AlertDialogTrigger
+        render={
+          <Button
+            size="sm"
+            variant="destructive"
+            className={cn(className)}
+            disabled={!member.active || deactivateMemberMutation.isPending}
+          >
+            <UserX className="size-4" />
+            {deactivateMemberMutation.isPending
+              ? t("settings.members.deactivatePending")
+              : t("settings.members.deactivate")}
+          </Button>
+        }
+      />
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>

--- a/apps/web/src/features/guild/settings/members/components/member-discord-sync-indicator.tsx
+++ b/apps/web/src/features/guild/settings/members/components/member-discord-sync-indicator.tsx
@@ -45,19 +45,21 @@ export const MemberDiscordSyncIndicator: FC<
   const Icon = iconByTone[presentation.tone];
 
   return (
-    <TooltipProvider delayDuration={100}>
+    <TooltipProvider delay={100}>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className={cn(
-              "p-1.5 rounded-md transition-colors",
-              indicatorToneClassNames[presentation.tone],
-            )}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <Icon className="size-4" />
-          </div>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <div
+              className={cn(
+                "p-1.5 rounded-md transition-colors",
+                indicatorToneClassNames[presentation.tone],
+              )}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Icon className="size-4" />
+            </div>
+          }
+        />
         <TooltipContent side="top" className="max-w-xs">
           <div className="space-y-1">
             <p className="text-sm font-semibold">

--- a/apps/web/src/features/guild/settings/members/components/member-sync-button.tsx
+++ b/apps/web/src/features/guild/settings/members/components/member-sync-button.tsx
@@ -126,37 +126,41 @@ export const MemberSyncButton: FC<MemberSyncButtonProps> = ({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <span>
-          <Button
-            className={cn("justify-center", className)}
-            size="sm"
-            variant={variant}
-            disabled={
-              isPending ||
-              !canRefresh ||
-              member.refreshQueued ||
-              !canTriggerRefresh
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              if (!guildId) {
-                return;
+      <TooltipTrigger
+        render={
+          <span>
+            <Button
+              className={cn("justify-center", className)}
+              size="sm"
+              variant={variant}
+              disabled={
+                isPending ||
+                !canRefresh ||
+                member.refreshQueued ||
+                !canTriggerRefresh
               }
+              onClick={(e) => {
+                e.stopPropagation();
+                if (!guildId) {
+                  return;
+                }
 
-              refreshMember({
-                pathParams: {
-                  guildId,
-                  discordId: member.userId,
-                },
-              });
-            }}
-          >
-            <RefreshCcw className={cn("size-4", isPending && "animate-spin")} />
-            {t("settings.members.refreshPermissions")}
-          </Button>
-        </span>
-      </TooltipTrigger>
+                refreshMember({
+                  pathParams: {
+                    guildId,
+                    discordId: member.userId,
+                  },
+                });
+              }}
+            >
+              <RefreshCcw
+                className={cn("size-4", isPending && "animate-spin")}
+              />
+              {t("settings.members.refreshPermissions")}
+            </Button>
+          </span>
+        }
+      />
       <TooltipContent>{tooltipText}</TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/features/guild/settings/members/members-table.tsx
+++ b/apps/web/src/features/guild/settings/members/members-table.tsx
@@ -166,16 +166,18 @@ export const MembersTable = ({
                           : "settings.members.webActivity.onlineSources.game";
 
                       return (
-                        <TooltipProvider key={source} delayDuration={100}>
+                        <TooltipProvider key={source} delay={100}>
                           <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span
-                                className="inline-flex size-5 items-center justify-center rounded-md bg-emerald-500/10 text-emerald-500"
-                                onClick={(event) => event.stopPropagation()}
-                              >
-                                <Icon className="size-3.5" />
-                              </span>
-                            </TooltipTrigger>
+                            <TooltipTrigger
+                              render={
+                                <span
+                                  className="inline-flex size-5 items-center justify-center rounded-md bg-emerald-500/10 text-emerald-500"
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  <Icon className="size-3.5" />
+                                </span>
+                              }
+                            />
                             <TooltipContent side="top">
                               <p className="text-sm font-semibold">
                                 {t(labelKey)}
@@ -186,16 +188,18 @@ export const MembersTable = ({
                       );
                     })}
                     {isGamePresenceVerified && (
-                      <TooltipProvider delayDuration={100}>
+                      <TooltipProvider delay={100}>
                         <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span
-                              className="inline-flex size-5 items-center justify-center rounded-md bg-sky-500/10 text-sky-500"
-                              onClick={(event) => event.stopPropagation()}
-                            >
-                              <BadgeCheck className="size-3.5" />
-                            </span>
-                          </TooltipTrigger>
+                          <TooltipTrigger
+                            render={
+                              <span
+                                className="inline-flex size-5 items-center justify-center rounded-md bg-sky-500/10 text-sky-500"
+                                onClick={(event) => event.stopPropagation()}
+                              >
+                                <BadgeCheck className="size-3.5" />
+                              </span>
+                            }
+                          />
                           <TooltipContent side="top">
                             <p className="text-sm font-semibold">
                               {t(
@@ -390,18 +394,20 @@ export const MembersTable = ({
                                 : "settings.members.webActivity.onlineSources.game";
 
                             return (
-                              <TooltipProvider key={source} delayDuration={100}>
+                              <TooltipProvider key={source} delay={100}>
                                 <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <span
-                                      className="inline-flex size-5 items-center justify-center rounded-md bg-emerald-500/10 text-emerald-500"
-                                      onClick={(event) =>
-                                        event.stopPropagation()
-                                      }
-                                    >
-                                      <Icon className="size-3.5" />
-                                    </span>
-                                  </TooltipTrigger>
+                                  <TooltipTrigger
+                                    render={
+                                      <span
+                                        className="inline-flex size-5 items-center justify-center rounded-md bg-emerald-500/10 text-emerald-500"
+                                        onClick={(event) =>
+                                          event.stopPropagation()
+                                        }
+                                      >
+                                        <Icon className="size-3.5" />
+                                      </span>
+                                    }
+                                  />
                                   <TooltipContent side="top">
                                     <p className="text-sm font-semibold">
                                       {t(labelKey)}
@@ -412,16 +418,20 @@ export const MembersTable = ({
                             );
                           })}
                           {isGamePresenceVerified && (
-                            <TooltipProvider delayDuration={100}>
+                            <TooltipProvider delay={100}>
                               <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span
-                                    className="inline-flex size-5 items-center justify-center rounded-md bg-sky-500/10 text-sky-500"
-                                    onClick={(event) => event.stopPropagation()}
-                                  >
-                                    <BadgeCheck className="size-3.5" />
-                                  </span>
-                                </TooltipTrigger>
+                                <TooltipTrigger
+                                  render={
+                                    <span
+                                      className="inline-flex size-5 items-center justify-center rounded-md bg-sky-500/10 text-sky-500"
+                                      onClick={(event) =>
+                                        event.stopPropagation()
+                                      }
+                                    >
+                                      <BadgeCheck className="size-3.5" />
+                                    </span>
+                                  }
+                                />
                                 <TooltipContent side="top">
                                   <p className="text-sm font-semibold">
                                     {t(
@@ -438,16 +448,18 @@ export const MembersTable = ({
                     <div className="flex min-h-7 flex-wrap items-center gap-1">
                       <MemberDiscordSyncIndicator member={member} />
                       {member.userId === guildOwnerId && (
-                        <TooltipProvider delayDuration={100}>
+                        <TooltipProvider delay={100}>
                           <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span
-                                className="inline-flex rounded-md bg-amber-500/10 p-1.5 text-amber-400 transition-colors"
-                                onClick={(event) => event.stopPropagation()}
-                              >
-                                <Crown className="size-4" />
-                              </span>
-                            </TooltipTrigger>
+                            <TooltipTrigger
+                              render={
+                                <span
+                                  className="inline-flex rounded-md bg-amber-500/10 p-1.5 text-amber-400 transition-colors"
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  <Crown className="size-4" />
+                                </span>
+                              }
+                            />
                             <TooltipContent side="top">
                               <p className="text-sm font-semibold">
                                 {t("settings.members.owner")}
@@ -456,7 +468,7 @@ export const MembersTable = ({
                           </Tooltip>
                         </TooltipProvider>
                       )}
-                      <TooltipProvider delayDuration={100}>
+                      <TooltipProvider delay={100}>
                         {activePermissionCategories.map((category) => {
                           const activePermissions = category.permissions.filter(
                             (permission) =>
@@ -535,21 +547,21 @@ export const MembersTable = ({
                 onClick={(event) => event.stopPropagation()}
               >
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      aria-label={t("settings.members.actions.more")}
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label={t("settings.members.actions.more")}
+                      >
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    }
+                  />
                   <DropdownMenuContent align="end" className="w-56">
-                    <DropdownMenuItem
-                      onSelect={() => openMemberDetails(member)}
-                    >
+                    <DropdownMenuItem onClick={() => openMemberDetails(member)}>
                       <CheckCircle2 className="size-4" />
                       {t("settings.members.actions.viewDetails")}
                     </DropdownMenuItem>

--- a/apps/web/src/features/guild/settings/npcs/npc-settings-detail-page.tsx
+++ b/apps/web/src/features/guild/settings/npcs/npc-settings-detail-page.tsx
@@ -92,22 +92,24 @@ export const NpcSettingsDetailPage = () => {
           </div>
           <div className="flex min-h-8 shrink-0 flex-wrap items-center gap-1 pl-12 sm:pl-0">
             {enabledRarities.length > 0 ? (
-              <TooltipProvider delayDuration={100}>
+              <TooltipProvider delay={100}>
                 {enabledRarities.map((rarity) => {
                   const Icon = rarity.icon;
 
                   return (
                     <Tooltip key={rarity.key}>
-                      <TooltipTrigger asChild>
-                        <span
-                          className={cn(
-                            "inline-flex size-8 items-center justify-center rounded-md",
-                            rarity.bgColor,
-                          )}
-                        >
-                          <Icon className={cn("size-4", rarity.color)} />
-                        </span>
-                      </TooltipTrigger>
+                      <TooltipTrigger
+                        render={
+                          <span
+                            className={cn(
+                              "inline-flex size-8 items-center justify-center rounded-md",
+                              rarity.bgColor,
+                            )}
+                          >
+                            <Icon className={cn("size-4", rarity.color)} />
+                          </span>
+                        }
+                      />
                       <TooltipContent side="bottom">
                         <p className="text-sm font-semibold">
                           {t(`itemRarity.${rarity.key}`)}

--- a/apps/web/src/features/guild/settings/npcs/npcs-form.tsx
+++ b/apps/web/src/features/guild/settings/npcs/npcs-form.tsx
@@ -140,12 +140,14 @@ export const NpcsForm: FC<NpcsFormProps> = ({ npc }) => {
                       field.value && "bg-primary/5",
                     )}
                   >
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      }
+                    />
                     <div className="flex items-center gap-2 flex-1">
                       <div className={cn("p-1 rounded", rarity.bgColor)}>
                         <rarity.icon className={cn("size-3", rarity.color)} />

--- a/apps/web/src/features/guild/settings/npcs/npcs-table.tsx
+++ b/apps/web/src/features/guild/settings/npcs/npcs-table.tsx
@@ -161,23 +161,27 @@ export const NpcsTable = ({ guildId, isMobile, npcs }: NpcsTableProps) => {
                   className="flex min-h-7 min-w-0 items-center gap-1"
                 >
                   {enabledRarities.length > 0 ? (
-                    <TooltipProvider delayDuration={100}>
+                    <TooltipProvider delay={100}>
                       {enabledRarities.map((rarity) => {
                         const Icon = rarity.icon;
 
                         return (
                           <Tooltip key={rarity.key}>
-                            <TooltipTrigger asChild>
-                              <span
-                                className={cn(
-                                  "inline-flex size-7 items-center justify-center rounded-md",
-                                  rarity.bgColor,
-                                )}
-                                onClick={(event) => event.stopPropagation()}
-                              >
-                                <Icon className={cn("size-4", rarity.color)} />
-                              </span>
-                            </TooltipTrigger>
+                            <TooltipTrigger
+                              render={
+                                <span
+                                  className={cn(
+                                    "inline-flex size-7 items-center justify-center rounded-md",
+                                    rarity.bgColor,
+                                  )}
+                                  onClick={(event) => event.stopPropagation()}
+                                >
+                                  <Icon
+                                    className={cn("size-4", rarity.color)}
+                                  />
+                                </span>
+                              }
+                            />
                             <TooltipContent side="top">
                               <p className="text-sm font-semibold">
                                 {t(`itemRarity.${rarity.key}`)}
@@ -200,19 +204,21 @@ export const NpcsTable = ({ guildId, isMobile, npcs }: NpcsTableProps) => {
                 onClick={(event) => event.stopPropagation()}
               >
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      aria-label={t("settings.npcs.actions.more")}
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label={t("settings.npcs.actions.more")}
+                      >
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    }
+                  />
                   <DropdownMenuContent align="end" className="w-48">
-                    <DropdownMenuItem onSelect={() => openNpcDetails(npc)}>
+                    <DropdownMenuItem onClick={() => openNpcDetails(npc)}>
                       <CheckCircle2 className="size-4" />
                       {t("settings.npcs.actions.viewDetails")}
                     </DropdownMenuItem>

--- a/apps/web/src/features/guild/settings/reservations/reservations-settings-form.tsx
+++ b/apps/web/src/features/guild/settings/reservations/reservations-settings-form.tsx
@@ -128,18 +128,20 @@ export const ReservationsSettingsForm = ({
                       <FormLabel>
                         {t("settings.reservations.fields.minDuration.label")}
                       </FormLabel>
-                      <FormControl>
-                        <Input
-                          type="number"
-                          min={5}
-                          max={240}
-                          step={5}
-                          {...field}
-                          onChange={(event) =>
-                            field.onChange(event.target.valueAsNumber)
-                          }
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Input
+                            type="number"
+                            min={5}
+                            max={240}
+                            step={5}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.valueAsNumber)
+                            }
+                          />
+                        }
+                      />
                       <FormDescription>
                         {t(
                           "settings.reservations.fields.minDuration.description",
@@ -158,18 +160,20 @@ export const ReservationsSettingsForm = ({
                       <FormLabel>
                         {t("settings.reservations.fields.maxDuration.label")}
                       </FormLabel>
-                      <FormControl>
-                        <Input
-                          type="number"
-                          min={30}
-                          max={720}
-                          step={5}
-                          {...field}
-                          onChange={(event) =>
-                            field.onChange(event.target.valueAsNumber)
-                          }
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Input
+                            type="number"
+                            min={30}
+                            max={720}
+                            step={5}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.valueAsNumber)
+                            }
+                          />
+                        }
+                      />
                       <FormDescription>
                         {t(
                           "settings.reservations.fields.maxDuration.description",
@@ -213,12 +217,27 @@ export const ReservationsSettingsForm = ({
                       <Select
                         value={String(field.value)}
                         onValueChange={(value) => field.onChange(Number(value))}
+                        items={[
+                          ...RESERVATION_GRANULARITY_OPTIONS.map((value) => ({
+                            value: String(value),
+                            label: (
+                              <>
+                                {t(
+                                  "settings.reservations.fields.granularity.option",
+                                  { minutes: value },
+                                )}
+                              </>
+                            ),
+                          })),
+                        ]}
                       >
-                        <FormControl>
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
+                        <FormControl
+                          render={
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                          }
+                        />
                         <SelectContent>
                           {RESERVATION_GRANULARITY_OPTIONS.map((value) => (
                             <SelectItem key={value} value={String(value)}>
@@ -248,18 +267,20 @@ export const ReservationsSettingsForm = ({
                       <FormLabel>
                         {t("settings.reservations.fields.maxAdvance.label")}
                       </FormLabel>
-                      <FormControl>
-                        <Input
-                          type="number"
-                          min={1}
-                          max={30}
-                          step={1}
-                          {...field}
-                          onChange={(event) =>
-                            field.onChange(event.target.valueAsNumber)
-                          }
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Input
+                            type="number"
+                            min={1}
+                            max={30}
+                            step={1}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.valueAsNumber)
+                            }
+                          />
+                        }
+                      />
                       <FormDescription>
                         {t(
                           "settings.reservations.fields.maxAdvance.description",
@@ -300,18 +321,20 @@ export const ReservationsSettingsForm = ({
                       <FormLabel>
                         {t("settings.reservations.fields.activeLimit.label")}
                       </FormLabel>
-                      <FormControl>
-                        <Input
-                          type="number"
-                          min={1}
-                          max={10}
-                          step={1}
-                          {...field}
-                          onChange={(event) =>
-                            field.onChange(event.target.valueAsNumber)
-                          }
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <Input
+                            type="number"
+                            min={1}
+                            max={10}
+                            step={1}
+                            {...field}
+                            onChange={(event) =>
+                              field.onChange(event.target.valueAsNumber)
+                            }
+                          />
+                        }
+                      />
                       <FormDescription>
                         {t(
                           "settings.reservations.fields.activeLimit.description",

--- a/apps/web/src/features/guild/settings/roles/components/roles-form.tsx
+++ b/apps/web/src/features/guild/settings/roles/components/roles-form.tsx
@@ -305,16 +305,18 @@ export const RolesForm: FC<RolesFormProps> = ({ role }) => {
                 name="lvlRangeFrom"
                 render={({ field }) => (
                   <FormItem className="flex-1 max-w-[100px]">
-                    <FormControl>
-                      <Input
-                        placeholder={DEFAULT_LVL_RANGE_FROM}
-                        type="number"
-                        max={500}
-                        min={0}
-                        className="h-9"
-                        {...field}
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <Input
+                          placeholder={DEFAULT_LVL_RANGE_FROM}
+                          type="number"
+                          max={500}
+                          min={0}
+                          className="h-9"
+                          {...field}
+                        />
+                      }
+                    />
                     <FormMessage />
                   </FormItem>
                 )}
@@ -325,16 +327,18 @@ export const RolesForm: FC<RolesFormProps> = ({ role }) => {
                 name="lvlRangeTo"
                 render={({ field }) => (
                   <FormItem className="flex-1 max-w-[100px]">
-                    <FormControl>
-                      <Input
-                        placeholder={DEFAULT_LVL_RANGE_TO}
-                        type="number"
-                        max={500}
-                        min={0}
-                        className="h-9"
-                        {...field}
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <Input
+                          placeholder={DEFAULT_LVL_RANGE_TO}
+                          type="number"
+                          max={500}
+                          min={0}
+                          className="h-9"
+                          {...field}
+                        />
+                      }
+                    />
                     <FormMessage />
                   </FormItem>
                 )}
@@ -345,7 +349,7 @@ export const RolesForm: FC<RolesFormProps> = ({ role }) => {
 
         <div className="space-y-3 pt-3">
           <Accordion
-            type="multiple"
+            multiple
             defaultValue={PERMISSION_GROUPS.map((g) => g.groupKey)}
             className="space-y-3"
           >
@@ -400,12 +404,14 @@ export const RolesForm: FC<RolesFormProps> = ({ role }) => {
                                   field.value && "bg-primary/5",
                                 )}
                               >
-                                <FormControl>
-                                  <Checkbox
-                                    checked={!!field.value}
-                                    onCheckedChange={field.onChange}
-                                  />
-                                </FormControl>
+                                <FormControl
+                                  render={
+                                    <Checkbox
+                                      checked={!!field.value}
+                                      onCheckedChange={field.onChange}
+                                    />
+                                  }
+                                />
                                 <div className="space-y-0.5 leading-none flex-1">
                                   <FormLabel className="text-sm font-medium cursor-pointer after:absolute after:inset-0">
                                     {t(`permissions.${perm}`)}

--- a/apps/web/src/features/guild/settings/roles/role-settings-detail-page.tsx
+++ b/apps/web/src/features/guild/settings/roles/role-settings-detail-page.tsx
@@ -110,7 +110,7 @@ export const RoleSettingsDetailPage = () => {
           </div>
           <div className="flex min-h-8 shrink-0 flex-wrap items-center gap-1 pl-12 sm:pl-0">
             {activeCategories.length > 0 ? (
-              <TooltipProvider delayDuration={100}>
+              <TooltipProvider delay={100}>
                 {activeCategories.map((category) => {
                   const activePermissions = category.permissions.filter(
                     (permission) => role.permissions.includes(permission),

--- a/apps/web/src/features/guild/settings/roles/roles-table.tsx
+++ b/apps/web/src/features/guild/settings/roles/roles-table.tsx
@@ -190,7 +190,7 @@ export const RolesTable = ({ guildId, isMobile, roles }: RolesTableProps) => {
                   className="flex min-h-7 min-w-0 items-center gap-1"
                 >
                   {activeCategories.length > 0 ? (
-                    <TooltipProvider delayDuration={100}>
+                    <TooltipProvider delay={100}>
                       {activeCategories.map((category) => {
                         const activePermissions = category.permissions.filter(
                           (permission) => role.permissions.includes(permission),
@@ -230,19 +230,21 @@ export const RolesTable = ({ guildId, isMobile, roles }: RolesTableProps) => {
                 onClick={(event) => event.stopPropagation()}
               >
                 <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-8"
-                      aria-label={t("settings.roles.actions.more")}
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
+                  <DropdownMenuTrigger
+                    render={
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-8"
+                        aria-label={t("settings.roles.actions.more")}
+                      >
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    }
+                  />
                   <DropdownMenuContent align="end" className="w-48">
-                    <DropdownMenuItem onSelect={() => openRoleDetails(role)}>
+                    <DropdownMenuItem onClick={() => openRoleDetails(role)}>
                       <CheckCircle2 className="size-4" />
                       {t("settings.roles.actions.viewDetails")}
                     </DropdownMenuItem>

--- a/apps/web/src/features/guild/stats/components/member-ranking-podium-card.tsx
+++ b/apps/web/src/features/guild/stats/components/member-ranking-podium-card.tsx
@@ -220,6 +220,12 @@ export const MemberRankingPodiumCard: React.FC<
         <Select
           value={selectedNpcType}
           onValueChange={(value) => setSelectedNpcType(value as NpcType)}
+          items={[
+            ...TRACKABLE_NPC_TYPES.map((type) => ({
+              value: type,
+              label: <>{t(`npcType.${type}`)}</>,
+            })),
+          ]}
         >
           <SelectTrigger className="w-[120px] h-8">
             <SelectValue />

--- a/apps/web/src/features/guild/stats/components/npc-stats-filters-mobile.tsx
+++ b/apps/web/src/features/guild/stats/components/npc-stats-filters-mobile.tsx
@@ -82,7 +82,19 @@ export const NpcStatsFiltersMobile = ({
 
       <div className="space-y-2">
         <Label>{t("kills.filters.npcType")}</Label>
-        <Select value={npcType ?? "ALL"} onValueChange={onNpcTypeChange}>
+        <Select
+          value={npcType ?? "ALL"}
+          onValueChange={(value) => {
+            if (value !== null) onNpcTypeChange(value);
+          }}
+          items={[
+            { value: "ALL", label: <>{t("kills.filters.allTypes")}</> },
+            ...TRACKABLE_NPC_TYPES.map((type) => ({
+              value: type,
+              label: <>{t(`npcType.${type}`)}</>,
+            })),
+          ]}
+        >
           <SelectTrigger className="w-full">
             <div className="flex items-center gap-2">
               <Sword className="h-4 w-4" />

--- a/apps/web/src/features/guild/stats/components/top-npcs-card.tsx
+++ b/apps/web/src/features/guild/stats/components/top-npcs-card.tsx
@@ -117,6 +117,12 @@ export const TopNpcsCard: React.FC<TopNpcsCardProps> = ({
         <Select
           value={selectedNpcType}
           onValueChange={(value) => setSelectedNpcType(value as NpcType)}
+          items={[
+            ...TRACKABLE_NPC_TYPES.map((type) => ({
+              value: type,
+              label: <>{t(`npcType.${type}`)}</>,
+            })),
+          ]}
         >
           <SelectTrigger className="w-[120px] h-8">
             <SelectValue />

--- a/apps/web/src/features/guild/stats/member-stats-page.tsx
+++ b/apps/web/src/features/guild/stats/member-stats-page.tsx
@@ -114,7 +114,8 @@ export const MemberStatsPage: React.FC = () => {
     setCursor(0);
   };
 
-  const handleNpcTypeChange = (value: string) => {
+  const handleNpcTypeChange = (value: string | null) => {
+    if (value === null) return;
     setNpcType(value as NpcType | "ALL");
     setCursor(0);
   };
@@ -325,6 +326,13 @@ export const MemberStatsPage: React.FC = () => {
               <Select
                 value={settings.npcType ?? "ALL"}
                 onValueChange={handleNpcTypeChange}
+                items={[
+                  { value: "ALL", label: <>{t("kills.filters.allTypes")}</> },
+                  ...TRACKABLE_NPC_TYPES.map((type) => ({
+                    value: type,
+                    label: <>{t(`npcType.${type}`)}</>,
+                  })),
+                ]}
               >
                 <SelectTrigger className="w-[140px]">
                   <SelectValue />

--- a/apps/web/src/features/guild/stats/stats-npcs-list.tsx
+++ b/apps/web/src/features/guild/stats/stats-npcs-list.tsx
@@ -118,7 +118,8 @@ export const StatsNpcsList: React.FC = () => {
     }
   };
 
-  const handleNpcTypeChange = (value: string) => {
+  const handleNpcTypeChange = (value: string | null) => {
+    if (value === null) return;
     setNpcType(value as NpcType | "ALL");
     setCursor(0);
   };
@@ -223,6 +224,13 @@ export const StatsNpcsList: React.FC = () => {
                 <Select
                   value={settings.npcType ?? "ALL"}
                   onValueChange={handleNpcTypeChange}
+                  items={[
+                    { value: "ALL", label: <>{t("kills.filters.allTypes")}</> },
+                    ...TRACKABLE_NPC_TYPES.map((type) => ({
+                      value: type,
+                      label: <>{t(`npcType.${type}`)}</>,
+                    })),
+                  ]}
                 >
                   <SelectTrigger className="w-[140px]">
                     <SelectValue />

--- a/apps/web/src/features/guild/timers/single-timer.tsx
+++ b/apps/web/src/features/guild/timers/single-timer.tsx
@@ -72,55 +72,57 @@ export const SingleTimer: FC<SingleTimerProps> = ({ timer }) => {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <div className="group flex cursor-pointer items-center gap-3 rounded-lg border border-border/50 bg-card px-3 py-2.5 transition-all hover:border-primary/50 hover:bg-card">
-          {npcIcon && (
-            <div className="flex size-8 shrink-0 items-center justify-center">
-              {/* eslint-disable-next-line eslint-plugin-next/no-img-element */}
-              <img
-                className="max-h-8 max-w-8 rounded"
-                src={`${imageHasDomain ? "" : MARGONEM_CDN_NPCS_URL}${npcIcon}`}
-                alt={npcName}
-              />
-            </div>
-          )}
-          <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-baseline gap-1">
-              <span className="min-w-0 truncate text-sm font-medium">
-                {npcName}
+      <TooltipTrigger
+        render={
+          <div className="group flex cursor-pointer items-center gap-3 rounded-lg border border-border/50 bg-card px-3 py-2.5 transition-all hover:border-primary/50 hover:bg-card">
+            {npcIcon && (
+              <div className="flex size-8 shrink-0 items-center justify-center">
+                {/* eslint-disable-next-line eslint-plugin-next/no-img-element */}
+                <img
+                  className="max-h-8 max-w-8 rounded"
+                  src={`${imageHasDomain ? "" : MARGONEM_CDN_NPCS_URL}${npcIcon}`}
+                  alt={npcName}
+                />
+              </div>
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-baseline gap-1">
+                <span className="min-w-0 truncate text-sm font-medium">
+                  {npcName}
+                </span>
+                {npcDetails && (
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {npcDetails}
+                  </span>
+                )}
+              </div>
+              <span className="block truncate text-xs text-muted-foreground">
+                {timer.member?.name ?? ""}
               </span>
-              {npcDetails && (
-                <span className="shrink-0 text-xs text-muted-foreground">
-                  {npcDetails}
+            </div>
+            <div className="flex shrink-0 flex-col items-end gap-0.5">
+              {!isMinSpawnTime && (
+                <span className="flex items-center gap-1 text-xs tabular-nums text-muted-foreground">
+                  <ClockArrowDown size="14px" />
+                  {parseMsToTime(minTimeLeft)}
                 </span>
               )}
-            </div>
-            <span className="block truncate text-xs text-muted-foreground">
-              {timer.member?.name ?? ""}
-            </span>
-          </div>
-          <div className="flex shrink-0 flex-col items-end gap-0.5">
-            {!isMinSpawnTime && (
-              <span className="flex items-center gap-1 text-xs tabular-nums text-muted-foreground">
-                <ClockArrowDown size="14px" />
-                {parseMsToTime(minTimeLeft)}
+              <span
+                className={cn(
+                  "flex items-center gap-1 text-xs font-medium tabular-nums",
+                  {
+                    "text-orange-400": isMinSpawnTime,
+                    "text-red-500": hasPassedRedThreshold,
+                  },
+                )}
+              >
+                <ClockArrowUp size="14px" />
+                {parseMsToTime(timeLeft)}
               </span>
-            )}
-            <span
-              className={cn(
-                "flex items-center gap-1 text-xs font-medium tabular-nums",
-                {
-                  "text-orange-400": isMinSpawnTime,
-                  "text-red-500": hasPassedRedThreshold,
-                },
-              )}
-            >
-              <ClockArrowUp size="14px" />
-              {parseMsToTime(timeLeft)}
-            </span>
+            </div>
           </div>
-        </div>
-      </TooltipTrigger>
+        }
+      />
       <TooltipContent className="grid gap-2">
         <div>
           <span className="block text-xs text-muted-foreground">

--- a/apps/web/src/features/guild/timers/timers.tsx
+++ b/apps/web/src/features/guild/timers/timers.tsx
@@ -103,31 +103,35 @@ export const Timers = () => {
             {isMobile && <WorldSwitcher />}
             <div className="flex items-center gap-1">
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={() => setViewMode("list")}
-                    variant={viewMode === "list" ? "default" : "ghost"}
-                    size="icon"
-                    className="h-8 w-8"
-                  >
-                    <List className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      onClick={() => setViewMode("list")}
+                      variant={viewMode === "list" ? "default" : "ghost"}
+                      size="icon"
+                      className="h-8 w-8"
+                    >
+                      <List className="h-4 w-4" />
+                    </Button>
+                  }
+                />
                 <TooltipContent side="bottom">
                   <p>{t("timers.view.list")}</p>
                 </TooltipContent>
               </Tooltip>
               <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={() => setViewMode("grid")}
-                    variant={viewMode === "grid" ? "default" : "ghost"}
-                    size="icon"
-                    className="h-8 w-8"
-                  >
-                    <Grid2X2 className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      onClick={() => setViewMode("grid")}
+                      variant={viewMode === "grid" ? "default" : "ghost"}
+                      size="icon"
+                      className="h-8 w-8"
+                    >
+                      <Grid2X2 className="h-4 w-4" />
+                    </Button>
+                  }
+                />
                 <TooltipContent side="bottom">
                   <p>{t("timers.view.grid")}</p>
                 </TooltipContent>

--- a/apps/web/src/features/user/battle-panel/battle-panel-abyss/abyss-hub.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-abyss/abyss-hub.tsx
@@ -208,7 +208,8 @@ export function AbyssHub() {
     });
   };
 
-  const handleSeasonChange = (seasonId: string) => {
+  const handleSeasonChange = (seasonId: string | null) => {
+    if (seasonId === null) return;
     const nextSeason = seasons.find((season) => season.id === seasonId);
     if (!nextSeason) {
       return;
@@ -305,6 +306,26 @@ export function AbyssHub() {
                 value={selectedSeason?.id ?? NO_SEASON_VALUE}
                 onValueChange={handleSeasonChange}
                 disabled={isLoadingSeasons || seasons.length === 0}
+                items={[
+                  {
+                    value: null,
+                    label: <>{t("battlePanel.abyss.selectSeason")}</>,
+                  },
+                  {
+                    value: NO_SEASON_VALUE,
+                    label: <>{t("battlePanel.abyss.noSeason")}</>,
+                  },
+                  ...seasons.map((season, index) => ({
+                    value: season.id,
+                    label: (
+                      <>
+                        {index === 0
+                          ? t("battlePanel.abyss.latestSeason")
+                          : getAbyssSeasonRangeLabel(season)}
+                      </>
+                    ),
+                  })),
+                ]}
               >
                 <SelectTrigger
                   size="lg"
@@ -343,18 +364,19 @@ export function AbyssHub() {
               </div>
 
               <Button
-                asChild
                 variant="outline"
                 className="h-10 w-full min-w-0 lg:w-auto"
-              >
-                <Link
-                  to={ROUTES.user.battlePanel.matchmakingH2h}
-                  search={h2hSearch}
-                >
-                  <List className="size-4" />
-                  {t("battlePanel.abyss.openH2h")}
-                </Link>
-              </Button>
+                render={
+                  <Link
+                    to={ROUTES.user.battlePanel.matchmakingH2h}
+                    search={h2hSearch}
+                  >
+                    <List className="size-4" />
+                    {t("battlePanel.abyss.openH2h")}
+                  </Link>
+                }
+                nativeButton={false}
+              />
             </div>
           </SectionHeader>
 

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battle-table-actions-menu.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battle-table-actions-menu.tsx
@@ -41,31 +41,33 @@ export const BattleTableActionsMenu = ({
       onKeyDown={stopBattleTableKeyboardAction}
     >
       <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            aria-label={t("battlePanel.actions.more")}
-            variant="ghost"
-            size="icon"
-            className="size-7 md:size-8"
-            disabled={disabled}
-          >
-            <MoreHorizontal className="size-4" />
-          </Button>
-        </DropdownMenuTrigger>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              aria-label={t("battlePanel.actions.more")}
+              variant="ghost"
+              size="icon"
+              className="size-7 md:size-8"
+              disabled={disabled}
+            >
+              <MoreHorizontal className="size-4" />
+            </Button>
+          }
+        />
         <DropdownMenuContent align="end" className="w-48">
           {battle.public ? (
             <>
-              <DropdownMenuItem onSelect={() => onCopyLink(battle.id)}>
+              <DropdownMenuItem onClick={() => onCopyLink(battle.id)}>
                 <Copy className="size-4" />
                 {t("battlePanel.actions.copyLink")}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => onUnshare(battle.id)}>
+              <DropdownMenuItem onClick={() => onUnshare(battle.id)}>
                 <Lock className="size-4" />
                 {t("battlePanel.actions.hide")}
               </DropdownMenuItem>
             </>
           ) : (
-            <DropdownMenuItem onSelect={() => onShare(battle.id)}>
+            <DropdownMenuItem onClick={() => onShare(battle.id)}>
               <Share2 className="size-4" />
               {t("battlePanel.actions.share")}
             </DropdownMenuItem>
@@ -73,7 +75,7 @@ export const BattleTableActionsMenu = ({
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
-            onSelect={() => onDelete(battle)}
+            onClick={() => onDelete(battle)}
           >
             <Trash2 className="size-4" />
             {t("battlePanel.actions.delete")}

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battle-table-delete-dialogs.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battle-table-delete-dialogs.tsx
@@ -55,15 +55,17 @@ export const BattleTableDeleteDialogs = ({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button
-                variant="destructive"
-                onClick={onBulkDelete}
-                disabled={isDeletePending}
-              >
-                {t("battlePanel.bulk.deleteDialog.confirm")}
-              </Button>
-            </AlertDialogAction>
+            <AlertDialogAction
+              render={
+                <Button
+                  variant="destructive"
+                  onClick={onBulkDelete}
+                  disabled={isDeletePending}
+                >
+                  {t("battlePanel.bulk.deleteDialog.confirm")}
+                </Button>
+              }
+            />
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -83,15 +85,17 @@ export const BattleTableDeleteDialogs = ({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button
-                variant="destructive"
-                onClick={onSingleDelete}
-                disabled={isDeletePending}
-              >
-                {t("battlePanel.dialogs.deleteBattle.confirm")}
-              </Button>
-            </AlertDialogAction>
+            <AlertDialogAction
+              render={
+                <Button
+                  variant="destructive"
+                  onClick={onSingleDelete}
+                  disabled={isDeletePending}
+                >
+                  {t("battlePanel.dialogs.deleteBattle.confirm")}
+                </Button>
+              }
+            />
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battle-table-info-badges.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battle-table-info-badges.tsx
@@ -94,23 +94,25 @@ export const BattleTableInfoBadges = ({
       <span className={BATTLE_INFO_TAG_CLASS_NAME}>{visibilityLabel}</span>
       {userWarrior?.ph !== 0 && userWarrior?.ph !== undefined && (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <Badge
-              onClick={handlePhBadgeClick}
-              onKeyDown={(event) =>
-                handleFilterBadgeKeyDown(event, () => onPhClick?.())
-              }
-              role="button"
-              tabIndex={0}
-              variant="outline"
-              className={cn(
-                BATTLE_INFO_TAG_CLASS_NAME,
-                BATTLE_INFO_TAG_ACTION_CLASS_NAME,
-              )}
-            >
-              {t("battlePanel.bulk.honorPointsShort")}
-            </Badge>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <Badge
+                onClick={handlePhBadgeClick}
+                onKeyDown={(event) =>
+                  handleFilterBadgeKeyDown(event, () => onPhClick?.())
+                }
+                role="button"
+                tabIndex={0}
+                variant="outline"
+                className={cn(
+                  BATTLE_INFO_TAG_CLASS_NAME,
+                  BATTLE_INFO_TAG_ACTION_CLASS_NAME,
+                )}
+              >
+                {t("battlePanel.bulk.honorPointsShort")}
+              </Badge>
+            }
+          />
           <TooltipContent>
             {t("battlePanel.filters.honorPoints")}
           </TooltipContent>
@@ -118,24 +120,26 @@ export const BattleTableInfoBadges = ({
       )}
       {battle.matchmaking && (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <Badge
-              onClick={handleMatchmakingBadgeClick}
-              onKeyDown={(event) =>
-                handleFilterBadgeKeyDown(event, () => onMatchmakingClick?.())
-              }
-              role="button"
-              tabIndex={0}
-              variant="outline"
-              className={cn(
-                BATTLE_INFO_TAG_CLASS_NAME,
-                BATTLE_INFO_TAG_ACTION_CLASS_NAME,
-                "border-purple-500/50 bg-purple-500/10 text-purple-400 hover:bg-purple-500/20",
-              )}
-            >
-              {t("battlePanel.filters.matchmaking")}
-            </Badge>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <Badge
+                onClick={handleMatchmakingBadgeClick}
+                onKeyDown={(event) =>
+                  handleFilterBadgeKeyDown(event, () => onMatchmakingClick?.())
+                }
+                role="button"
+                tabIndex={0}
+                variant="outline"
+                className={cn(
+                  BATTLE_INFO_TAG_CLASS_NAME,
+                  BATTLE_INFO_TAG_ACTION_CLASS_NAME,
+                  "border-purple-500/50 bg-purple-500/10 text-purple-400 hover:bg-purple-500/20",
+                )}
+              >
+                {t("battlePanel.filters.matchmaking")}
+              </Badge>
+            }
+          />
           <TooltipContent>
             {t("battlePanel.filters.matchmaking")}
           </TooltipContent>

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filter-toolbar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filter-toolbar.tsx
@@ -171,24 +171,26 @@ export const BattlesListFilterToolbar = ({
       />
 
       <Popover open={characterOpen} onOpenChange={setCharacterOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-controls={characterListId}
-            aria-expanded={characterOpen}
-            className="h-10 w-[160px] justify-between"
-          >
-            <div className="flex min-w-0 items-center gap-2">
-              <User className="size-4 shrink-0" aria-hidden="true" />
-              <span className="truncate text-sm">{characterLabel}</span>
-            </div>
-            <ChevronsUpDown
-              className="ml-2 size-4 shrink-0 opacity-50"
-              aria-hidden="true"
-            />
-          </Button>
-        </PopoverTrigger>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="outline"
+              role="combobox"
+              aria-controls={characterListId}
+              aria-expanded={characterOpen}
+              className="h-10 w-[160px] justify-between"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <User className="size-4 shrink-0" aria-hidden="true" />
+                <span className="truncate text-sm">{characterLabel}</span>
+              </div>
+              <ChevronsUpDown
+                className="ml-2 size-4 shrink-0 opacity-50"
+                aria-hidden="true"
+              />
+            </Button>
+          }
+        />
         <PopoverContent className="w-[280px] p-0">
           <Command>
             <CommandInput
@@ -250,12 +252,14 @@ export const BattlesListFilterToolbar = ({
       />
 
       <Popover>
-        <PopoverTrigger asChild>
-          <Button type="button" variant="outline" className="h-10 gap-2">
-            <SlidersHorizontal className="size-4" aria-hidden="true" />
-            {moreLabel}
-          </Button>
-        </PopoverTrigger>
+        <PopoverTrigger
+          render={
+            <Button type="button" variant="outline" className="h-10 gap-2">
+              <SlidersHorizontal className="size-4" aria-hidden="true" />
+              {moreLabel}
+            </Button>
+          }
+        />
         <PopoverContent align="end" className="w-[300px] p-4">
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-desktop.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-desktop.tsx
@@ -121,27 +121,29 @@ export const BattlesListFiltersDesktop = ({
       />
 
       <Popover open={characterOpen} onOpenChange={onCharacterOpenChange}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            role="combobox"
-            aria-controls={characterListId}
-            aria-expanded={characterOpen}
-            className="w-[180px] justify-between h-10"
-          >
-            <div className="flex items-center gap-2">
-              <User className="h-4 w-4" />
-              <span className="text-sm">
-                {filters.characterId && filters.characterId.length > 0
-                  ? t("battlePanel.filters.selectedCount", {
-                      count: filters.characterId.length,
-                    })
-                  : t("battlePanel.filters.character")}
-              </span>
-            </div>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-          </Button>
-        </PopoverTrigger>
+        <PopoverTrigger
+          render={
+            <Button
+              variant="outline"
+              role="combobox"
+              aria-controls={characterListId}
+              aria-expanded={characterOpen}
+              className="w-[180px] justify-between h-10"
+            >
+              <div className="flex items-center gap-2">
+                <User className="h-4 w-4" />
+                <span className="text-sm">
+                  {filters.characterId && filters.characterId.length > 0
+                    ? t("battlePanel.filters.selectedCount", {
+                        count: filters.characterId.length,
+                      })
+                    : t("battlePanel.filters.character")}
+                </span>
+              </div>
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          }
+        />
         <PopoverContent className="w-[180px] p-0">
           <Command>
             <CommandInput

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-mobile.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-list-filters-mobile.tsx
@@ -106,20 +106,22 @@ export const BattlesListFiltersMobile = ({
   ];
 
   return (
-    <Drawer shouldScaleBackground={false}>
-      <DrawerTrigger asChild>
-        <Button className="w-full justify-between">
-          <div className="flex items-center gap-2">
-            <Filter className="h-4 w-4" />
-            <span>{t("battlePanel.filters.title")}</span>
-          </div>
-          {activeFiltersCount > 0 && (
-            <Badge variant="secondary" className="ml-2">
-              {activeFiltersCount}
-            </Badge>
-          )}
-        </Button>
-      </DrawerTrigger>
+    <Drawer>
+      <DrawerTrigger
+        render={
+          <Button className="w-full justify-between">
+            <div className="flex items-center gap-2">
+              <Filter className="h-4 w-4" />
+              <span>{t("battlePanel.filters.title")}</span>
+            </div>
+            {activeFiltersCount > 0 && (
+              <Badge variant="secondary" className="ml-2">
+                {activeFiltersCount}
+              </Badge>
+            )}
+          </Button>
+        }
+      />
       <DrawerContent className="flex max-h-[85vh] flex-col p-4">
         <DrawerHeader className="mb-4 shrink-0">
           <DrawerTitle>{t("battlePanel.filters.battlesTitle")}</DrawerTitle>
@@ -142,30 +144,30 @@ export const BattlesListFiltersMobile = ({
                 onOpenChange={onWorldOpenChange}
                 modal={false}
               >
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    role="combobox"
-                    aria-controls={worldListId}
-                    aria-expanded={worldOpen}
-                    className="w-full justify-between"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Globe className="h-4 w-4" />
-                      <span className="text-sm">
-                        {filters.world
-                          ? capitalizeFirstLetter(filters.world)
-                          : t("battlePanel.filters.allWorlds")}
-                      </span>
-                    </div>
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
+                <PopoverTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-controls={worldListId}
+                      aria-expanded={worldOpen}
+                      className="w-full justify-between"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Globe className="h-4 w-4" />
+                        <span className="text-sm">
+                          {filters.world
+                            ? capitalizeFirstLetter(filters.world)
+                            : t("battlePanel.filters.allWorlds")}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  }
+                />
                 <PopoverContent
-                  className="w-[var(--radix-popover-trigger-width)] p-0"
-                  onOpenAutoFocus={(event) => {
-                    event.preventDefault();
-                  }}
+                  className="w-[var(--anchor-width)] p-0"
+                  initialFocus={false}
                 >
                   <Command>
                     <CommandInput
@@ -209,28 +211,30 @@ export const BattlesListFiltersMobile = ({
                 onOpenChange={onResultOpenChange}
                 modal={false}
               >
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    role="combobox"
-                    aria-controls={resultListId}
-                    aria-expanded={resultOpen}
-                    className="w-full justify-between"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Medal className="h-4 w-4" />
-                      <span className="text-sm">
-                        {filters.result && filters.result.length > 0
-                          ? t("battlePanel.filters.selectedCount", {
-                              count: filters.result.length,
-                            })
-                          : t("battlePanel.filters.allResults")}
-                      </span>
-                    </div>
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+                <PopoverTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-controls={resultListId}
+                      aria-expanded={resultOpen}
+                      className="w-full justify-between"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Medal className="h-4 w-4" />
+                        <span className="text-sm">
+                          {filters.result && filters.result.length > 0
+                            ? t("battlePanel.filters.selectedCount", {
+                                count: filters.result.length,
+                              })
+                            : t("battlePanel.filters.allResults")}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  }
+                />
+                <PopoverContent className="w-[var(--anchor-width)] p-0">
                   <Command>
                     <CommandList id={resultListId}>
                       <CommandEmpty>
@@ -268,28 +272,30 @@ export const BattlesListFiltersMobile = ({
                 onOpenChange={onCharacterOpenChange}
                 modal={false}
               >
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    role="combobox"
-                    aria-controls={characterListId}
-                    aria-expanded={characterOpen}
-                    className="w-full justify-between"
-                  >
-                    <div className="flex items-center gap-2">
-                      <User className="h-4 w-4" />
-                      <span className="text-sm">
-                        {filters.characterId && filters.characterId.length > 0
-                          ? t("battlePanel.filters.selectedCount", {
-                              count: filters.characterId.length,
-                            })
-                          : t("battlePanel.filters.allCharacters")}
-                      </span>
-                    </div>
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+                <PopoverTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-controls={characterListId}
+                      aria-expanded={characterOpen}
+                      className="w-full justify-between"
+                    >
+                      <div className="flex items-center gap-2">
+                        <User className="h-4 w-4" />
+                        <span className="text-sm">
+                          {filters.characterId && filters.characterId.length > 0
+                            ? t("battlePanel.filters.selectedCount", {
+                                count: filters.characterId.length,
+                              })
+                            : t("battlePanel.filters.allCharacters")}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  }
+                />
+                <PopoverContent className="w-[var(--anchor-width)] p-0">
                   <Command>
                     <CommandInput
                       placeholder={t(
@@ -338,28 +344,30 @@ export const BattlesListFiltersMobile = ({
                 onOpenChange={onTypeOpenChange}
                 modal={false}
               >
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    role="combobox"
-                    aria-controls={typeListId}
-                    aria-expanded={typeOpen}
-                    className="w-full justify-between"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4" />
-                      <span className="text-sm">
-                        {filters.type && filters.type.length > 0
-                          ? t("battlePanel.filters.selectedCount", {
-                              count: filters.type.length,
-                            })
-                          : t("battlePanel.filters.allTypes")}
-                      </span>
-                    </div>
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+                <PopoverTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      role="combobox"
+                      aria-controls={typeListId}
+                      aria-expanded={typeOpen}
+                      className="w-full justify-between"
+                    >
+                      <div className="flex items-center gap-2">
+                        <Users className="h-4 w-4" />
+                        <span className="text-sm">
+                          {filters.type && filters.type.length > 0
+                            ? t("battlePanel.filters.selectedCount", {
+                                count: filters.type.length,
+                              })
+                            : t("battlePanel.filters.allTypes")}
+                        </span>
+                      </div>
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  }
+                />
+                <PopoverContent className="w-[var(--anchor-width)] p-0">
                   <Command>
                     <CommandList id={typeListId}>
                       <CommandEmpty>
@@ -423,11 +431,13 @@ export const BattlesListFiltersMobile = ({
           </div>
         </ScrollArea>
         <div className="mt-6 shrink-0">
-          <DrawerClose asChild>
-            <Button variant="outline" className="w-full">
-              {t("battlePanel.actions.close")}
-            </Button>
-          </DrawerClose>
+          <DrawerClose
+            render={
+              <Button variant="outline" className="w-full">
+                {t("battlePanel.actions.close")}
+              </Button>
+            }
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-table.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/battles-table.tsx
@@ -257,7 +257,8 @@ export const BattlesTable = ({
           onKeyDown={stopBattleTableKeyboardAction}
         >
           <Checkbox
-            checked={headerCheckboxState}
+            checked={headerCheckboxState === true}
+            indeterminate={headerCheckboxState === "indeterminate"}
             aria-label={t("battlePanel.bulk.selectRows")}
             className="size-5"
             onClick={stopBattleTableAction}
@@ -357,11 +358,13 @@ export const BattlesTable = ({
         return (
           <div className="flex min-w-0 items-center md:min-w-[104px]">
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="max-w-full truncate text-xs font-medium text-muted-foreground">
-                  {getRelativeTime(battle.createdAt)}
-                </span>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <span className="max-w-full truncate text-xs font-medium text-muted-foreground">
+                    {getRelativeTime(battle.createdAt)}
+                  </span>
+                }
+              />
               <TooltipContent>{exactTime}</TooltipContent>
             </Tooltip>
           </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/filters-sidebar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-battles-list/components/filters-sidebar.tsx
@@ -220,27 +220,30 @@ export const FiltersSidebar = ({
                   {t("battlePanel.filters.character")}
                 </Label>
                 <Popover open={characterOpen} onOpenChange={setCharacterOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      role="combobox"
-                      aria-controls={characterListId}
-                      aria-expanded={characterOpen}
-                      className="w-full justify-between h-10"
-                    >
-                      <div className="flex items-center gap-2">
-                        <User className="h-4 w-4" />
-                        <span className="text-sm">
-                          {filters.characterId && filters.characterId.length > 0
-                            ? t("battlePanel.filters.selectedCount", {
-                                count: filters.characterId.length,
-                              })
-                            : t("battlePanel.filters.character")}
-                        </span>
-                      </div>
-                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
+                  <PopoverTrigger
+                    render={
+                      <Button
+                        variant="outline"
+                        role="combobox"
+                        aria-controls={characterListId}
+                        aria-expanded={characterOpen}
+                        className="w-full justify-between h-10"
+                      >
+                        <div className="flex items-center gap-2">
+                          <User className="h-4 w-4" />
+                          <span className="text-sm">
+                            {filters.characterId &&
+                            filters.characterId.length > 0
+                              ? t("battlePanel.filters.selectedCount", {
+                                  count: filters.characterId.length,
+                                })
+                              : t("battlePanel.filters.character")}
+                          </span>
+                        </div>
+                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                      </Button>
+                    }
+                  />
                   <PopoverContent className="w-[280px] p-0">
                     <Command>
                       <CommandInput

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-detail-view.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-detail-view.tsx
@@ -474,25 +474,29 @@ export function BattleDetailView({
                           compactTrigger
                         />
                         <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              onClick={() => setHideZeros(!hideZeros)}
-                              aria-label={
-                                hideZeros
-                                  ? t("battlePanel.single.statistics.showAll")
-                                  : t("battlePanel.single.statistics.hideZeros")
-                              }
-                              className="size-8"
-                            >
-                              {hideZeros ? (
-                                <Eye className="h-4 w-4" />
-                              ) : (
-                                <EyeOff className="h-4 w-4" />
-                              )}
-                            </Button>
-                          </TooltipTrigger>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => setHideZeros(!hideZeros)}
+                                aria-label={
+                                  hideZeros
+                                    ? t("battlePanel.single.statistics.showAll")
+                                    : t(
+                                        "battlePanel.single.statistics.hideZeros",
+                                      )
+                                }
+                                className="size-8"
+                              >
+                                {hideZeros ? (
+                                  <Eye className="h-4 w-4" />
+                                ) : (
+                                  <EyeOff className="h-4 w-4" />
+                                )}
+                              </Button>
+                            }
+                          />
                           <TooltipContent>
                             {hideZeros
                               ? t("battlePanel.single.statistics.showAll")

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-hp-timeline-chart.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-hp-timeline-chart.tsx
@@ -97,33 +97,37 @@ export function BattleHpTimelineChart({
         </div>
         <div className="flex items-center gap-2">
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label={visibilityLabel}
-                aria-pressed={isChartHidden}
-                variant="ghost"
-                size="icon"
-                className="size-8"
-                onClick={toggleChartHidden}
-              >
-                <VisibilityIcon className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={visibilityLabel}
+                  aria-pressed={isChartHidden}
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                  onClick={toggleChartHidden}
+                >
+                  <VisibilityIcon className="size-3.5" />
+                </Button>
+              }
+            />
             <TooltipContent>{visibilityLabel}</TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label={heightLabel}
-                aria-pressed={isExpanded}
-                variant="ghost"
-                size="icon"
-                className="size-8"
-                onClick={toggleHeightMode}
-              >
-                <HeightIcon className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={heightLabel}
+                  aria-pressed={isExpanded}
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                  onClick={toggleHeightMode}
+                >
+                  <HeightIcon className="size-3.5" />
+                </Button>
+              }
+            />
             <TooltipContent>{heightLabel}</TooltipContent>
           </Tooltip>
           <BattleHpTimelineLegendPopover

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-hp-timeline-dialog.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-hp-timeline-dialog.tsx
@@ -61,18 +61,22 @@ export function BattleHpTimelineDialog({
   return (
     <Dialog>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button
-              aria-label={openLabel}
-              variant="ghost"
-              size="icon"
-              className="size-8"
-            >
-              <Maximize2 className="size-3.5" />
-            </Button>
-          </DialogTrigger>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <DialogTrigger
+              render={
+                <Button
+                  aria-label={openLabel}
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                >
+                  <Maximize2 className="size-3.5" />
+                </Button>
+              }
+            />
+          }
+        />
         <TooltipContent>{openLabel}</TooltipContent>
       </Tooltip>
       <DialogContent className="flex h-[88dvh] max-h-[900px] w-[calc(100vw-2rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-[calc(100vw-2rem)] xl:max-w-[1500px] max-sm:h-dvh max-sm:w-screen max-sm:max-w-none max-sm:rounded-none">

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-hp-timeline-legend-popover.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-hp-timeline-legend-popover.tsx
@@ -46,18 +46,22 @@ export function BattleHpTimelineLegendPopover({
   return (
     <Popover>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <PopoverTrigger asChild>
-            <Button
-              aria-label={openLabel}
-              variant="ghost"
-              size="icon"
-              className="size-8"
-            >
-              <CircleHelp className="size-3.5" />
-            </Button>
-          </PopoverTrigger>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <PopoverTrigger
+              render={
+                <Button
+                  aria-label={openLabel}
+                  variant="ghost"
+                  size="icon"
+                  className="size-8"
+                >
+                  <CircleHelp className="size-3.5" />
+                </Button>
+              }
+            />
+          }
+        />
         <TooltipContent>{openLabel}</TooltipContent>
       </Tooltip>
       <PopoverContent align="end" className="w-72 p-0 sm:w-80">

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-panel-single-battle-actions.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/battle-panel-single-battle-actions.tsx
@@ -116,69 +116,79 @@ export const BattlePanelSingleBattleActions: FC<
       {battle.public ? (
         <>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label={t("battlePanel.actions.copyLink")}
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                onClick={handleCopyClick}
-                disabled={isBusy}
-              >
-                <Copy className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={t("battlePanel.actions.copyLink")}
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={handleCopyClick}
+                  disabled={isBusy}
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </Button>
+              }
+            />
             <TooltipContent>{t("battlePanel.actions.copyLink")}</TooltipContent>
           </Tooltip>
           <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                aria-label={t("battlePanel.actions.hide")}
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                onClick={handleUnshareClick}
-                disabled={isBusy}
-              >
-                <Lock className="h-3.5 w-3.5" />
-              </Button>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Button
+                  aria-label={t("battlePanel.actions.hide")}
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={handleUnshareClick}
+                  disabled={isBusy}
+                >
+                  <Lock className="h-3.5 w-3.5" />
+                </Button>
+              }
+            />
             <TooltipContent>{t("battlePanel.actions.hide")}</TooltipContent>
           </Tooltip>
         </>
       ) : (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              aria-label={t("battlePanel.actions.share")}
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={handleShareClick}
-              disabled={isBusy}
-            >
-              <Share2 className="h-3.5 w-3.5" />
-            </Button>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("battlePanel.actions.share")}
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                onClick={handleShareClick}
+                disabled={isBusy}
+              >
+                <Share2 className="h-3.5 w-3.5" />
+              </Button>
+            }
+          />
           <TooltipContent>{t("battlePanel.actions.share")}</TooltipContent>
         </Tooltip>
       )}
 
       <AlertDialog>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <AlertDialogTrigger asChild>
-              <Button
-                aria-label={t("battlePanel.actions.delete")}
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 text-destructive hover:text-destructive"
-                disabled={isBusy}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            </AlertDialogTrigger>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <AlertDialogTrigger
+                render={
+                  <Button
+                    aria-label={t("battlePanel.actions.delete")}
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-destructive hover:text-destructive"
+                    disabled={isBusy}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                }
+              />
+            }
+          />
           <TooltipContent>{t("battlePanel.actions.delete")}</TooltipContent>
         </Tooltip>
         <AlertDialogContent>
@@ -192,15 +202,17 @@ export const BattlePanelSingleBattleActions: FC<
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-            <AlertDialogAction asChild>
-              <Button
-                variant="destructive"
-                onClick={handleDeleteClick}
-                disabled={isBusy}
-              >
-                {t("battlePanel.dialogs.deleteBattle.confirm")}
-              </Button>
-            </AlertDialogAction>
+            <AlertDialogAction
+              render={
+                <Button
+                  variant="destructive"
+                  onClick={handleDeleteClick}
+                  disabled={isBusy}
+                >
+                  {t("battlePanel.dialogs.deleteBattle.confirm")}
+                </Button>
+              }
+            />
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-card.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-card.tsx
@@ -57,29 +57,35 @@ export function RecentOpponentBattlesCard({
           </div>
         </div>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              asChild
-              variant="ghost"
-              size="icon"
-              className="size-8 shrink-0"
-            >
-              <Link
-                aria-label={t("battlePanel.single.recentOpponent.viewAllAria", {
-                  opponent: context.opponentName,
-                })}
-                to={
-                  ROUTES.user.battlePanel.playerVsPlayer(
-                    context.characterId,
-                    context.opponentId,
-                  ) as string
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 shrink-0"
+                render={
+                  <Link
+                    aria-label={t(
+                      "battlePanel.single.recentOpponent.viewAllAria",
+                      {
+                        opponent: context.opponentName,
+                      },
+                    )}
+                    to={
+                      ROUTES.user.battlePanel.playerVsPlayer(
+                        context.characterId,
+                        context.opponentId,
+                      ) as string
+                    }
+                    search={{ period: "all" }}
+                  >
+                    <ArrowUpRight className="size-3.5" />
+                  </Link>
                 }
-                search={{ period: "all" }}
-              >
-                <ArrowUpRight className="size-3.5" />
-              </Link>
-            </Button>
-          </TooltipTrigger>
+                nativeButton={false}
+              />
+            }
+          />
           <TooltipContent>
             {t("battlePanel.single.recentOpponent.viewAllAria", {
               opponent: context.opponentName,

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-dialog.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-dialog.tsx
@@ -37,18 +37,22 @@ export function RecentOpponentBattlesDialog({
   return (
     <Dialog>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button
-              aria-label={t("battlePanel.single.recentOpponent.openDialog")}
-              variant="ghost"
-              size="icon"
-              className={cn("h-8 w-8", className)}
-            >
-              <History className="h-3.5 w-3.5" />
-            </Button>
-          </DialogTrigger>
-        </TooltipTrigger>
+        <TooltipTrigger
+          render={
+            <DialogTrigger
+              render={
+                <Button
+                  aria-label={t("battlePanel.single.recentOpponent.openDialog")}
+                  variant="ghost"
+                  size="icon"
+                  className={cn("h-8 w-8", className)}
+                >
+                  <History className="h-3.5 w-3.5" />
+                </Button>
+              }
+            />
+          }
+        />
         <TooltipContent>
           {t("battlePanel.single.recentOpponent.openDialog")}
         </TooltipContent>

--- a/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-list.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-single-battle/components/recent-opponent-battles-list.tsx
@@ -116,11 +116,13 @@ export function RecentOpponentBattlesList({
                     </span>
                   ) : null}
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="block whitespace-normal break-words text-right text-[11px] leading-snug text-muted-foreground">
-                        {relativeTime}
-                      </span>
-                    </TooltipTrigger>
+                    <TooltipTrigger
+                      render={
+                        <span className="block whitespace-normal break-words text-right text-[11px] leading-snug text-muted-foreground">
+                          {relativeTime}
+                        </span>
+                      }
+                    />
                     <TooltipContent>{exactTime}</TooltipContent>
                   </Tooltip>
                 </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-columns.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-columns.tsx
@@ -162,11 +162,13 @@ export const headToHeadLastBattleColumn: ColumnDef<HeadToHeadRecord> = {
     return (
       <div className="flex min-w-0 justify-end">
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="max-w-full truncate text-xs font-medium text-muted-foreground">
-              {getRelativeTime(row.original.lastBattleDate)}
-            </span>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <span className="max-w-full truncate text-xs font-medium text-muted-foreground">
+                {getRelativeTime(row.original.lastBattleDate)}
+              </span>
+            }
+          />
           <TooltipContent>{exactTime}</TooltipContent>
         </Tooltip>
       </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-filter-toolbar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-filter-toolbar.tsx
@@ -111,12 +111,14 @@ export const HeadToHeadFilterToolbar = ({
         width="w-[170px]"
       />
       <Popover>
-        <PopoverTrigger asChild>
-          <Button type="button" variant="outline" className="h-10 gap-2">
-            <SlidersHorizontal className="size-4" aria-hidden="true" />
-            {moreLabel}
-          </Button>
-        </PopoverTrigger>
+        <PopoverTrigger
+          render={
+            <Button type="button" variant="outline" className="h-10 gap-2">
+              <SlidersHorizontal className="size-4" aria-hidden="true" />
+              {moreLabel}
+            </Button>
+          }
+        />
         <PopoverContent align="end" className="w-[300px] p-4">
           <div className="flex flex-col gap-4">
             <div className="flex flex-col gap-2">

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-table.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/head-to-head-table.tsx
@@ -221,16 +221,21 @@ export function HeadToHeadTable({
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
         <div className="mt-auto flex justify-end pt-4">
-          <Button asChild variant="outline" size="sm">
-            <Link
-              to={ROUTES.user.battlePanel.h2h}
-              search={search}
-              onClick={(event) => event.stopPropagation()}
-            >
-              {t("battlePanel.statistics.directMatchups.link")}
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            render={
+              <Link
+                to={ROUTES.user.battlePanel.h2h}
+                search={search}
+                onClick={(event) => event.stopPropagation()}
+              >
+                {t("battlePanel.statistics.directMatchups.link")}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            }
+            nativeButton={false}
+          />
         </div>
       </div>
     </StatCard>

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/player-vs-player-columns.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/player-vs-player-columns.tsx
@@ -153,11 +153,13 @@ export const playerVsPlayerColumns: ColumnDef<PlayerVsPlayerBattle>[] = [
       return (
         <div className="flex min-w-0 justify-end">
           <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="max-w-full truncate text-xs font-medium text-muted-foreground">
-                {getRelativeTime(row.original.createdAt)}
-              </span>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <span className="max-w-full truncate text-xs font-medium text-muted-foreground">
+                  {getRelativeTime(row.original.createdAt)}
+                </span>
+              }
+            />
             <TooltipContent>{exactTime}</TooltipContent>
           </Tooltip>
         </div>

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/player-vs-player-filter-toolbar.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/player-vs-player-filter-toolbar.tsx
@@ -75,12 +75,14 @@ export const PlayerVsPlayerFilterToolbar = ({
         width="w-[190px]"
       />
       <Popover>
-        <PopoverTrigger asChild>
-          <Button type="button" variant="outline" className="h-10 gap-2">
-            <SlidersHorizontal className="size-4" aria-hidden="true" />
-            {moreLabel}
-          </Button>
-        </PopoverTrigger>
+        <PopoverTrigger
+          render={
+            <Button type="button" variant="outline" className="h-10 gap-2">
+              <SlidersHorizontal className="size-4" aria-hidden="true" />
+              {moreLabel}
+            </Button>
+          }
+        />
         <PopoverContent align="end" className="w-[300px] p-4">
           <div className="flex flex-col gap-2">
             <Label className="text-xs text-muted-foreground">

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/rating-delta-by-opponent-card.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/rating-delta-by-opponent-card.tsx
@@ -321,12 +321,17 @@ export function RatingDeltaByOpponentCard({
           </ScrollArea>
         )}
         <div className="mt-auto flex justify-end pt-4">
-          <Button asChild variant="outline" size="sm">
-            <Link to={ROUTES.user.battlePanel.matchmakingH2h} search={search}>
-              {t("battlePanel.statistics.matchmaking.link")}
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            render={
+              <Link to={ROUTES.user.battlePanel.matchmakingH2h} search={search}>
+                {t("battlePanel.statistics.matchmaking.link")}
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            }
+            nativeButton={false}
+          />
         </div>
       </div>
     </StatCard>

--- a/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/statistics-filters-mobile.tsx
+++ b/apps/web/src/features/user/battle-panel/battle-panel-statistics/components/statistics-filters-mobile.tsx
@@ -81,15 +81,17 @@ export const StatisticsFiltersMobile = ({
   ];
 
   return (
-    <Drawer shouldScaleBackground={false}>
-      <DrawerTrigger asChild>
-        <Button className="w-full justify-between">
-          <div className="flex items-center gap-2">
-            <Filter className="h-4 w-4" />
-            <span>{t("battlePanel.filters.title")}</span>
-          </div>
-        </Button>
-      </DrawerTrigger>
+    <Drawer>
+      <DrawerTrigger
+        render={
+          <Button className="w-full justify-between">
+            <div className="flex items-center gap-2">
+              <Filter className="h-4 w-4" />
+              <span>{t("battlePanel.filters.title")}</span>
+            </div>
+          </Button>
+        }
+      />
       <DrawerContent className="flex max-h-[85vh] flex-col p-4">
         <DrawerHeader className="mb-4 shrink-0">
           <DrawerTitle>{t("battlePanel.filters.statisticsTitle")}</DrawerTitle>
@@ -101,8 +103,24 @@ export const StatisticsFiltersMobile = ({
               <Select
                 value={characterId}
                 onValueChange={(value) =>
-                  onCharacterChange(value === "all" ? undefined : value)
+                  onCharacterChange(
+                    value === null || value === "all" ? undefined : value,
+                  )
                 }
+                items={[
+                  {
+                    value: null,
+                    label: <>{t("battlePanel.filters.selectCharacter")}</>,
+                  },
+                  ...characters.map((char) => ({
+                    value: char.id,
+                    label: (
+                      <>
+                        {char.name} ({char.world})
+                      </>
+                    ),
+                  })),
+                ]}
               >
                 <SelectTrigger className="w-full">
                   <div className="flex items-center gap-2">
@@ -124,7 +142,18 @@ export const StatisticsFiltersMobile = ({
 
             <div className="space-y-2">
               <Label>{t("battlePanel.filters.period")}</Label>
-              <Select value={period} onValueChange={onPeriodChange}>
+              <Select
+                value={period}
+                onValueChange={(value) => {
+                  if (value !== null) onPeriodChange(value);
+                }}
+                items={[
+                  ...periodOptions.map((option) => ({
+                    value: option.value,
+                    label: <>{option.label}</>,
+                  })),
+                ]}
+              >
                 <SelectTrigger className="w-full">
                   <div className="flex items-center gap-2">
                     <Calendar className="h-4 w-4" />
@@ -213,11 +242,13 @@ export const StatisticsFiltersMobile = ({
           </div>
         </ScrollArea>
         <div className="mt-6 shrink-0">
-          <DrawerClose asChild>
-            <Button variant="outline" className="w-full">
-              {t("battlePanel.actions.close")}
-            </Button>
-          </DrawerClose>
+          <DrawerClose
+            render={
+              <Button variant="outline" className="w-full">
+                {t("battlePanel.actions.close")}
+              </Button>
+            }
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/features/user/battle-panel/components/battle-damage-tags.tsx
+++ b/apps/web/src/features/user/battle-panel/components/battle-damage-tags.tsx
@@ -157,23 +157,25 @@ export function BattleDamageTags({
 
         return (
           <Tooltip key={tag.key}>
-            <TooltipTrigger asChild>
-              <Badge
-                {...restBadgeProps}
-                data-battle-table-action={battleTableAction ? "" : undefined}
-                tabIndex={badgeTabIndex ?? 0}
-                role="img"
-                aria-label={tagLabel}
-                variant="outline"
-                className={cn(
-                  "inline-flex size-5 min-w-5 items-center justify-center rounded-full p-0 shadow-none",
-                  tag.badgeClassName,
-                  badgeClassName,
-                )}
-              >
-                <Icon className="size-3" aria-hidden="true" />
-              </Badge>
-            </TooltipTrigger>
+            <TooltipTrigger
+              render={
+                <Badge
+                  {...restBadgeProps}
+                  data-battle-table-action={battleTableAction ? "" : undefined}
+                  tabIndex={badgeTabIndex ?? 0}
+                  role="img"
+                  aria-label={tagLabel}
+                  variant="outline"
+                  className={cn(
+                    "inline-flex size-5 min-w-5 items-center justify-center rounded-full p-0 shadow-none",
+                    tag.badgeClassName,
+                    badgeClassName,
+                  )}
+                >
+                  <Icon className="size-3" aria-hidden="true" />
+                </Badge>
+              }
+            />
             <TooltipContent>{tagLabel}</TooltipContent>
           </Tooltip>
         );

--- a/apps/web/src/features/user/battle-panel/components/battle-panel-h2h-card.tsx
+++ b/apps/web/src/features/user/battle-panel/components/battle-panel-h2h-card.tsx
@@ -43,11 +43,13 @@ export const BattlePanelH2hCard = ({
       <div className="flex items-start justify-between gap-3">
         <BattleResultStatus result={record.lastBattleResult} showLabel />
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="text-right text-xs font-medium text-muted-foreground">
-              {getRelativeTime(record.lastBattleDate)}
-            </span>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <span className="text-right text-xs font-medium text-muted-foreground">
+                {getRelativeTime(record.lastBattleDate)}
+              </span>
+            }
+          />
           <TooltipContent>{exactTime}</TooltipContent>
         </Tooltip>
       </div>

--- a/apps/web/src/features/user/battle-panel/components/battle-panel-mobile-filters-drawer.tsx
+++ b/apps/web/src/features/user/battle-panel/components/battle-panel-mobile-filters-drawer.tsx
@@ -24,11 +24,7 @@ export const BattlePanelMobileFiltersDrawer = ({
   title,
 }: BattlePanelMobileFiltersDrawerProps) => {
   return (
-    <Drawer
-      open={open}
-      onOpenChange={onOpenChange}
-      shouldScaleBackground={false}
-    >
+    <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent className="flex h-[85vh] max-h-[85vh] flex-col overflow-hidden p-0">
         <DrawerHeader className="shrink-0 border-b px-4 py-3">
           <DrawerTitle>{title}</DrawerTitle>

--- a/apps/web/src/features/user/battle-panel/components/battle-result-status.tsx
+++ b/apps/web/src/features/user/battle-panel/components/battle-result-status.tsx
@@ -86,21 +86,23 @@ export function BattleResultStatus({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          role="img"
-          aria-label={resultLabel}
-          className={cn(
-            "inline-flex min-h-6 items-center justify-center gap-1 rounded-md border px-1.5 text-xs font-semibold leading-none",
-            !showLabel && "size-6 min-w-6 p-0",
-            resultConfig.className,
-            className,
-          )}
-        >
-          <ResultIcon className="size-3.5" aria-hidden="true" />
-          {showLabel && <span>{resultLabel}</span>}
-        </span>
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <span
+            role="img"
+            aria-label={resultLabel}
+            className={cn(
+              "inline-flex min-h-6 items-center justify-center gap-1 rounded-md border px-1.5 text-xs font-semibold leading-none",
+              !showLabel && "size-6 min-w-6 p-0",
+              resultConfig.className,
+              className,
+            )}
+          >
+            <ResultIcon className="size-3.5" aria-hidden="true" />
+            {showLabel && <span>{resultLabel}</span>}
+          </span>
+        }
+      />
       <TooltipContent>{resultLabel}</TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/features/user/dashboard/components/top-killed-npcs-card.tsx
+++ b/apps/web/src/features/user/dashboard/components/top-killed-npcs-card.tsx
@@ -169,12 +169,18 @@ export const TopKilledNpcsCard: React.FC<TopKilledNpcsCardProps> = ({
             ))}
           </div>
         )}
-        <Button asChild variant="outline" size="sm" className="mt-auto w-full">
-          <Link to="/@me/kills">
-            {t("kills.home.topKilledNpcs.viewAll")}
-            <ChevronRight className="ml-2 size-4" />
-          </Link>
-        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-auto w-full"
+          render={
+            <Link to="/@me/kills">
+              {t("kills.home.topKilledNpcs.viewAll")}
+              <ChevronRight className="ml-2 size-4" />
+            </Link>
+          }
+          nativeButton={false}
+        />
       </CardContent>
     </Card>
   );

--- a/apps/web/src/features/user/kills/components/kills-filters.tsx
+++ b/apps/web/src/features/user/kills/components/kills-filters.tsx
@@ -61,11 +61,13 @@ export const KillsFilters: React.FC<KillsFiltersProps> = ({
     ? Object.keys(data.overview.killsByWorld).sort()
     : [];
 
-  const handleWorldChange = (value: string) => {
+  const handleWorldChange = (value: string | null) => {
+    if (value === null) return;
     onWorldChange(value === "all" ? undefined : value);
   };
 
-  const handleNpcTypeChange = (value: string) => {
+  const handleNpcTypeChange = (value: string | null) => {
+    if (value === null) return;
     onNpcTypeChange(value === "all" ? undefined : [value as NpcType]);
   };
 
@@ -93,6 +95,14 @@ export const KillsFilters: React.FC<KillsFiltersProps> = ({
         <Select
           value={filters.world ?? "all"}
           onValueChange={handleWorldChange}
+          items={[
+            { value: null, label: <>{t("kills.home.filters.allWorlds")}</> },
+            { value: "all", label: <>{t("kills.home.filters.allWorlds")}</> },
+            ...worlds.map((world) => ({
+              value: world,
+              label: <>{world.charAt(0).toUpperCase() + world.slice(1)}</>,
+            })),
+          ]}
         >
           <SelectTrigger className="h-9 w-full min-w-0 md:w-[170px]">
             <div className="flex items-center gap-2">
@@ -115,6 +125,14 @@ export const KillsFilters: React.FC<KillsFiltersProps> = ({
         <Select
           value={filters.npcTypes?.[0] ?? "all"}
           onValueChange={handleNpcTypeChange}
+          items={[
+            { value: null, label: <>{t("kills.filters.allTypes")}</> },
+            { value: "all", label: <>{t("kills.filters.allTypes")}</> },
+            ...TRACKABLE_NPC_TYPES.map((type) => ({
+              value: type,
+              label: <>{t(`npcType.${type}`)}</>,
+            })),
+          ]}
         >
           <SelectTrigger className="h-9 w-full min-w-0 md:w-[140px]">
             <SelectValue placeholder={t("kills.filters.allTypes")} />

--- a/apps/web/src/features/user/notifications/components/dm-actions-card.tsx
+++ b/apps/web/src/features/user/notifications/components/dm-actions-card.tsx
@@ -181,22 +181,25 @@ export const DmActionsCard = ({ dmTarget, onAddWatch }: DmActionsCardProps) => {
         {hasActiveDm ? (
           <>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <span>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="w-full"
-                    disabled={
-                      isDmActionPending || dmTarget?.testTrigger.remaining === 0
-                    }
-                    onClick={handleTriggerDmTest}
-                  >
-                    <FlaskConical className="size-4" />
-                    {t("settings.userNotifications.dm.test")}
-                  </Button>
-                </span>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="w-full"
+                      disabled={
+                        isDmActionPending ||
+                        dmTarget?.testTrigger.remaining === 0
+                      }
+                      onClick={handleTriggerDmTest}
+                    >
+                      <FlaskConical className="size-4" />
+                      {t("settings.userNotifications.dm.test")}
+                    </Button>
+                  </span>
+                }
+              />
               <TooltipContent>
                 <p>
                   {t("settings.userNotifications.dm.testUsage", {
@@ -220,17 +223,19 @@ export const DmActionsCard = ({ dmTarget, onAddWatch }: DmActionsCardProps) => {
               </TooltipContent>
             </Tooltip>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="sm"
-                  variant="destructive"
-                  disabled={isDmActionPending}
-                  onClick={handleDisableDm}
-                >
-                  <BellOff className="size-4" />
-                  {t("settings.userNotifications.dm.deactivate")}
-                </Button>
-              </TooltipTrigger>
+              <TooltipTrigger
+                render={
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    disabled={isDmActionPending}
+                    onClick={handleDisableDm}
+                  >
+                    <BellOff className="size-4" />
+                    {t("settings.userNotifications.dm.deactivate")}
+                  </Button>
+                }
+              />
               <TooltipContent>
                 {t("settings.userNotifications.dm.deactivateHint")}
               </TooltipContent>

--- a/apps/web/src/features/user/notifications/components/watch-item-form-dialog.tsx
+++ b/apps/web/src/features/user/notifications/components/watch-item-form-dialog.tsx
@@ -290,24 +290,26 @@ export const WatchFormDialog = ({
                     <FormLabel className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                       {t("settings.userNotifications.fields.guilds")}
                     </FormLabel>
-                    <FormControl>
-                      <MultiSelect
-                        options={guildOptions}
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        onClose={field.onChange}
-                        placeholder={t(
-                          "settings.userNotifications.placeholders.guilds",
-                        )}
-                        searchPlaceholder={t(
-                          "settings.userNotifications.placeholders.searchGuilds",
-                        )}
-                        emptyMessage={t(
-                          "settings.userNotifications.empty.guilds",
-                        )}
-                        commandSearch
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <MultiSelect
+                          options={guildOptions}
+                          value={field.value}
+                          onValueChange={field.onChange}
+                          onClose={field.onChange}
+                          placeholder={t(
+                            "settings.userNotifications.placeholders.guilds",
+                          )}
+                          searchPlaceholder={t(
+                            "settings.userNotifications.placeholders.searchGuilds",
+                          )}
+                          emptyMessage={t(
+                            "settings.userNotifications.empty.guilds",
+                          )}
+                          commandSearch
+                        />
+                      }
+                    />
                   </FormItem>
                 )}
               />
@@ -320,14 +322,16 @@ export const WatchFormDialog = ({
                     <FormLabel className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                       {t("settings.notifications.fields.world")}
                     </FormLabel>
-                    <FormControl>
-                      <WorldSwitcher
-                        worlds={worldOptions}
-                        value={field.value || null}
-                        onValueChange={(world) => field.onChange(world ?? "")}
-                        width="w-full"
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <WorldSwitcher
+                          worlds={worldOptions}
+                          value={field.value || null}
+                          onValueChange={(world) => field.onChange(world ?? "")}
+                          width="w-full"
+                        />
+                      }
+                    />
                   </FormItem>
                 )}
               />
@@ -342,15 +346,17 @@ export const WatchFormDialog = ({
                         <FormLabel className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                           {t("settings.userNotifications.manualEntry.itemId")}
                         </FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            disabled={!selectedWorld}
-                            placeholder={t(
-                              "settings.userNotifications.manualEntry.itemIdPlaceholder",
-                            )}
-                          />
-                        </FormControl>
+                        <FormControl
+                          render={
+                            <Input
+                              {...field}
+                              disabled={!selectedWorld}
+                              placeholder={t(
+                                "settings.userNotifications.manualEntry.itemIdPlaceholder",
+                              )}
+                            />
+                          }
+                        />
                         {form.formState.errors.manualItemId ? (
                           <p className="text-sm text-destructive">
                             {t(
@@ -370,15 +376,17 @@ export const WatchFormDialog = ({
                         <FormLabel className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                           {t("settings.userNotifications.manualEntry.itemName")}
                         </FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            disabled={!selectedWorld}
-                            placeholder={t(
-                              "settings.userNotifications.manualEntry.itemNamePlaceholder",
-                            )}
-                          />
-                        </FormControl>
+                        <FormControl
+                          render={
+                            <Input
+                              {...field}
+                              disabled={!selectedWorld}
+                              placeholder={t(
+                                "settings.userNotifications.manualEntry.itemNamePlaceholder",
+                              )}
+                            />
+                          }
+                        />
                         {form.formState.errors.manualItemName ? (
                           <p className="text-sm text-destructive">
                             {t(
@@ -399,32 +407,34 @@ export const WatchFormDialog = ({
                       <FormLabel className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">
                         {t("settings.userNotifications.fields.item")}
                       </FormLabel>
-                      <FormControl>
-                        <WatchedItemSelector
-                          disabled={!selectedWorld}
-                          loading={isItemsLoading}
-                          items={itemSearchResults}
-                          searchValue={itemSearchValue}
-                          selectedItem={field.value as GameItem | null}
-                          placeholder={t(
-                            "settings.userNotifications.placeholders.item",
-                          )}
-                          searchPlaceholder={t(
-                            "settings.userNotifications.placeholders.searchItems",
-                          )}
-                          emptyMessage={t(
-                            "settings.userNotifications.empty.items",
-                          )}
-                          loadingMessage={t(
-                            "settings.userNotifications.loading.items",
-                          )}
-                          disabledMessage={t(
-                            "settings.userNotifications.validation.worldRequired",
-                          )}
-                          onSearchChange={setItemSearchValue}
-                          onSelect={field.onChange}
-                        />
-                      </FormControl>
+                      <FormControl
+                        render={
+                          <WatchedItemSelector
+                            disabled={!selectedWorld}
+                            loading={isItemsLoading}
+                            items={itemSearchResults}
+                            searchValue={itemSearchValue}
+                            selectedItem={field.value as GameItem | null}
+                            placeholder={t(
+                              "settings.userNotifications.placeholders.item",
+                            )}
+                            searchPlaceholder={t(
+                              "settings.userNotifications.placeholders.searchItems",
+                            )}
+                            emptyMessage={t(
+                              "settings.userNotifications.empty.items",
+                            )}
+                            loadingMessage={t(
+                              "settings.userNotifications.loading.items",
+                            )}
+                            disabledMessage={t(
+                              "settings.userNotifications.validation.worldRequired",
+                            )}
+                            onSearchChange={setItemSearchValue}
+                            onSelect={field.onChange}
+                          />
+                        }
+                      />
                       {form.formState.errors.item ? (
                         <p className="text-sm text-destructive">
                           {t(
@@ -442,12 +452,14 @@ export const WatchFormDialog = ({
                 name="manualEntry"
                 render={({ field }) => (
                   <FormItem className="flex items-center gap-2">
-                    <FormControl>
-                      <Checkbox
-                        checked={field.value}
-                        onCheckedChange={field.onChange}
-                      />
-                    </FormControl>
+                    <FormControl
+                      render={
+                        <Checkbox
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      }
+                    />
                     <FormLabel className="!mt-0 text-xs text-muted-foreground">
                       {t("settings.userNotifications.manualEntry.checkbox")}
                     </FormLabel>

--- a/apps/web/src/features/user/notifications/components/watched-item-selector.tsx
+++ b/apps/web/src/features/user/notifications/components/watched-item-selector.tsx
@@ -87,57 +87,59 @@ export const WatchedItemSelector = ({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-controls={resultsListId}
-          aria-expanded={open}
-          disabled={disabled}
-          className="justify-between gap-2"
-        >
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            {selectedItem ? (
-              <ItemImage
-                icon={selectedItem.icon}
-                rarity={
-                  (selectedItem.rarity as ItemRarity | null) ??
-                  ItemRarity.COMMON
-                }
-              />
-            ) : (
-              <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
-            )}
-            <span
-              className={cn(
-                "truncate",
-                !selectedItem && "text-muted-foreground",
-              )}
-            >
-              {disabled ? disabledMessage : displayLabel}
-            </span>
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {selectedItem ? (
-              <span
-                role="button"
-                tabIndex={0}
-                onMouseDown={handleClear}
-                onClick={(event) => event.stopPropagation()}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    handleClear(event);
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-controls={resultsListId}
+            aria-expanded={open}
+            disabled={disabled}
+            className="justify-between gap-2"
+          >
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              {selectedItem ? (
+                <ItemImage
+                  icon={selectedItem.icon}
+                  rarity={
+                    (selectedItem.rarity as ItemRarity | null) ??
+                    ItemRarity.COMMON
                   }
-                }}
-                className="flex items-center justify-center"
+                />
+              ) : (
+                <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span
+                className={cn(
+                  "truncate",
+                  !selectedItem && "text-muted-foreground",
+                )}
               >
-                <X className="h-4 w-4 cursor-pointer text-muted-foreground transition-colors hover:text-foreground" />
+                {disabled ? disabledMessage : displayLabel}
               </span>
-            ) : null}
-            <ChevronsUpDown className="h-4 w-4 opacity-50" />
-          </div>
-        </Button>
-      </PopoverTrigger>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {selectedItem ? (
+                <span
+                  role="button"
+                  tabIndex={0}
+                  onMouseDown={handleClear}
+                  onClick={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      handleClear(event);
+                    }
+                  }}
+                  className="flex items-center justify-center"
+                >
+                  <X className="h-4 w-4 cursor-pointer text-muted-foreground transition-colors hover:text-foreground" />
+                </span>
+              ) : null}
+              <ChevronsUpDown className="h-4 w-4 opacity-50" />
+            </div>
+          </Button>
+        }
+      />
       <PopoverContent className="w-[360px] p-0" align="start">
         <Command shouldFilter={false}>
           <CommandInputRaw

--- a/apps/web/src/features/user/notifications/notifications.tsx
+++ b/apps/web/src/features/user/notifications/notifications.tsx
@@ -99,15 +99,17 @@ export const UserNotifications = () => {
               description={t("settings.userNotifications.description")}
               actions={
                 <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      onClick={() => setIsInfoDialogOpen(true)}
-                    >
-                      <Info className="h-4 w-4" />
-                    </Button>
-                  </TooltipTrigger>
+                  <TooltipTrigger
+                    render={
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setIsInfoDialogOpen(true)}
+                      >
+                        <Info className="h-4 w-4" />
+                      </Button>
+                    }
+                  />
                   <TooltipContent>
                     {t("settings.userNotifications.infoDialog.title")}
                   </TooltipContent>

--- a/apps/wiki/src/routes/items.tsx
+++ b/apps/wiki/src/routes/items.tsx
@@ -488,7 +488,18 @@ function ItemsRoute() {
               </Label>
               <Label className="grid gap-2">
                 <span>{t("filters.sort")}</span>
-                <Select value={sortValue} onValueChange={setSortValue}>
+                <Select
+                  value={sortValue}
+                  onValueChange={(value) => {
+                    if (value !== null) setSortValue(value);
+                  }}
+                  items={[
+                    ...sortOptions.map((sortOption) => ({
+                      value: sortOption,
+                      label: <>{t(`filters.sortOptions.${sortOption}`)}</>,
+                    })),
+                  ]}
+                >
                   <SelectTrigger className="w-full">
                     <SelectValue />
                   </SelectTrigger>

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "new-york",
+  "style": "base-nova",
   "rsc": true,
   "tsx": true,
   "tailwind": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,31 +18,15 @@
     "./postcss.config.mjs": "./postcss.config.mjs"
   },
   "scripts": {
+    "build": "tsc --noEmit",
     "lint": "oxlint .",
+    "test": "vitest run",
     "doctor": "npx -y react-doctor@latest ."
   },
   "dependencies": {
+    "@base-ui/react": "^1.7.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@fontsource-variable/geist-mono": "^5.3.0",
-    "@radix-ui/react-accordion": "^1.2.20",
-    "@radix-ui/react-alert-dialog": "^1.1.23",
-    "@radix-ui/react-avatar": "^1.2.6",
-    "@radix-ui/react-checkbox": "^1.3.11",
-    "@radix-ui/react-collapsible": "^1.1.20",
-    "@radix-ui/react-context-menu": "^2.3.7",
-    "@radix-ui/react-dialog": "^1.1.23",
-    "@radix-ui/react-dropdown-menu": "^2.1.24",
-    "@radix-ui/react-label": "^2.1.15",
-    "@radix-ui/react-navigation-menu": "^1.2.22",
-    "@radix-ui/react-popover": "^1.1.23",
-    "@radix-ui/react-radio-group": "^1.4.7",
-    "@radix-ui/react-scroll-area": "^1.2.18",
-    "@radix-ui/react-select": "^2.3.7",
-    "@radix-ui/react-separator": "^1.1.15",
-    "@radix-ui/react-slot": "^1.3.3",
-    "@radix-ui/react-switch": "^1.3.7",
-    "@radix-ui/react-tabs": "^1.1.21",
-    "@radix-ui/react-tooltip": "^1.2.16",
     "@tailwindcss/postcss": "catalog:",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -62,13 +46,17 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "catalog:",
     "three": "^0.185.1",
-    "tw-animate-css": "^1.4.0",
-    "vaul": "^1.1.2"
+    "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
     "@lootlog/typescript-config": "workspace:*",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@types/three": "^0.185.1"
+    "@types/three": "^0.185.1",
+    "happy-dom": "^20.11.1",
+    "vitest": "catalog:"
   }
 }

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,19 +1,13 @@
-import * as React from "react";
-import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
 import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Accordion({
-  ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+function Accordion({ ...props }: AccordionPrimitive.Root.Props) {
   return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
 }
 
-function AccordionItem({
-  className,
-  ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props) {
   return (
     <AccordionPrimitive.Item
       data-slot="accordion-item"
@@ -27,13 +21,13 @@ function AccordionTrigger({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+}: AccordionPrimitive.Trigger.Props) {
   return (
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "flex w-full items-center justify-between group outline-none [&[data-state=open]>svg]:rotate-180",
+          "group flex w-full items-center justify-between outline-none",
           className,
         )}
         {...props}
@@ -41,7 +35,7 @@ function AccordionTrigger({
         <span className="text-sm font-semibold cursor-pointer group-hover:text-primary transition-colors">
           {children}
         </span>
-        <ChevronDownIcon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-all duration-200" />
+        <ChevronDownIcon className="h-4 w-4 text-muted-foreground group-hover:text-primary transition-all duration-200 group-aria-expanded:rotate-180" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   );
@@ -51,15 +45,15 @@ function AccordionContent({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+}: AccordionPrimitive.Panel.Props) {
   return (
-    <AccordionPrimitive.Content
+    <AccordionPrimitive.Panel
       data-slot="accordion-content"
-      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden"
+      className="data-closed:animate-accordion-up data-open:animate-accordion-down overflow-hidden"
       {...props}
     >
       <div className={cn("pt-3", className)}>{children}</div>
-    </AccordionPrimitive.Content>
+    </AccordionPrimitive.Panel>
   );
 }
 

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -115,11 +115,12 @@ function AlertDialogDescription({
 function AlertDialogAction({
   className,
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: AlertDialogPrimitive.Close.Props) {
   return (
-    <Button
+    <AlertDialogPrimitive.Close
       data-slot="alert-dialog-action"
-      className={cn(className)}
+      className={className}
+      render={<Button />}
       {...props}
     />
   );

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -1,28 +1,22 @@
 "use client";
 
 import * as React from "react";
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
 
 import { cn } from "@lootlog/ui/lib/utils";
-import { buttonVariants } from "@lootlog/ui/components/button";
+import { Button } from "@lootlog/ui/components/button";
 
-function AlertDialog({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
 }
 
-function AlertDialogTrigger({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
   return (
     <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
   );
 }
 
-function AlertDialogPortal({
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
   return (
     <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
   );
@@ -31,12 +25,12 @@ function AlertDialogPortal({
 function AlertDialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+}: AlertDialogPrimitive.Backdrop.Props) {
   return (
-    <AlertDialogPrimitive.Overlay
+    <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className,
       )}
       {...props}
@@ -47,14 +41,14 @@ function AlertDialogOverlay({
 function AlertDialogContent({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+}: AlertDialogPrimitive.Popup.Props) {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
+      <AlertDialogPrimitive.Popup
         data-slot="alert-dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -95,7 +89,7 @@ function AlertDialogFooter({
 function AlertDialogTitle({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+}: AlertDialogPrimitive.Title.Props) {
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
@@ -108,7 +102,7 @@ function AlertDialogTitle({
 function AlertDialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+}: AlertDialogPrimitive.Description.Props) {
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
@@ -121,10 +115,11 @@ function AlertDialogDescription({
 function AlertDialogAction({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+}: React.ComponentProps<typeof Button>) {
   return (
-    <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
       {...props}
     />
   );
@@ -133,10 +128,11 @@ function AlertDialogAction({
 function AlertDialogCancel({
   className,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+}: AlertDialogPrimitive.Close.Props) {
   return (
-    <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      render={<Button variant="outline" className={className} />}
       {...props}
     />
   );

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,26 +1,25 @@
 import * as React from "react";
-import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-const Avatar = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className,
-    )}
-    {...props}
-  />
-));
-Avatar.displayName = AvatarPrimitive.Root.displayName;
+const Avatar = React.forwardRef<HTMLSpanElement, AvatarPrimitive.Root.Props>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Root
+      ref={ref}
+      className={cn(
+        "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Avatar.displayName = "Avatar";
 
 const AvatarImage = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Image>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+  HTMLImageElement,
+  AvatarPrimitive.Image.Props
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
@@ -28,11 +27,11 @@ const AvatarImage = React.forwardRef<
     {...props}
   />
 ));
-AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+AvatarImage.displayName = "AvatarImage";
 
 const AvatarFallback = React.forwardRef<
-  React.ElementRef<typeof AvatarPrimitive.Fallback>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+  HTMLSpanElement,
+  AvatarPrimitive.Fallback.Props
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Fallback
     ref={ref}
@@ -43,6 +42,6 @@ const AvatarFallback = React.forwardRef<
     {...props}
   />
 ));
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+AvatarFallback.displayName = "AvatarFallback";
 
 export { Avatar, AvatarImage, AvatarFallback };

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@lootlog/ui/lib/utils";
@@ -38,16 +37,10 @@ function Button({
   className,
   variant,
   size,
-  asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
-  const Comp = asChild ? Slot : "button";
-
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
   return (
-    <Comp
+    <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,28 +1,26 @@
-import * as React from "react";
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
 import { Check } from "lucide-react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
-      className,
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-checked:bg-primary data-checked:text-primary-foreground",
+        className,
+      )}
+      {...props}
     >
-      <Check className="h-4 w-4" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-));
-Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        <Check className="h-4 w-4" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
 
 export { Checkbox };

--- a/packages/ui/src/components/collapsible.tsx
+++ b/packages/ui/src/components/collapsible.tsx
@@ -1,11 +1,21 @@
 "use client";
 
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
 
-const Collapsible = CollapsiblePrimitive.Root;
+function Collapsible(props: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
 
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger;
+function CollapsibleTrigger(props: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  );
+}
 
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent;
+function CollapsibleContent(props: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+  );
+}
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -38,7 +38,8 @@ function CommandDialog({
   showCloseButton = true,
   shouldFilter = true,
   ...props
-}: React.ComponentProps<typeof Dialog> & {
+}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
+  children?: React.ReactNode;
   title?: string;
   description?: string;
   className?: string;

--- a/packages/ui/src/components/confirm-delete-dialog.tsx
+++ b/packages/ui/src/components/confirm-delete-dialog.tsx
@@ -144,7 +144,7 @@ export function ConfirmDeleteDialog({
           </AlertDialogCancel>
           <AlertDialogAction
             onClick={(e) => {
-              e.preventDefault();
+              e.preventBaseUIHandler();
               void handleConfirm();
             }}
             disabled={isConfirmDisabled}

--- a/packages/ui/src/components/confirm-delete-dialog.tsx
+++ b/packages/ui/src/components/confirm-delete-dialog.tsx
@@ -110,9 +110,9 @@ export function ConfirmDeleteDialog({
     <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
       {triggerTooltip ? (
         <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="inline-flex">{triggerElement}</span>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={<span className="inline-flex">{triggerElement}</span>}
+          />
           <TooltipContent side={triggerTooltipSide}>
             {triggerTooltip}
           </TooltipContent>

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,174 +1,219 @@
 "use client";
 
-import * as React from "react";
-import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-const ContextMenu = ContextMenuPrimitive.Root;
+function ContextMenu(props: ContextMenuPrimitive.Root.Props) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
 
-const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+function ContextMenuTrigger(props: ContextMenuPrimitive.Trigger.Props) {
+  return (
+    <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />
+  );
+}
 
-const ContextMenuGroup = ContextMenuPrimitive.Group;
+function ContextMenuGroup(props: ContextMenuPrimitive.Group.Props) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  );
+}
 
-const ContextMenuPortal = ContextMenuPrimitive.Portal;
+function ContextMenuPortal(props: ContextMenuPrimitive.Portal.Props) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  );
+}
 
-const ContextMenuSub = ContextMenuPrimitive.Sub;
+function ContextMenuSub(props: ContextMenuPrimitive.SubmenuRoot.Props) {
+  return (
+    <ContextMenuPrimitive.SubmenuRoot data-slot="context-menu-sub" {...props} />
+  );
+}
 
-const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+function ContextMenuRadioGroup(props: ContextMenuPrimitive.RadioGroup.Props) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  );
+}
 
-const ContextMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <ContextMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
-  </ContextMenuPrimitive.SubTrigger>
-));
-ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
-
-const ContextMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
-      className,
-    )}
-    {...props}
-  />
-));
-ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
-
-const ContextMenuContent = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content
-      ref={ref}
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ContextMenuPrimitive.SubmenuTrigger.Props & { inset?: boolean }) {
+  return (
+    <ContextMenuPrimitive.SubmenuTrigger
+      data-slot="context-menu-sub-trigger"
       className={cn(
-        "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto h-4 w-4" />
+    </ContextMenuPrimitive.SubmenuTrigger>
+  );
+}
+
+type ContextMenuContentProps = ContextMenuPrimitive.Popup.Props &
+  Pick<
+    ContextMenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >;
+
+function ContextMenuContent({
+  className,
+  align = "start",
+  alignOffset = 4,
+  side = "right",
+  sideOffset = 0,
+  ...props
+}: ContextMenuContentProps) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ContextMenuPrimitive.Popup
+          data-slot="context-menu-content"
+          className={cn(
+            "z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+            className,
+          )}
+          {...props}
+        />
+      </ContextMenuPrimitive.Positioner>
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuSubContent(props: ContextMenuContentProps) {
+  return (
+    <ContextMenuContent
+      data-slot="context-menu-sub-content"
+      side="right"
+      {...props}
+    />
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  ...props
+}: ContextMenuPrimitive.Item.Props & { inset?: boolean }) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+        inset && "pl-8",
         className,
       )}
       {...props}
     />
-  </ContextMenuPrimitive.Portal>
-));
-ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+  );
+}
 
-const ContextMenuItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  />
-));
-ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: ContextMenuPrimitive.CheckboxItem.Props) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <ContextMenuPrimitive.CheckboxItemIndicator>
+          <Check className="h-4 w-4" />
+        </ContextMenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
 
-const ContextMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <ContextMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className,
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </ContextMenuPrimitive.CheckboxItem>
-));
-ContextMenuCheckboxItem.displayName =
-  ContextMenuPrimitive.CheckboxItem.displayName;
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: ContextMenuPrimitive.RadioItem.Props) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <ContextMenuPrimitive.RadioItemIndicator>
+          <Circle className="h-2 w-2 fill:current" />
+        </ContextMenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
 
-const ContextMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <ContextMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill:current" />
-      </ContextMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </ContextMenuPrimitive.RadioItem>
-));
-ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: ContextMenuPrimitive.GroupLabel.Props & { inset?: boolean }) {
+  return (
+    <ContextMenuPrimitive.GroupLabel
+      data-slot="context-menu-label"
+      className={cn(
+        "px-2 py-1.5 text-sm font-semibold text-foreground",
+        inset && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
-const ContextMenuLabel = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Label
-    ref={ref}
-    className={cn(
-      "px-2 py-1.5 text-sm font-semibold text-foreground",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  />
-));
-ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
-
-const ContextMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
-    {...props}
-  />
-));
-ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
-
-const ContextMenuShortcut = ({
+function ContextMenuSeparator({
   className,
   ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
+}: ContextMenuPrimitive.Separator.Props) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
   return (
     <span
       className={cn(
@@ -178,23 +223,22 @@ const ContextMenuShortcut = ({
       {...props}
     />
   );
-};
-ContextMenuShortcut.displayName = "ContextMenuShortcut";
+}
 
 export {
   ContextMenu,
-  ContextMenuTrigger,
-  ContextMenuContent,
-  ContextMenuItem,
   ContextMenuCheckboxItem,
-  ContextMenuRadioItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
   ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
   ContextMenuSeparator,
   ContextMenuShortcut,
-  ContextMenuGroup,
-  ContextMenuPortal,
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuRadioGroup,
+  ContextMenuTrigger,
 };

--- a/packages/ui/src/components/controls.test.tsx
+++ b/packages/ui/src/components/controls.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "./button";
+import { Checkbox } from "./checkbox";
+import { RadioGroup, RadioGroupItem } from "./radio-group";
+import { Switch } from "./switch";
+
+describe("Base UI controls", () => {
+  it("renders a custom button element through the render prop", () => {
+    render(
+      <Button render={<a href="/settings" />} nativeButton={false}>
+        Settings
+      </Button>,
+    );
+
+    expect(screen.getByRole("button", { name: "Settings" })).toHaveAttribute(
+      "href",
+      "/settings",
+    );
+  });
+
+  it("reports checkbox state changes", () => {
+    const handleCheckedChange = vi.fn();
+    render(
+      <Checkbox
+        aria-label="Notifications"
+        onCheckedChange={handleCheckedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Notifications" }));
+
+    expect(handleCheckedChange).toHaveBeenCalledWith(true, expect.any(Object));
+  });
+
+  it("does not change a disabled checkbox", () => {
+    const handleCheckedChange = vi.fn();
+    render(
+      <Checkbox
+        aria-label="Disabled notifications"
+        disabled
+        onCheckedChange={handleCheckedChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Disabled notifications" }),
+    );
+    expect(handleCheckedChange).not.toHaveBeenCalled();
+  });
+
+  it("reports switch state changes", () => {
+    const handleCheckedChange = vi.fn();
+    render(
+      <Switch aria-label="Dark mode" onCheckedChange={handleCheckedChange} />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "Dark mode" }));
+
+    expect(handleCheckedChange).toHaveBeenCalledWith(true, expect.any(Object));
+  });
+
+  it("changes the selected radio item", () => {
+    const handleValueChange = vi.fn();
+    render(
+      <RadioGroup aria-label="Theme" onValueChange={handleValueChange}>
+        <RadioGroupItem value="light" aria-label="Light" />
+        <RadioGroupItem value="dark" aria-label="Dark" />
+      </RadioGroup>,
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Dark" }));
+
+    expect(handleValueChange).toHaveBeenCalledWith("dark", expect.any(Object));
+  });
+});

--- a/packages/ui/src/components/date-time-picker.tsx
+++ b/packages/ui/src/components/date-time-picker.tsx
@@ -90,31 +90,33 @@ export function DateTimePicker({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          className={cn(
-            "justify-start text-left font-normal",
-            !selectedDate && "text-muted-foreground",
-            className,
-          )}
-        >
-          <CalendarIcon className="mr-2 h-4 w-4" />
-          {selectedDate ? (
-            format(selectedDate, "PPP HH:mm", { locale })
-          ) : (
-            <span>{placeholder}</span>
-          )}
-          {selectedDate && (
-            <div
-              onMouseDown={handleClear}
-              onClick={(e) => e.stopPropagation()}
-              className="ml-auto flex items-center justify-center"
-            >
-              <X className="h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer transition-colors" />
-            </div>
-          )}
-        </Button>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            className={cn(
+              "justify-start text-left font-normal",
+              !selectedDate && "text-muted-foreground",
+              className,
+            )}
+          />
+        }
+      >
+        <CalendarIcon className="mr-2 h-4 w-4" />
+        {selectedDate ? (
+          format(selectedDate, "PPP HH:mm", { locale })
+        ) : (
+          <span>{placeholder}</span>
+        )}
+        {selectedDate && (
+          <div
+            onMouseDown={handleClear}
+            onClick={(e) => e.stopPropagation()}
+            className="ml-auto flex items-center justify-center"
+          >
+            <X className="h-4 w-4 text-muted-foreground hover:text-foreground cursor-pointer transition-colors" />
+          </div>
+        )}
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
 
 import { cn } from "@lootlog/ui/lib/utils";
@@ -9,39 +9,31 @@ import { CatPawOverlay } from "@lootlog/ui/components/cat-paw-overlay";
 import { RukiaFrostCardOverlay } from "@lootlog/ui/components/rukia-frost-card-overlay";
 import { RiasMagicCardOverlay } from "@lootlog/ui/components/rias-magic-card-overlay";
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: DialogPrimitive.Backdrop.Props) {
   return (
-    <DialogPrimitive.Overlay
+    <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className,
       )}
       {...props}
@@ -54,16 +46,16 @@ function DialogContent({
   children,
   showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+}: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
-      <DialogPrimitive.Content
+      <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-hidden rounded-lg border p-0 shadow-lg duration-200 sm:max-w-lg",
+          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] overflow-hidden rounded-lg border p-0 shadow-lg duration-200 sm:max-w-lg",
           className,
         )}
         {...props}
@@ -75,13 +67,13 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-open:bg-accent data-open:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
-      </DialogPrimitive.Content>
+      </DialogPrimitive.Popup>
     </DialogPortal>
   );
 }
@@ -109,10 +101,7 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
@@ -125,7 +114,7 @@ function DialogTitle({
 function DialogDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+}: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"

--- a/packages/ui/src/components/disclosure.test.tsx
+++ b/packages/ui/src/components/disclosure.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "./accordion";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./collapsible";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+import { ScrollArea } from "./scroll-area";
+
+describe("Base UI disclosure components", () => {
+  it("opens an accordion item with array-based values", () => {
+    render(
+      <Accordion defaultValue={[]}>
+        <AccordionItem value="details">
+          <AccordionTrigger>Details</AccordionTrigger>
+          <AccordionContent>Accordion content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Details" }));
+
+    expect(screen.getByText("Accordion content")).toBeVisible();
+  });
+
+  it("reports controlled accordion values", () => {
+    const handleValueChange = vi.fn();
+    render(
+      <Accordion value={[]} onValueChange={handleValueChange}>
+        <AccordionItem value="details">
+          <AccordionTrigger>Controlled details</AccordionTrigger>
+          <AccordionContent>Controlled content</AccordionContent>
+        </AccordionItem>
+      </Accordion>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Controlled details" }));
+    expect(handleValueChange).toHaveBeenCalledWith(
+      ["details"],
+      expect.any(Object),
+    );
+  });
+
+  it("opens collapsible content", () => {
+    render(
+      <Collapsible>
+        <CollapsibleTrigger>More</CollapsibleTrigger>
+        <CollapsibleContent>Collapsible content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More" }));
+
+    expect(screen.getByText("Collapsible content")).toBeVisible();
+  });
+
+  it("switches tabs", () => {
+    render(
+      <Tabs defaultValue="general">
+        <TabsList>
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="advanced">Advanced</TabsTrigger>
+        </TabsList>
+        <TabsContent value="general">General panel</TabsContent>
+        <TabsContent value="advanced">Advanced panel</TabsContent>
+      </Tabs>,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Advanced" }));
+
+    expect(screen.getByText("Advanced panel")).toBeVisible();
+  });
+
+  it("forwards viewport scroll events", () => {
+    const handleScroll = vi.fn();
+    const { container } = render(
+      <ScrollArea aria-label="Scrollable content" onScroll={handleScroll}>
+        <div>Long content</div>
+      </ScrollArea>,
+    );
+
+    const viewport = container.querySelector(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    if (!viewport) throw new Error("Scroll area viewport was not rendered.");
+    fireEvent.scroll(viewport);
+    expect(handleScroll).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/components/drawer.tsx
+++ b/packages/ui/src/components/drawer.tsx
@@ -1,43 +1,82 @@
 "use client";
 
+import { Drawer as DrawerPrimitive } from "@base-ui/react/drawer";
 import * as React from "react";
-import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Drawer({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+type DrawerContextValue = {
+  modal: DrawerPrimitive.Root.Props["modal"];
+  showSwipeHandle: boolean;
+  swipeDirection: NonNullable<DrawerPrimitive.Root.Props["swipeDirection"]>;
+};
+
+const DrawerContext = React.createContext<DrawerContextValue | null>(null);
+
+function useDrawer() {
+  const context = React.useContext(DrawerContext);
+  if (!context) throw new Error("useDrawer must be used within a Drawer.");
+  return context;
 }
 
-function DrawerTrigger({
+function Drawer({
+  modal = true,
+  showSwipeHandle = true,
+  swipeDirection = "down",
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+}: DrawerPrimitive.Root.Props & { showSwipeHandle?: boolean }) {
+  const contextValue = { modal, showSwipeHandle, swipeDirection };
+
+  return (
+    <DrawerContext.Provider value={contextValue}>
+      <DrawerPrimitive.Root
+        data-slot="drawer"
+        modal={modal}
+        swipeDirection={swipeDirection}
+        {...props}
+      />
+    </DrawerContext.Provider>
+  );
+}
+
+function DrawerTrigger(props: DrawerPrimitive.Trigger.Props) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+function DrawerPortal(props: DrawerPrimitive.Portal.Props) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+function DrawerClose(props: DrawerPrimitive.Close.Props) {
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
 function DrawerOverlay({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+}: DrawerPrimitive.Backdrop.Props) {
   return (
-    <DrawerPrimitive.Overlay
+    <DrawerPrimitive.Backdrop
       data-slot="drawer-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed inset-0 z-50 min-h-dvh bg-black/50 transition-opacity duration-300 data-starting-style:opacity-0 data-ending-style:opacity-0 data-swiping:duration-0 supports-[-webkit-touch-callout:none]:absolute",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerSwipeHandle({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-swipe-handle"
+      aria-hidden="true"
+      className={cn(
+        "bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[swipe-direction=down]/drawer-popup:block",
         className,
       )}
       {...props}
@@ -49,25 +88,42 @@ function DrawerContent({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: DrawerPrimitive.Popup.Props) {
+  const { modal, showSwipeHandle, swipeDirection } = useDrawer();
+  const swipeAxis =
+    swipeDirection === "down" || swipeDirection === "up" ? "y" : "x";
+
   return (
-    <DrawerPortal data-slot="drawer-portal">
-      <DrawerOverlay />
-      <DrawerPrimitive.Content
-        data-slot="drawer-content"
-        className={cn(
-          "group/drawer-content bg-background fixed z-50 flex h-auto flex-col",
-          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
-          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
-          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
-          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
-          className,
-        )}
-        {...props}
+    <DrawerPortal>
+      {modal === true ? <DrawerOverlay /> : null}
+      <DrawerPrimitive.Viewport
+        data-slot="drawer-viewport"
+        data-modal={modal}
+        className="pointer-events-none fixed inset-0 z-50 select-none data-[modal=true]:pointer-events-auto"
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
-        {children}
-      </DrawerPrimitive.Content>
+        <DrawerPrimitive.Popup
+          data-slot="drawer-popup"
+          data-swipe-axis={swipeAxis}
+          className={cn(
+            "group/drawer-popup bg-background pointer-events-auto fixed z-50 flex h-auto flex-col outline-none transition-[transform,opacity] duration-300 data-swiping:duration-0",
+            "transform-[translate3d(var(--drawer-swipe-movement-x,0),var(--drawer-swipe-movement-y,0),0)] data-starting-style:transform-(--closed-transform) data-ending-style:transform-(--closed-transform)",
+            "data-[swipe-direction=up]:inset-x-0 data-[swipe-direction=up]:top-0 data-[swipe-direction=up]:mb-24 data-[swipe-direction=up]:max-h-[80vh] data-[swipe-direction=up]:rounded-b-lg data-[swipe-direction=up]:border-b data-[swipe-direction=up]:[--closed-transform:translate3d(0,-100%,0)]",
+            "data-[swipe-direction=down]:inset-x-0 data-[swipe-direction=down]:bottom-0 data-[swipe-direction=down]:mt-24 data-[swipe-direction=down]:max-h-[80vh] data-[swipe-direction=down]:rounded-t-lg data-[swipe-direction=down]:border-t data-[swipe-direction=down]:[--closed-transform:translate3d(0,100%,0)]",
+            "data-[swipe-direction=right]:inset-y-0 data-[swipe-direction=right]:right-0 data-[swipe-direction=right]:w-3/4 data-[swipe-direction=right]:border-l data-[swipe-direction=right]:sm:max-w-sm data-[swipe-direction=right]:[--closed-transform:translate3d(100%,0,0)]",
+            "data-[swipe-direction=left]:inset-y-0 data-[swipe-direction=left]:left-0 data-[swipe-direction=left]:w-3/4 data-[swipe-direction=left]:border-r data-[swipe-direction=left]:sm:max-w-sm data-[swipe-direction=left]:[--closed-transform:translate3d(-100%,0,0)]",
+            className,
+          )}
+          {...props}
+        >
+          {showSwipeHandle ? <DrawerSwipeHandle /> : null}
+          <DrawerPrimitive.Content
+            data-slot="drawer-content"
+            className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-[inherit]"
+          >
+            {children}
+          </DrawerPrimitive.Content>
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
     </DrawerPortal>
   );
 }
@@ -77,7 +133,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="drawer-header"
       className={cn(
-        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        "flex flex-col gap-0.5 p-4 group-data-[swipe-axis=y]/drawer-popup:text-center md:gap-1.5 md:text-left",
         className,
       )}
       {...props}
@@ -95,10 +151,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
@@ -111,7 +164,7 @@ function DrawerTitle({
 function DrawerDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+}: DrawerPrimitive.Description.Props) {
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"
@@ -123,13 +176,14 @@ function DrawerDescription({
 
 export {
   Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
   DrawerClose,
   DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
   DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerSwipeHandle,
+  DrawerTitle,
+  DrawerTrigger,
 };

--- a/packages/ui/src/components/dropdown-menu.tsx
+++ b/packages/ui/src/components/dropdown-menu.tsx
@@ -1,20 +1,16 @@
 "use client";
 
 import * as React from "react";
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Menu as DropdownMenuPrimitive } from "@base-ui/react/menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function DropdownMenu({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+function DropdownMenu({ ...props }: DropdownMenuPrimitive.Root.Props) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
-function DropdownMenuPortal({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+function DropdownMenuPortal({ ...props }: DropdownMenuPrimitive.Portal.Props) {
   return (
     <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
   );
@@ -22,7 +18,7 @@ function DropdownMenuPortal({
 
 function DropdownMenuTrigger({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+}: DropdownMenuPrimitive.Trigger.Props) {
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
@@ -33,27 +29,39 @@ function DropdownMenuTrigger({
 
 function DropdownMenuContent({
   className,
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
   sideOffset = 4,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: DropdownMenuPrimitive.Popup.Props &
+  Pick<
+    DropdownMenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
   return (
     <DropdownMenuPrimitive.Portal>
-      <DropdownMenuPrimitive.Content
-        data-slot="dropdown-menu-content"
+      <DropdownMenuPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
         sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
-          className,
-        )}
-        {...props}
-      />
+        className="isolate z-50 outline-none"
+      >
+        <DropdownMenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+            className,
+          )}
+          {...props}
+        />
+      </DropdownMenuPrimitive.Positioner>
     </DropdownMenuPrimitive.Portal>
   );
 }
 
-function DropdownMenuGroup({
-  ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+function DropdownMenuGroup({ ...props }: DropdownMenuPrimitive.Group.Props) {
   return (
     <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
   );
@@ -64,7 +72,7 @@ function DropdownMenuItem({
   inset,
   variant = "default",
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+}: DropdownMenuPrimitive.Item.Props & {
   inset?: boolean;
   variant?: "default" | "destructive";
 }) {
@@ -74,7 +82,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 data-inset:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -87,21 +95,21 @@ function DropdownMenuCheckboxItem({
   children,
   checked,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+}: DropdownMenuPrimitive.CheckboxItem.Props) {
   return (
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
+        <DropdownMenuPrimitive.CheckboxItemIndicator>
           <CheckIcon className="size-4" />
-        </DropdownMenuPrimitive.ItemIndicator>
+        </DropdownMenuPrimitive.CheckboxItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
@@ -110,7 +118,7 @@ function DropdownMenuCheckboxItem({
 
 function DropdownMenuRadioGroup({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+}: DropdownMenuPrimitive.RadioGroup.Props) {
   return (
     <DropdownMenuPrimitive.RadioGroup
       data-slot="dropdown-menu-radio-group"
@@ -123,20 +131,20 @@ function DropdownMenuRadioItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+}: DropdownMenuPrimitive.RadioItem.Props) {
   return (
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
+        <DropdownMenuPrimitive.RadioItemIndicator>
           <CircleIcon className="size-2 fill:current" />
-        </DropdownMenuPrimitive.ItemIndicator>
+        </DropdownMenuPrimitive.RadioItemIndicator>
       </span>
       {children}
     </DropdownMenuPrimitive.RadioItem>
@@ -147,15 +155,15 @@ function DropdownMenuLabel({
   className,
   inset,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+}: DropdownMenuPrimitive.GroupLabel.Props & {
   inset?: boolean;
 }) {
   return (
-    <DropdownMenuPrimitive.Label
+    <DropdownMenuPrimitive.GroupLabel
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        "px-2 py-1.5 text-sm font-medium data-inset:pl-8",
         className,
       )}
       {...props}
@@ -166,7 +174,7 @@ function DropdownMenuLabel({
 function DropdownMenuSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+}: DropdownMenuPrimitive.Separator.Props) {
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
@@ -194,8 +202,13 @@ function DropdownMenuShortcut({
 
 function DropdownMenuSub({
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}: DropdownMenuPrimitive.SubmenuRoot.Props) {
+  return (
+    <DropdownMenuPrimitive.SubmenuRoot
+      data-slot="dropdown-menu-sub"
+      {...props}
+    />
+  );
 }
 
 function DropdownMenuSubTrigger({
@@ -203,36 +216,37 @@ function DropdownMenuSubTrigger({
   inset,
   children,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+}: DropdownMenuPrimitive.SubmenuTrigger.Props & {
   inset?: boolean;
 }) {
   return (
-    <DropdownMenuPrimitive.SubTrigger
+    <DropdownMenuPrimitive.SubmenuTrigger
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "focus:bg-accent focus:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-inset:pl-8",
         className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto size-4" />
-    </DropdownMenuPrimitive.SubTrigger>
+    </DropdownMenuPrimitive.SubmenuTrigger>
   );
 }
 
 function DropdownMenuSubContent({
   className,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+}: React.ComponentProps<typeof DropdownMenuContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
+    <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
+      side="right"
       {...props}
     />
   );

--- a/packages/ui/src/components/filter-popover.tsx
+++ b/packages/ui/src/components/filter-popover.tsx
@@ -107,24 +107,26 @@ export function FilterPopover<T extends string = string>({
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          disabled={disabled}
-          className={cn(
-            width,
-            "h-10 justify-between focus-visible:ring-inset focus-visible:ring-offset-0 data-[state=open]:border-ring data-[state=open]:ring-2 data-[state=open]:ring-inset data-[state=open]:ring-ring",
-            triggerClassName,
-          )}
-        >
-          <div className="flex items-center gap-2">
-            {Icon && <Icon className="h-4 w-4" />}
-            <span className="text-sm truncate">{getLabel()}</span>
-          </div>
-          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-        </Button>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            disabled={disabled}
+            className={cn(
+              width,
+              "h-10 justify-between focus-visible:ring-inset focus-visible:ring-offset-0 data-popup-open:border-ring data-popup-open:ring-2 data-popup-open:ring-inset data-popup-open:ring-ring",
+              triggerClassName,
+            )}
+          />
+        }
+      >
+        <div className="flex items-center gap-2">
+          {Icon && <Icon className="h-4 w-4" />}
+          <span className="text-sm truncate">{getLabel()}</span>
+        </div>
+        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
       </PopoverTrigger>
       <PopoverContent
         className={cn(

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type * as LabelPrimitive from "@radix-ui/react-label";
-import { Slot } from "@radix-ui/react-slot";
+import { useRender } from "@base-ui/react/use-render";
 import {
   Controller,
   FormProvider,
@@ -90,7 +89,7 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
 function FormLabel({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: React.ComponentProps<typeof Label>) {
   const { error, formItemId } = useFormField();
 
   return (
@@ -104,23 +103,23 @@ function FormLabel({
   );
 }
 
-function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+function FormControl({ render, ...props }: useRender.ComponentProps<"div">) {
   const { error, formItemId, formDescriptionId, formMessageId } =
     useFormField();
 
-  return (
-    <Slot
-      data-slot="form-control"
-      id={formItemId}
-      aria-describedby={
-        !error
-          ? `${formDescriptionId}`
-          : `${formDescriptionId} ${formMessageId}`
-      }
-      aria-invalid={!!error}
-      {...props}
-    />
-  );
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: {
+      "data-slot": "form-control",
+      id: formItemId,
+      "aria-describedby": !error
+        ? formDescriptionId
+        : `${formDescriptionId} ${formMessageId}`,
+      "aria-invalid": !!error,
+      ...props,
+    },
+  });
 }
 
 function FormDescription({ className, ...props }: React.ComponentProps<"p">) {

--- a/packages/ui/src/components/item-tile.tsx
+++ b/packages/ui/src/components/item-tile.tsx
@@ -9,6 +9,7 @@ import { useSharedTooltip } from "@lootlog/ui/components/shared-tooltip-provider
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@lootlog/ui/components/tooltip";
 import { cn } from "@lootlog/ui/lib/utils";
@@ -227,15 +228,17 @@ export const ItemTile: FC<ItemTileProps> = ({
   }
 
   return (
-    <Tooltip delayDuration={100}>
-      <TooltipTrigger asChild>
-        <button className={triggerClassName} type="button">
+    <TooltipProvider delay={100}>
+      <Tooltip>
+        <TooltipTrigger
+          render={<button className={triggerClassName} type="button" />}
+        >
           {itemImage}
-        </button>
-      </TooltipTrigger>
-      <TooltipContent className={tooltipBorderClassName}>
-        {tooltipContent}
-      </TooltipContent>
-    </Tooltip>
+        </TooltipTrigger>
+        <TooltipContent className={tooltipBorderClassName}>
+          {tooltipContent}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,16 +1,12 @@
 "use client";
 
-import * as React from "react";
-import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as React from "react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<"label">) {
   return (
-    <LabelPrimitive.Root
+    <label
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",

--- a/packages/ui/src/components/menus.test.tsx
+++ b/packages/ui/src/components/menus.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "./context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+
+describe("menus", () => {
+  it("runs a dropdown menu item action", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>Actions</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onClick={onClick}>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Actions" }));
+    await user.click(screen.getByText("Delete"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("supports a keyboard-opened submenu", async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger>More actions</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>Sharing</DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem>Copy link</DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    const submenuTrigger = screen.getByText("Sharing");
+    submenuTrigger.focus();
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByText("Copy link")).toBeInTheDocument();
+  });
+
+  it("opens a context menu and handles its item", async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Target</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={onClick}>Inspect</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText("Target"));
+    await user.click(screen.getByText("Inspect"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("changes a select value with keyboard navigation", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+    const items = [
+      { label: "First", value: "first" },
+      { label: "Second", value: "second" },
+    ];
+    render(
+      <Select items={items} defaultValue="first" onValueChange={onValueChange}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((item) => (
+            <SelectItem key={item.value} value={item.value}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    await user.click(trigger);
+    await user.keyboard("{ArrowDown}{Enter}");
+    expect(onValueChange).toHaveBeenCalledWith("second", expect.anything());
+  });
+});

--- a/packages/ui/src/components/navigation-menu.tsx
+++ b/packages/ui/src/components/navigation-menu.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
+import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/navigation-menu";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
 
@@ -10,9 +9,7 @@ function NavigationMenu({
   children,
   viewport = true,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
-  viewport?: boolean;
-}) {
+}: NavigationMenuPrimitive.Root.Props & { viewport?: boolean }) {
   return (
     <NavigationMenuPrimitive.Root
       data-slot="navigation-menu"
@@ -24,7 +21,7 @@ function NavigationMenu({
       {...props}
     >
       {children}
-      {viewport && <NavigationMenuViewport />}
+      {viewport ? <NavigationMenuViewport /> : null}
     </NavigationMenuPrimitive.Root>
   );
 }
@@ -32,7 +29,7 @@ function NavigationMenu({
 function NavigationMenuList({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) {
+}: NavigationMenuPrimitive.List.Props) {
   return (
     <NavigationMenuPrimitive.List
       data-slot="navigation-menu-list"
@@ -48,7 +45,7 @@ function NavigationMenuList({
 function NavigationMenuItem({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Item>) {
+}: NavigationMenuPrimitive.Item.Props) {
   return (
     <NavigationMenuPrimitive.Item
       data-slot="navigation-menu-item"
@@ -59,14 +56,14 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1",
+  "group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-popup-open:hover:bg-accent data-popup-open:text-accent-foreground data-popup-open:focus:bg-accent data-popup-open:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1",
 );
 
 function NavigationMenuTrigger({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) {
+}: NavigationMenuPrimitive.Trigger.Props) {
   return (
     <NavigationMenuPrimitive.Trigger
       data-slot="navigation-menu-trigger"
@@ -75,7 +72,7 @@ function NavigationMenuTrigger({
     >
       {children}{" "}
       <ChevronDownIcon
-        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+        className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-popup-open:rotate-180"
         aria-hidden="true"
       />
     </NavigationMenuPrimitive.Trigger>
@@ -85,13 +82,13 @@ function NavigationMenuTrigger({
 function NavigationMenuContent({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) {
+}: NavigationMenuPrimitive.Content.Props) {
   return (
     <NavigationMenuPrimitive.Content
       data-slot="navigation-menu-content"
       className={cn(
         "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
-        "group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+        "group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-open:animate-in group-data-[viewport=false]/navigation-menu:data-closed:animate-out group-data-[viewport=false]/navigation-menu:data-closed:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-open:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-open:fade-in-0 group-data-[viewport=false]/navigation-menu:data-closed:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
         className,
       )}
       {...props}
@@ -101,35 +98,45 @@ function NavigationMenuContent({
 
 function NavigationMenuViewport({
   className,
+  side = "bottom",
+  sideOffset = 6,
+  align = "start",
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+}: NavigationMenuPrimitive.Positioner.Props) {
   return (
-    <div
-      className={cn(
-        "absolute top-full left-0 isolate z-50 flex justify-center",
-      )}
-    >
-      <NavigationMenuPrimitive.Viewport
-        data-slot="navigation-menu-viewport"
-        className={cn(
-          "origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--radix-navigation-menu-viewport-width)]",
-          className,
-        )}
+    <NavigationMenuPrimitive.Portal>
+      <NavigationMenuPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        className="isolate z-50 flex justify-center"
         {...props}
-      />
-    </div>
+      >
+        <NavigationMenuPrimitive.Popup
+          className={cn(
+            "origin-(--transform-origin) bg-popover text-popover-foreground data-starting-style:scale-90 data-ending-style:scale-95 data-starting-style:opacity-0 data-ending-style:opacity-0 relative h-(--popup-height) w-(--popup-width) overflow-hidden rounded-md border shadow transition-[opacity,transform,width,height]",
+            className,
+          )}
+        >
+          <NavigationMenuPrimitive.Viewport
+            data-slot="navigation-menu-viewport"
+            className="relative size-full overflow-hidden"
+          />
+        </NavigationMenuPrimitive.Popup>
+      </NavigationMenuPrimitive.Positioner>
+    </NavigationMenuPrimitive.Portal>
   );
 }
 
 function NavigationMenuLink({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Link>) {
+}: NavigationMenuPrimitive.Link.Props) {
   return (
     <NavigationMenuPrimitive.Link
       data-slot="navigation-menu-link"
       className={cn(
-        "data-[active=true]:focus:bg-accent data-[active=true]:hover:bg-accent data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
+        "data-active:focus:bg-accent data-active:hover:bg-accent data-active:bg-accent/50 data-active:text-accent-foreground hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -140,29 +147,29 @@ function NavigationMenuLink({
 function NavigationMenuIndicator({
   className,
   ...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+}: NavigationMenuPrimitive.Icon.Props) {
   return (
-    <NavigationMenuPrimitive.Indicator
+    <NavigationMenuPrimitive.Icon
       data-slot="navigation-menu-indicator"
       className={cn(
-        "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
+        "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
         className,
       )}
       {...props}
     >
       <div className="bg-border relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm shadow-md" />
-    </NavigationMenuPrimitive.Indicator>
+    </NavigationMenuPrimitive.Icon>
   );
 }
 
 export {
   NavigationMenu,
-  NavigationMenuList,
-  NavigationMenuItem,
   NavigationMenuContent,
-  NavigationMenuTrigger,
-  NavigationMenuLink,
   NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
   NavigationMenuViewport,
   navigationMenuTriggerStyle,
 };

--- a/packages/ui/src/components/npc-tile.tsx
+++ b/packages/ui/src/components/npc-tile.tsx
@@ -2,6 +2,7 @@ import { useSharedTooltip } from "@lootlog/ui/components/shared-tooltip-provider
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@lootlog/ui/components/tooltip";
 import { cn } from "@lootlog/ui/lib/utils";
@@ -79,13 +80,15 @@ export const NpcTile: FC<NpcTileProps> = ({
   }
 
   return (
-    <Tooltip delayDuration={100}>
-      <TooltipTrigger asChild>
-        <div className={tileClassName}>{npcImage}</div>
-      </TooltipTrigger>
-      <TooltipContent className="border-border/50 bg-popover/95 backdrop-blur-md">
-        {tooltipContent}
-      </TooltipContent>
-    </Tooltip>
+    <TooltipProvider delay={100}>
+      <Tooltip>
+        <TooltipTrigger render={<div className={tileClassName} />}>
+          {npcImage}
+        </TooltipTrigger>
+        <TooltipContent className="border-border/50 bg-popover/95 backdrop-blur-md">
+          {tooltipContent}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };

--- a/packages/ui/src/components/overlays.test.tsx
+++ b/packages/ui/src/components/overlays.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "./dialog";
+import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from "./drawer";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "./sheet";
+
+describe("Base UI overlays", () => {
+  it("opens a dialog and closes it with Escape", async () => {
+    const handleOpenChange = vi.fn();
+    render(
+      <Dialog onOpenChange={handleOpenChange}>
+        <DialogTrigger>Open dialog</DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Dialog title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open dialog" }));
+    expect(screen.getByRole("dialog", { name: "Dialog title" })).toBeVisible();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(handleOpenChange).toHaveBeenLastCalledWith(
+      false,
+      expect.any(Object),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Open dialog" })).toHaveFocus(),
+    );
+  });
+
+  it("opens an alert dialog and closes it with its cancel action", async () => {
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open alert</AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogTitle>Alert title</AlertDialogTitle>
+          <AlertDialogCancel>Cancel alert</AlertDialogCancel>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open alert" }));
+    expect(
+      screen.getByRole("alertdialog", { name: "Alert title" }),
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel alert" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("opens a sheet and closes it with Escape", () => {
+    const handleOpenChange = vi.fn();
+    render(
+      <Sheet onOpenChange={handleOpenChange}>
+        <SheetTrigger>Open sheet</SheetTrigger>
+        <SheetContent>
+          <SheetTitle>Sheet title</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open sheet" }));
+    expect(screen.getByRole("dialog", { name: "Sheet title" })).toBeVisible();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(handleOpenChange).toHaveBeenLastCalledWith(
+      false,
+      expect.any(Object),
+    );
+  });
+
+  it("opens a popover and closes it on outside press", async () => {
+    render(
+      <Popover>
+        <PopoverTrigger>Open popover</PopoverTrigger>
+        <PopoverContent>Popover content</PopoverContent>
+      </Popover>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open popover" }));
+
+    expect(screen.getByText("Popover content")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open popover" }),
+    ).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Open popover" }),
+      ).toHaveAttribute("aria-expanded", "false"),
+    );
+  });
+
+  it("shows a tooltip on focus", () => {
+    render(
+      <Tooltip>
+        <TooltipTrigger>Tooltip trigger</TooltipTrigger>
+        <TooltipContent>Tooltip content</TooltipContent>
+      </Tooltip>,
+    );
+
+    fireEvent.focus(screen.getByRole("button", { name: "Tooltip trigger" }));
+
+    expect(screen.getByText("Tooltip content")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Tooltip trigger" }),
+    ).toHaveAttribute("data-popup-open");
+  });
+
+  it("opens a drawer", () => {
+    render(
+      <Drawer>
+        <DrawerTrigger>Open drawer</DrawerTrigger>
+        <DrawerContent>
+          <DrawerTitle>Drawer title</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open drawer" }));
+
+    expect(screen.getByRole("dialog", { name: "Drawer title" })).toBeVisible();
+  });
+
+  it("configures a drawer for a downward swipe", async () => {
+    render(
+      <Drawer defaultOpen swipeDirection="down">
+        <DrawerContent>
+          <DrawerTitle>Swipe drawer</DrawerTitle>
+        </DrawerContent>
+      </Drawer>,
+    );
+
+    const drawer = screen.getByRole("dialog", { name: "Swipe drawer" });
+    await waitFor(() => expect(drawer).toHaveAttribute("data-open"));
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve()),
+    );
+    const viewport = drawer.parentElement;
+    expect(viewport).toHaveAttribute("data-slot", "drawer-viewport");
+    expect(drawer).toHaveAttribute("data-swipe-direction", "down");
+  });
+});

--- a/packages/ui/src/components/overlays.test.tsx
+++ b/packages/ui/src/components/overlays.test.tsx
@@ -6,6 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 import {
   AlertDialog,
+  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogTitle,
@@ -57,6 +58,50 @@ describe("Base UI overlays", () => {
     await waitFor(() =>
       expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument(),
     );
+  });
+
+  it("closes an alert dialog with its confirm action", async () => {
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open confirmation</AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogTitle>Confirmation title</AlertDialogTitle>
+          <AlertDialogAction>Confirm action</AlertDialogAction>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open confirmation" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm action" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("keeps an alert dialog open when its confirm handler prevents Base UI", () => {
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Open persistent confirmation</AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogTitle>Persistent confirmation title</AlertDialogTitle>
+          <AlertDialogAction onClick={(event) => event.preventBaseUIHandler()}>
+            Keep open
+          </AlertDialogAction>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open persistent confirmation" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Keep open" }));
+
+    expect(
+      screen.getByRole("alertdialog", {
+        name: "Persistent confirmation title",
+      }),
+    ).toBeVisible();
   });
 
   it("opens a sheet and closes it with Escape", () => {

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,51 +1,54 @@
 "use client";
 
-import * as React from "react";
-import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Popover({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
   return <PopoverPrimitive.Root data-slot="popover" {...props} />;
 }
 
-function PopoverTrigger({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
 function PopoverContent({
   className,
   align = "center",
+  alignOffset = 0,
+  side = "bottom",
   sideOffset = 4,
+  collisionPadding,
   container,
   ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content> & {
-  container?: HTMLElement | null;
-}) {
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "collisionPadding"
+  > & {
+    container?: HTMLElement | null;
+  }) {
   return (
     <PopoverPrimitive.Portal container={container}>
-      <PopoverPrimitive.Content
-        data-slot="popover-content"
+      <PopoverPrimitive.Positioner
         align={align}
+        alignOffset={alignOffset}
+        side={side}
         sideOffset={sideOffset}
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[100] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
-          className,
-        )}
-        {...props}
-      />
+        collisionPadding={collisionPadding}
+        className="isolate z-[100]"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[100] w-72 origin-(--transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>
   );
 }
 
-function PopoverAnchor({
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
-}
-
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+export { Popover, PopoverTrigger, PopoverContent };

--- a/packages/ui/src/components/radio-group.tsx
+++ b/packages/ui/src/components/radio-group.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import * as React from "react";
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
-import { CircleIcon } from "lucide-react";
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function RadioGroup({
-  className,
-  ...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
   return (
-    <RadioGroupPrimitive.Root
+    <RadioGroupPrimitive
       data-slot="radio-group"
       className={cn("grid gap-3", className)}
       {...props}
@@ -19,26 +15,23 @@ function RadioGroup({
   );
 }
 
-function RadioGroupItem({
-  className,
-  ...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
   return (
-    <RadioGroupPrimitive.Item
+    <RadioPrimitive.Root
       data-slot="radio-group-item"
       className={cn(
-        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-checked:border-primary",
         className,
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator
+      <RadioPrimitive.Indicator
         data-slot="radio-group-indicator"
         className="relative flex items-center justify-center"
       >
-        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
-      </RadioGroupPrimitive.Indicator>
-    </RadioGroupPrimitive.Item>
+        <span className="bg-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full" />
+      </RadioPrimitive.Indicator>
+    </RadioPrimitive.Root>
   );
 }
 

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import * as React from "react";
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
 const ScrollArea = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  ScrollAreaPrimitive.Root.Props & {
     onScroll?: (event: React.UIEvent<HTMLDivElement>) => void;
   }
 >(({ className, children, onScroll, ...props }, ref) => {
@@ -38,9 +38,9 @@ function ScrollBar({
   className,
   orientation = "vertical",
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+}: ScrollAreaPrimitive.Scrollbar.Props) {
   return (
-    <ScrollAreaPrimitive.ScrollAreaScrollbar
+    <ScrollAreaPrimitive.Scrollbar
       data-slot="scroll-area-scrollbar"
       orientation={orientation}
       className={cn(
@@ -53,11 +53,11 @@ function ScrollBar({
       )}
       {...props}
     >
-      <ScrollAreaPrimitive.ScrollAreaThumb
+      <ScrollAreaPrimitive.Thumb
         data-slot="scroll-area-thumb"
         className="bg-border relative flex-1 rounded-full"
       />
-    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+    </ScrollAreaPrimitive.Scrollbar>
   );
 }
 

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,26 +1,29 @@
 "use client";
 
-import * as React from "react";
-import * as SelectPrimitive from "@radix-ui/react-select";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import * as React from "react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />;
+type SelectProps<Value, Multiple extends boolean | undefined = false> = Omit<
+  SelectPrimitive.Root.Props<Value, Multiple>,
+  "items"
+> & {
+  items: NonNullable<SelectPrimitive.Root.Props<Value, Multiple>["items"]>;
+};
+
+function Select<Value, Multiple extends boolean | undefined = false>(
+  props: SelectProps<Value, Multiple>,
+) {
+  return <SelectPrimitive.Root {...props} />;
 }
 
-function SelectGroup({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+function SelectGroup(props: SelectPrimitive.Group.Props) {
   return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
-function SelectValue({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+function SelectValue(props: SelectPrimitive.Value.Props) {
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
@@ -29,23 +32,21 @@ function SelectTrigger({
   size = "default",
   children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default" | "lg";
-}) {
+}: SelectPrimitive.Trigger.Props & { size?: "sm" | "default" | "lg" }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 data-[size=lg]:h-10 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 data-[size=lg]:h-10 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
       {children}
-      <SelectPrimitive.Icon asChild>
-        <ChevronDownIcon className="size-4 opacity-50" />
-      </SelectPrimitive.Icon>
+      <SelectPrimitive.Icon
+        render={<ChevronDownIcon className="size-4 opacity-50" />}
+      />
     </SelectPrimitive.Trigger>
   );
 }
@@ -53,34 +54,43 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "popper",
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
   return (
     <SelectPrimitive.Portal>
-      <SelectPrimitive.Content
-        data-slot="select-content"
-        className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
-          position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className,
-        )}
-        position={position}
-        {...props}
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
       >
-        <SelectScrollUpButton />
-        <SelectPrimitive.Viewport
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
           className={cn(
-            "p-1",
-            position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll:my-1",
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md data-[align-trigger=true]:w-(--anchor-width)",
+            className,
           )}
+          {...props}
         >
-          {children}
-        </SelectPrimitive.Viewport>
-        <SelectScrollDownButton />
-      </SelectPrimitive.Content>
+          <SelectScrollUpButton />
+          <SelectPrimitive.List className="p-1">
+            {children}
+          </SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
     </SelectPrimitive.Portal>
   );
 }
@@ -88,9 +98,9 @@ function SelectContent({
 function SelectLabel({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+}: SelectPrimitive.GroupLabel.Props) {
   return (
-    <SelectPrimitive.Label
+    <SelectPrimitive.GroupLabel
       data-slot="select-label"
       className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
       {...props}
@@ -102,22 +112,24 @@ function SelectItem({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+}: SelectPrimitive.Item.Props) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}
     >
-      <span className="absolute right-2 flex size-3.5 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="absolute right-2 flex size-3.5 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="size-4" />
+      </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
   );
 }
@@ -125,7 +137,7 @@ function SelectItem({
 function SelectSeparator({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+}: SelectPrimitive.Separator.Props) {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
@@ -138,10 +150,10 @@ function SelectSeparator({
 function SelectScrollUpButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
   return (
-    <SelectPrimitive.ScrollUpButton
-      data-slot="select-scroll:up-button"
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
       className={cn(
         "flex cursor-default items-center justify-center py-1",
         className,
@@ -149,17 +161,17 @@ function SelectScrollUpButton({
       {...props}
     >
       <ChevronUpIcon className="size-4" />
-    </SelectPrimitive.ScrollUpButton>
+    </SelectPrimitive.ScrollUpArrow>
   );
 }
 
 function SelectScrollDownButton({
   className,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
   return (
-    <SelectPrimitive.ScrollDownButton
-      data-slot="select-scroll:down-button"
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
       className={cn(
         "flex cursor-default items-center justify-center py-1",
         className,
@@ -167,7 +179,7 @@ function SelectScrollDownButton({
       {...props}
     >
       <ChevronDownIcon className="size-4" />
-    </SelectPrimitive.ScrollDownButton>
+    </SelectPrimitive.ScrollDownArrow>
   );
 }
 

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,23 +1,20 @@
 "use client";
 
-import * as React from "react";
-import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
 function Separator({
   className,
   orientation = "horizontal",
-  decorative = true,
   ...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: SeparatorPrimitive.Props) {
   return (
-    <SeparatorPrimitive.Root
+    <SeparatorPrimitive
       data-slot="separator"
-      decorative={decorative}
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        "bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:h-full data-vertical:w-px",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/shared-tooltip-provider.tsx
+++ b/packages/ui/src/components/shared-tooltip-provider.tsx
@@ -210,16 +210,17 @@ function SharedTooltipRoot({
           );
         }
       }}
-      delayDuration={0}
-      disableHoverableContent
+      disableHoverablePopup
     >
-      <TooltipTrigger asChild>
-        <span
-          aria-hidden="true"
-          className="pointer-events-none fixed block"
-          style={proxyTriggerStyle}
-        />
-      </TooltipTrigger>
+      <TooltipTrigger
+        render={
+          <span
+            aria-hidden="true"
+            className="pointer-events-none fixed block"
+            style={proxyTriggerStyle}
+          />
+        }
+      />
       <TooltipContent
         className={cn("pointer-events-none", tooltipState.contentClassName)}
       >

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,42 +1,33 @@
 "use client";
 
 import * as React from "react";
-import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 import { XIcon } from "lucide-react";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
-function SheetTrigger({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
   return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
-function SheetClose({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
   return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
-function SheetPortal({
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
   return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
-function SheetOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
   return (
-    <SheetPrimitive.Overlay
+    <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className,
       )}
       {...props}
@@ -49,34 +40,34 @@ function SheetContent({
   children,
   side = "right",
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+}: SheetPrimitive.Popup.Props & {
   side?: "top" | "right" | "bottom" | "left";
 }) {
   return (
     <SheetPortal>
       <SheetOverlay />
-      <SheetPrimitive.Content
+      <SheetPrimitive.Popup
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-open:animate-in data-closed:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-closed:duration-300 data-open:duration-500",
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+            "data-closed:slide-out-to-right data-open:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            "data-closed:slide-out-to-left data-open:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
           side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            "data-closed:slide-out-to-top data-open:slide-in-from-top inset-x-0 top-0 h-auto border-b",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "data-closed:slide-out-to-bottom data-open:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
           className,
         )}
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-open:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
           <XIcon className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
-      </SheetPrimitive.Content>
+      </SheetPrimitive.Popup>
     </SheetPortal>
   );
 }
@@ -101,10 +92,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function SheetTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
@@ -117,7 +105,7 @@ function SheetTitle({
 function SheetDescription({
   className,
   ...props
-}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+}: SheetPrimitive.Description.Props) {
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
+import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react";
 
@@ -73,25 +73,21 @@ function SidebarProvider({
   // We use openProp and setOpenProp for control from outside the component.
   const [_open, _setOpen] = React.useState(defaultOpen);
   const open = openProp ?? _open;
-  const setOpen = React.useCallback(
-    (value: boolean | ((value: boolean) => boolean)) => {
-      const openState = typeof value === "function" ? value(open) : value;
-      if (setOpenProp) {
-        setOpenProp(openState);
-      } else {
-        _setOpen(openState);
-      }
+  const setOpen = (value: boolean | ((value: boolean) => boolean)) => {
+    const openState = typeof value === "function" ? value(open) : value;
+    if (setOpenProp) {
+      setOpenProp(openState);
+    } else {
+      _setOpen(openState);
+    }
 
-      // This sets the cookie to keep the sidebar state.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
-    },
-    [setOpenProp, open],
-  );
+    document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+  };
 
   // Helper to toggle the sidebar.
-  const toggleSidebar = React.useCallback(() => {
+  const toggleSidebar = () => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-  }, [isMobile, setOpen, setOpenMobile]);
+  };
 
   // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
@@ -113,22 +109,19 @@ function SidebarProvider({
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed";
 
-  const contextValue = React.useMemo<SidebarContextProps>(
-    () => ({
-      state,
-      open,
-      setOpen,
-      isMobile,
-      openMobile,
-      setOpenMobile,
-      toggleSidebar,
-    }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
-  );
+  const contextValue: SidebarContextProps = {
+    state,
+    open,
+    setOpen,
+    isMobile,
+    openMobile,
+    setOpenMobile,
+    toggleSidebar,
+  };
 
   return (
     <SidebarContext.Provider value={contextValue}>
-      <TooltipProvider delayDuration={0}>
+      <TooltipProvider delay={0}>
         <div
           data-slot="sidebar-wrapper"
           style={
@@ -395,46 +388,46 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
 
 function SidebarGroupLabel({
   className,
-  asChild = false,
+  render,
   ...props
-}: React.ComponentProps<"div"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "div";
-
-  return (
-    <Comp
-      data-slot="sidebar-group-label"
-      data-sidebar="group-label"
-      className={cn(
+}: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    render,
+    props: {
+      "data-slot": "sidebar-group-label",
+      "data-sidebar": "group-label",
+      className: cn(
         "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
-      )}
-      {...props}
-    />
-  );
+      ),
+      ...props,
+    },
+  });
 }
 
 function SidebarGroupAction({
   className,
-  asChild = false,
+  render,
   ...props
-}: React.ComponentProps<"button"> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "button";
-
-  return (
-    <Comp
-      data-slot="sidebar-group-action"
-      data-sidebar="group-action"
-      className={cn(
+}: useRender.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    render,
+    props: {
+      "data-slot": "sidebar-group-action",
+      "data-sidebar": "group-action",
+      className: cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-transparent-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
         "group-data-[collapsible=icon]:hidden",
         className,
-      )}
-      {...props}
-    />
-  );
+      ),
+      ...props,
+    },
+  });
 }
 
 function SidebarGroupContent({
@@ -497,31 +490,31 @@ const sidebarMenuButtonVariants = cva(
 );
 
 function SidebarMenuButton({
-  asChild = false,
+  render,
   isActive = false,
   variant = "default",
   size = "default",
   tooltip,
   className,
   ...props
-}: React.ComponentProps<"button"> & {
-  asChild?: boolean;
+}: useRender.ComponentProps<"button"> & {
   isActive?: boolean;
   tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
-  const Comp = asChild ? Slot : "button";
   const { isMobile, state } = useSidebar();
 
-  const button = (
-    <Comp
-      data-slot="sidebar-menu-button"
-      data-sidebar="menu-button"
-      data-size={size}
-      data-active={isActive}
-      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
-      {...props}
-    />
-  );
+  const button = useRender({
+    defaultTagName: "button",
+    render,
+    props: {
+      "data-slot": "sidebar-menu-button",
+      "data-sidebar": "menu-button",
+      "data-size": size,
+      "data-active": isActive,
+      className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+      ...props,
+    },
+  });
 
   if (!tooltip) {
     return button;
@@ -535,7 +528,7 @@ function SidebarMenuButton({
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipTrigger render={button} />
       <TooltipContent
         side="right"
         align="center"
@@ -548,20 +541,19 @@ function SidebarMenuButton({
 
 function SidebarMenuAction({
   className,
-  asChild = false,
+  render,
   showOnHover = false,
   ...props
-}: React.ComponentProps<"button"> & {
-  asChild?: boolean;
+}: useRender.ComponentProps<"button"> & {
   showOnHover?: boolean;
 }) {
-  const Comp = asChild ? Slot : "button";
-
-  return (
-    <Comp
-      data-slot="sidebar-menu-action"
-      data-sidebar="menu-action"
-      className={cn(
+  return useRender({
+    defaultTagName: "button",
+    render,
+    props: {
+      "data-slot": "sidebar-menu-action",
+      "data-sidebar": "menu-action",
+      className: cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-transparent-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         // Increases the hit area of the button on mobile.
         "after:absolute after:-inset-2 md:after:hidden",
@@ -570,12 +562,12 @@ function SidebarMenuAction({
         "peer-data-[size=lg]/menu-button:top-2.5",
         "group-data-[collapsible=icon]:hidden",
         showOnHover &&
-          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0",
+          "peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-popup-open:opacity-100 md:opacity-0",
         className,
-      )}
-      {...props}
-    />
-  );
+      ),
+      ...props,
+    },
+  });
 }
 
 function SidebarMenuBadge({
@@ -668,35 +660,34 @@ function SidebarMenuSubItem({
 }
 
 function SidebarMenuSubButton({
-  asChild = false,
+  render,
   size = "md",
   isActive = false,
   className,
   ...props
-}: React.ComponentProps<"a"> & {
-  asChild?: boolean;
+}: useRender.ComponentProps<"a"> & {
   size?: "sm" | "md";
   isActive?: boolean;
 }) {
-  const Comp = asChild ? Slot : "a";
-
-  return (
-    <Comp
-      data-slot="sidebar-menu-sub-button"
-      data-sidebar="menu-sub-button"
-      data-size={size}
-      data-active={isActive}
-      className={cn(
+  return useRender({
+    defaultTagName: "a",
+    render,
+    props: {
+      "data-slot": "sidebar-menu-sub-button",
+      "data-sidebar": "menu-sub-button",
+      "data-size": size,
+      "data-active": isActive,
+      className: cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-transparent-accent hover:text-sidebar-accent-foreground active:bg-transparent-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-hidden focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
         "data-[active=true]:bg-transparent-accent data-[active=true]:text-sidebar-accent-foreground",
         size === "sm" && "text-xs",
         size === "md" && "text-sm",
         "group-data-[collapsible=icon]:hidden",
         className,
-      )}
-      {...props}
-    />
-  );
+      ),
+      ...props,
+    },
+  });
 }
 
 export {

--- a/packages/ui/src/components/switch.tsx
+++ b/packages/ui/src/components/switch.tsx
@@ -1,19 +1,15 @@
 "use client";
 
-import * as React from "react";
-import * as SwitchPrimitive from "@radix-ui/react-switch";
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Switch({
-  className,
-  ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+function Switch({ className, ...props }: SwitchPrimitive.Root.Props) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-unchecked:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       {...props}
@@ -21,7 +17,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+          "bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-checked:translate-x-[calc(100%-2px)] data-unchecked:translate-x-0",
         )}
       />
     </SwitchPrimitive.Root>

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,14 +1,10 @@
 "use client";
 
-import * as React from "react";
-import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
-function Tabs({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+function Tabs({ className, ...props }: TabsPrimitive.Root.Props) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
@@ -18,10 +14,7 @@ function Tabs({
   );
 }
 
-function TabsList({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+function TabsList({ className, ...props }: TabsPrimitive.List.Props) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -34,15 +27,12 @@ function TabsList({
   );
 }
 
-function TabsTrigger({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
   return (
-    <TabsPrimitive.Trigger
+    <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "data-[state=active]:bg-background cursor-pointer dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-active:bg-background cursor-pointer dark:data-active:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-active:border-input dark:data-active:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-active:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -50,12 +40,9 @@ function TabsTrigger({
   );
 }
 
-function TabsContent({
-  className,
-  ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
-    <TabsPrimitive.Content
+    <TabsPrimitive.Panel
       data-slot="tabs-content"
       className={cn("flex-1 outline-none", className)}
       {...props}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,58 +1,63 @@
 "use client";
 
-import * as React from "react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
 import { cn } from "@lootlog/ui/lib/utils";
 
 function TooltipProvider({
-  delayDuration = 0,
+  delay = 0,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+}: TooltipPrimitive.Provider.Props) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
-      delayDuration={delayDuration}
+      delay={delay}
       {...props}
     />
   );
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  );
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
   className,
+  align = "center",
+  alignOffset = 0,
+  side = "top",
   sideOffset = -5,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Content
-        data-slot="tooltip-content"
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
         sideOffset={sideOffset}
-        className={cn(
-          "bg-background border-solid border text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className,
-        )}
-        {...props}
+        className="isolate z-50"
       >
-        {children}
-      </TooltipPrimitive.Content>
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "bg-background border-solid border text-primary-foreground animate-in fade-in-0 zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
   );
 }

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,0 +1,3 @@
+import "@testing-library/jest-dom/vitest";
+
+Element.prototype.getAnimations ??= () => [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -678,7 +678,7 @@ importers:
     dependencies:
       '@lootlog/ui':
         specifier: workspace:*
-        version: file:packages/ui(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)
+        version: file:packages/ui(@date-fns/tz@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)
       '@tanstack/react-router':
         specifier: 'catalog:'
         version: 1.170.18(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1124,7 +1124,7 @@ importers:
     dependencies:
       '@lootlog/ui':
         specifier: workspace:*
-        version: file:packages/ui(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)
+        version: file:packages/ui(@date-fns/tz@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1(supports-color@10.2.2)(webpack@5.106.2(@swc/core@1.15.46)(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))
@@ -1460,7 +1460,7 @@ importers:
         version: link:../../packages/api-client
       '@lootlog/ui':
         specifier: workspace:*
-        version: file:packages/ui(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)
+        version: file:packages/ui(@date-fns/tz@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)
       '@tanstack/react-query':
         specifier: 'catalog:'
         version: 5.101.4(react@19.2.8)
@@ -1785,69 +1785,15 @@ importers:
 
   packages/ui:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.7.0
+        version: 1.7.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/geist':
         specifier: ^5.3.0
         version: 5.3.0
       '@fontsource-variable/geist-mono':
         specifier: ^5.3.0
         version: 5.3.0
-      '@radix-ui/react-accordion':
-        specifier: ^1.2.20
-        version: 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.23
-        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-avatar':
-        specifier: ^1.2.6
-        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-checkbox':
-        specifier: ^1.3.11
-        version: 1.3.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-collapsible':
-        specifier: ^1.1.20
-        version: 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-context-menu':
-        specifier: ^2.3.7
-        version: 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-dialog':
-        specifier: ^1.1.23
-        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.24
-        version: 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-label':
-        specifier: ^2.1.15
-        version: 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-navigation-menu':
-        specifier: ^1.2.22
-        version: 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-popover':
-        specifier: ^1.1.23
-        version: 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-radio-group':
-        specifier: ^1.4.7
-        version: 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-scroll-area':
-        specifier: ^1.2.18
-        version: 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-select':
-        specifier: ^2.3.7
-        version: 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-separator':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot':
-        specifier: ^1.3.3
-        version: 1.3.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-switch':
-        specifier: ^1.3.7
-        version: 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-tabs':
-        specifier: ^1.1.21
-        version: 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.2.16
-        version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.3
@@ -1908,13 +1854,19 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
-      vaul:
-        specifier: ^1.1.2
-        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@lootlog/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@testing-library/jest-dom':
+        specifier: ^7.0.0
+        version: 7.0.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17
@@ -1924,6 +1876,12 @@ importers:
       '@types/three':
         specifier: ^0.185.1
         version: 0.185.1
+      happy-dom:
+        specifier: ^20.11.1
+        version: 20.11.1
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1)(jsdom@29.0.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -2219,8 +2177,35 @@ packages:
       date-fns:
         optional: true
 
+  '@base-ui/react@1.7.0':
+    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
   '@base-ui/utils@0.3.1':
     resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@base-ui/utils@0.3.2':
+    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
     peerDependencies:
       '@types/react': ^17 || ^18 || ^19
       react: ^17 || ^18 || ^19
@@ -5596,47 +5581,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-alert-dialog@1.1.23':
-    resolution: {integrity: sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-arrow@1.1.15':
     resolution: {integrity: sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-avatar@1.2.6':
-    resolution: {integrity: sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-checkbox@1.3.11':
-    resolution: {integrity: sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5692,19 +5638,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-context-menu@2.3.7':
-    resolution: {integrity: sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-context@1.2.2':
     resolution: {integrity: sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==}
     peerDependencies:
@@ -5749,19 +5682,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.24':
-    resolution: {integrity: sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-focus-guards@1.1.6':
     resolution: {integrity: sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==}
     peerDependencies:
@@ -5791,32 +5711,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-label@2.1.15':
-    resolution: {integrity: sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.24':
-    resolution: {integrity: sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-navigation-menu@1.2.22':
@@ -5910,19 +5804,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-radio-group@1.4.7':
-    resolution: {integrity: sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-roving-focus@1.1.19':
     resolution: {integrity: sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==}
     peerDependencies:
@@ -5938,32 +5819,6 @@ packages:
 
   '@radix-ui/react-scroll-area@1.2.18':
     resolution: {integrity: sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.3.7':
-    resolution: {integrity: sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.15':
-    resolution: {integrity: sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5993,19 +5848,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-switch@1.3.7':
-    resolution: {integrity: sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-tabs@1.1.21':
     resolution: {integrity: sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==}
     peerDependencies:
@@ -6021,19 +5863,6 @@ packages:
 
   '@radix-ui/react-toggle@1.1.10':
     resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.16':
-    resolution: {integrity: sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -13270,12 +13099,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  vaul@1.1.2:
-    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
-    peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-
   verkit@0.3.0:
     resolution: {integrity: sha512-Njrh4U8UODGajoZ44QS2C/BsoEM9DTI/aCqY5swsizb+/ap0FamvnCMcZAxrR5+aoC0ZqkawEfpC/N2SBc+xeA==}
     engines: {node: '>=18.12.0'}
@@ -14214,7 +14037,32 @@ snapshots:
       '@types/react': 19.2.17
       date-fns: 4.4.0
 
+  '@base-ui/react@1.7.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@date-fns/tz': 1.5.0
+      '@types/react': 19.2.17
+      date-fns: 4.4.0
+
   '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12
@@ -15717,29 +15565,11 @@ snapshots:
     optionalDependencies:
       typescript: 7.0.2
 
-  '@lootlog/ui@file:packages/ui(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)':
+  '@lootlog/ui@file:packages/ui(@date-fns/tz@1.5.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-is@18.3.1)(redux@5.0.1)':
     dependencies:
+      '@base-ui/react': 1.7.0(@date-fns/tz@1.5.0)(@types/react@19.2.17)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fontsource-variable/geist': 5.3.0
       '@fontsource-variable/geist-mono': 5.3.0
-      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-alert-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-avatar': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-checkbox': 1.3.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-dropdown-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-radio-group': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-select': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-switch': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-tooltip': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tailwindcss/postcss': 4.3.3
       class-variance-authority: 0.7.1
       clsx: 2.1.1
@@ -15760,8 +15590,8 @@ snapshots:
       tailwindcss: 4.3.3
       three: 0.185.1
       tw-animate-css: 1.4.0
-      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
+      - '@date-fns/tz'
       - '@emotion/is-prop-valid'
       - '@types/react'
       - '@types/react-dom'
@@ -17550,51 +17380,9 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-arrow@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-checkbox@1.3.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.17)(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -17640,19 +17428,6 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.17
-
-  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-context@1.2.2(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
@@ -17702,21 +17477,6 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-dropdown-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-focus-guards@1.1.6(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
       react: 19.2.8
@@ -17740,41 +17500,6 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.17
-
-  '@radix-ui/react-label@2.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-menu@2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      aria-hidden: 1.2.6
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-navigation-menu@1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -17876,23 +17601,6 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-radio-group@1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-roving-focus@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -17929,45 +17637,6 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@radix-ui/react-select@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/number': 1.1.3
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-previous': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      aria-hidden: 1.2.6
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-separator@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.8)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.8)
@@ -17981,20 +17650,6 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@types/react': 19.2.17
-
-  '@radix-ui/react-switch@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-tabs@1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
@@ -18017,27 +17672,6 @@ snapshots:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.7
-      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.8)
-      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
@@ -25535,15 +25169,6 @@ snapshots:
     optional: true
 
   vary@1.1.2: {}
-
-  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
 
   verkit@0.3.0: {}
 


### PR DESCRIPTION
## Summary

- migrate all `@lootlog/ui` Radix UI wrappers to the current shadcn/Base UI implementations
- replace Vaul with the Base UI Drawer and update component consumers to the native Base UI API
- preserve the existing component classes, dimensions, positioning, animation behavior, and stacking
- migrate consumers in `@lootlog/web`, `@lootlog/wiki`, and `@lootlog/landing`
- add interaction tests and the required major/patch changesets

## Impact

The `@lootlog/ui` component props now follow Base UI rather than Radix UI. This is intentionally a breaking change. Shared wrapper export names are retained where they also exist in the current shadcn/Base implementation.

Direct `@radix-ui/*` and `vaul` dependencies were removed from `@lootlog/ui`. The accepted Radix path through `cmdk` remains.

## Validation

- UI interaction tests: 21 passed
- lint passed for UI, web, wiki, landing, and developer
- build/typecheck passed for UI, web, wiki, landing, and developer
- no direct Radix or Vaul dependency remains in `@lootlog/ui`
- no migrated `asChild` usage remains
- staged diff and pre-commit checks passed

## Visual verification

Automated screenshot comparison was not run because the expected application instances were not available. No additional application servers were started, following the repository instructions.