### PR TITLE
fix(ui): address Base UI migration regressions

### DIFF
--- a/.changeset/fix-base-ui-separator-orientation.md
+++ b/.changeset/fix-base-ui-separator-orientation.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/ui": patch
+---
+
+Fix separator dimensions by matching Base UI's orientation data attribute.

--- a/.changeset/fix-multi-select-popover-trigger.md
+++ b/.changeset/fix-multi-select-popover-trigger.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/web": patch
+---
+
+Fix MultiSelect popover triggers that render as non-button elements.

--- a/apps/web/src/components/ui/multi-select.spec.tsx
+++ b/apps/web/src/components/ui/multi-select.spec.tsx
@@ -10,9 +10,29 @@ vi.mock("react-i18next", () => ({
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("MultiSelect", () => {
+  it("renders its custom popover trigger without native button warnings", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <MultiSelect
+        onClose={() => {}}
+        onValueChange={() => {}}
+        options={[]}
+        value={[]}
+      />,
+    );
+
+    expect(consoleError.mock.calls.flat().join(" ")).not.toContain(
+      "expected a native <button>",
+    );
+  });
+
   it("distinguishes an untouched search from an empty result", () => {
     render(
       <MultiSelect

--- a/apps/web/src/components/ui/multi-select.tsx
+++ b/apps/web/src/components/ui/multi-select.tsx
@@ -277,6 +277,7 @@ export const MultiSelect = React.forwardRef<HTMLDivElement, MultiSelectProps>(
         modal={modalPopover}
       >
         <PopoverTrigger
+          nativeButton={false}
           render={
             <div
               ref={ref}

--- a/packages/ui/src/components/controls.test.tsx
+++ b/packages/ui/src/components/controls.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Button } from "./button";
 import { Checkbox } from "./checkbox";
 import { RadioGroup, RadioGroupItem } from "./radio-group";
+import { Separator } from "./separator";
 import { Switch } from "./switch";
 
 describe("Base UI controls", () => {
@@ -73,4 +74,19 @@ describe("Base UI controls", () => {
 
     expect(handleValueChange).toHaveBeenCalledWith("dark", expect.any(Object));
   });
+
+  it.each([
+    ["horizontal", "data-[orientation=horizontal]:h-px"],
+    ["vertical", "data-[orientation=vertical]:w-px"],
+  ] as const)(
+    "styles a %s separator using Base UI's orientation attribute",
+    (orientation, orientationClassName) => {
+      const { container } = render(<Separator orientation={orientation} />);
+      const separator = container.firstElementChild;
+
+      expect(separator).toHaveAttribute("role", "separator");
+      expect(separator).toHaveAttribute("data-orientation", orientation);
+      expect(separator).toHaveClass(orientationClassName);
+    },
+  );
 });

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -14,7 +14,7 @@ function Separator({
       data-slot="separator"
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-horizontal:h-px data-horizontal:w-full data-vertical:h-full data-vertical:w-px",
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
         className,
       )}
       {...props}


### PR DESCRIPTION
## What changed

- restore sidebar separator dimensions by styling Base UI's `data-orientation` attribute
- configure the `MultiSelect` popover trigger as a non-native button when rendering a custom `<div>`
- add regression coverage for separator orientation classes and the Base UI native-button warning
- add patch changesets for `@lootlog/ui` and `@lootlog/web`

## Why

The Radix UI to Base UI migration left two mismatches in component state contracts. Separators were styled with `data-horizontal` / `data-vertical` selectors even though Base UI exposes `data-orientation`. `MultiSelect` also replaced `Popover.Trigger` with a `<div>` while leaving `nativeButton` at its default `true`, producing an accessibility warning.

## Impact

Sidebar section dividers are visible again, and loot-filter multi-selects no longer emit the Base UI native-button warning. Existing popover behavior and keyboard semantics remain intact.

## Validation

- `pnpm --filter @lootlog/ui test`
- `pnpm --filter @lootlog/ui lint`
- `pnpm --filter @lootlog/ui build`
- `pnpm --filter @lootlog/web exec vitest run src/components/ui/multi-select.spec.tsx`
- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web build`
- verified sidebar separator dimensions and MultiSelect popover behavior in the running local app
