### PR TITLE
Add the canonical NPC access policy model

### DIFF
--- a/.changeset/wise-dragons-guard.md
+++ b/.changeset/wise-dragons-guard.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/api-helpers": minor
+---
+
+Add a canonical pure NPC access policy evaluator for organization, world, role, selector, level, owner, and action decisions.

--- a/apps/api/src/shared/permissions/npc-access-policy.spec.ts
+++ b/apps/api/src/shared/permissions/npc-access-policy.spec.ts
@@ -1,0 +1,210 @@
+import {
+  evaluateNpcAccess,
+  type NpcAccessContext,
+  type NpcAccessRole,
+  type NpcResource,
+  type NpcVisibilityPermissions,
+} from "@lootlog/api-helpers/permissions";
+
+const TIMER_VISIBILITY_PERMISSIONS: NpcVisibilityPermissions = {
+  base: "LOOTLOG_TIMERS_READ",
+  heroes: "LOOTLOG_TIMERS_HEROES_READ",
+  titans: "LOOTLOG_TIMERS_TITANS_READ",
+};
+
+const createRole = (overrides: Partial<NpcAccessRole> = {}): NpcAccessRole => ({
+  permissions: ["LOOTLOG_TIMERS_READ"],
+  ...overrides,
+});
+
+const createContext = (
+  overrides: Partial<NpcAccessContext> = {},
+): NpcAccessContext => ({
+  organizationId: "organization-1",
+  isOwner: false,
+  roles: [createRole()],
+  ...overrides,
+});
+
+const createResource = (overrides: Partial<NpcResource> = {}): NpcResource => ({
+  organizationId: "organization-1",
+  world: "Aether",
+  npc: {
+    id: 100,
+    type: "ELITE2",
+    group: "elite",
+    level: 150,
+  },
+  ...overrides,
+});
+
+const evaluate = (options?: {
+  context?: NpcAccessContext;
+  resource?: NpcResource;
+  actionPermission?: string;
+}) =>
+  evaluateNpcAccess({
+    context: options?.context ?? createContext(),
+    resource: options?.resource ?? createResource(),
+    visibilityPermissions: TIMER_VISIBILITY_PERMISSIONS,
+    actionPermission: options?.actionPermission,
+  });
+
+describe("evaluateNpcAccess", () => {
+  it("allows an owner inside their organization without mapped roles", () => {
+    expect(
+      evaluate({
+        context: createContext({ isOwner: true, roles: [] }),
+        actionPermission: "LOOTLOG_TIMERS_DELETE",
+      }),
+    ).toEqual({ visible: true, allowed: true });
+  });
+
+  it("does not let owner authority cross the organization boundary", () => {
+    expect(
+      evaluate({
+        context: createContext({ isOwner: true, roles: [] }),
+        resource: createResource({ organizationId: "organization-2" }),
+      }),
+    ).toEqual({ visible: false, allowed: false });
+  });
+
+  it.each([
+    {
+      name: "missing base permission",
+      role: createRole({ permissions: [] }),
+    },
+    {
+      name: "world outside the role scope",
+      role: createRole({ worlds: ["Fobos"] }),
+    },
+    {
+      name: "level below the inclusive range",
+      role: createRole({ npc: { levelRange: { from: 151, to: 200 } } }),
+    },
+    {
+      name: "NPC excluded by id",
+      role: createRole({ npc: { excludeIds: [100] } }),
+    },
+    {
+      name: "NPC outside the included types",
+      role: createRole({ npc: { includeTypes: ["TITAN"] } }),
+    },
+    {
+      name: "NPC outside the included groups",
+      role: createRole({ npc: { includeGroups: ["hero"] } }),
+    },
+  ])("denies visibility for $name", ({ role }) => {
+    expect(evaluate({ context: createContext({ roles: [role] }) })).toEqual({
+      visible: false,
+      allowed: false,
+    });
+  });
+
+  it("matches inclusive level bounds, world and NPC selectors", () => {
+    const role = createRole({
+      worlds: ["Aether"],
+      npc: {
+        includeIds: [100],
+        includeTypes: ["ELITE2"],
+        includeGroups: ["elite"],
+        levelRange: { from: 150, to: 150 },
+      },
+    });
+
+    expect(evaluate({ context: createContext({ roles: [role] }) })).toEqual({
+      visible: true,
+      allowed: true,
+    });
+  });
+
+  it.each(["HERO", "EVENT_HERO"])(
+    "requires the hero selector permission for %s",
+    (type) => {
+      const resource = createResource({
+        npc: { ...createResource().npc, type },
+      });
+
+      expect(evaluate({ resource })).toEqual({
+        visible: false,
+        allowed: false,
+      });
+      expect(
+        evaluate({
+          context: createContext({
+            roles: [
+              createRole({
+                permissions: [
+                  "LOOTLOG_TIMERS_READ",
+                  "LOOTLOG_TIMERS_HEROES_READ",
+                ],
+              }),
+            ],
+          }),
+          resource,
+        }),
+      ).toEqual({ visible: true, allowed: true });
+    },
+  );
+
+  it("requires the titan selector permission for titans", () => {
+    const resource = createResource({
+      npc: { ...createResource().npc, type: "TITAN" },
+    });
+
+    expect(evaluate({ resource })).toEqual({
+      visible: false,
+      allowed: false,
+    });
+  });
+
+  it("does not combine permissions and selectors from separate roles", () => {
+    const context = createContext({
+      roles: [
+        createRole({
+          permissions: ["LOOTLOG_TIMERS_READ", "LOOTLOG_TIMERS_TITANS_READ"],
+          npc: { levelRange: { from: 1, to: 149 } },
+        }),
+        createRole({
+          permissions: [],
+          npc: { levelRange: { from: 150, to: 200 } },
+        }),
+      ],
+    });
+    const resource = createResource({
+      npc: { ...createResource().npc, type: "TITAN" },
+    });
+
+    expect(evaluate({ context, resource })).toEqual({
+      visible: false,
+      allowed: false,
+    });
+  });
+
+  it("requires visibility and the action permission on one matching policy", () => {
+    const visibleRole = createRole();
+    const actionOnlyRole = createRole({
+      permissions: ["LOOTLOG_TIMERS_DELETE"],
+    });
+
+    expect(
+      evaluate({
+        context: createContext({ roles: [visibleRole, actionOnlyRole] }),
+        actionPermission: "LOOTLOG_TIMERS_DELETE",
+      }),
+    ).toEqual({ visible: true, allowed: false });
+
+    expect(
+      evaluate({
+        context: createContext({
+          roles: [
+            createRole({
+              permissions: ["LOOTLOG_TIMERS_READ", "LOOTLOG_TIMERS_DELETE"],
+            }),
+          ],
+        }),
+        actionPermission: "LOOTLOG_TIMERS_DELETE",
+      }),
+    ).toEqual({ visible: true, allowed: true });
+  });
+});

--- a/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
+++ b/packages/api-helpers/src/lib/permissions/can-view-npc-timer.ts
@@ -9,6 +9,169 @@ export type RolePermissionData = {
   lvlRangeTo: number;
 };
 
+export type NpcSelector = {
+  includeIds?: readonly number[];
+  excludeIds?: readonly number[];
+  includeTypes?: readonly string[];
+  excludeTypes?: readonly string[];
+  includeGroups?: readonly string[];
+  excludeGroups?: readonly string[];
+  levelRange?: {
+    from: number;
+    to: number;
+  };
+};
+
+export type NpcAccessRole = {
+  permissions: readonly string[];
+  worlds?: readonly string[];
+  npc?: NpcSelector;
+};
+
+export type NpcAccessContext = {
+  organizationId: string;
+  isOwner: boolean;
+  roles: readonly NpcAccessRole[];
+};
+
+export type NpcResource = {
+  organizationId: string;
+  world: string;
+  npc: {
+    id: number;
+    type: string;
+    group: string | null;
+    level: number;
+  };
+};
+
+export type NpcVisibilityPermissions = {
+  base: string;
+  heroes: string;
+  titans: string;
+};
+
+export type NpcAccessDecision = {
+  visible: boolean;
+  allowed: boolean;
+};
+
+type EvaluateNpcAccessOptions = {
+  context: NpcAccessContext;
+  resource: NpcResource;
+  visibilityPermissions: NpcVisibilityPermissions;
+  actionPermission?: string;
+};
+
+const HERO_NPC_TYPES = new Set(["HERO", "EVENT_HERO"]);
+
+const matchesIncludedValue = <T>(
+  includedValues: readonly T[] | undefined,
+  value: T,
+): boolean => !includedValues?.length || includedValues.includes(value);
+
+const matchesExcludedValue = <T>(
+  excludedValues: readonly T[] | undefined,
+  value: T,
+): boolean => !excludedValues?.includes(value);
+
+const matchesNpcSelector = (
+  selector: NpcSelector | undefined,
+  resource: NpcResource,
+): boolean => {
+  if (!selector) return true;
+
+  const { npc } = resource;
+  if (!matchesIncludedValue(selector.includeIds, npc.id)) return false;
+  if (!matchesExcludedValue(selector.excludeIds, npc.id)) return false;
+  if (!matchesIncludedValue(selector.includeTypes, npc.type)) return false;
+  if (!matchesExcludedValue(selector.excludeTypes, npc.type)) return false;
+
+  if (selector.includeGroups?.length) {
+    if (npc.group === null || !selector.includeGroups.includes(npc.group)) {
+      return false;
+    }
+  }
+
+  if (npc.group !== null && selector.excludeGroups?.includes(npc.group)) {
+    return false;
+  }
+
+  if (
+    selector.levelRange &&
+    (npc.level < selector.levelRange.from || npc.level > selector.levelRange.to)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+const getRequiredVisibilityPermissions = (
+  npcType: string,
+  visibilityPermissions: NpcVisibilityPermissions,
+): readonly string[] => {
+  if (npcType === "TITAN") {
+    return [visibilityPermissions.base, visibilityPermissions.titans];
+  }
+
+  if (HERO_NPC_TYPES.has(npcType)) {
+    return [visibilityPermissions.base, visibilityPermissions.heroes];
+  }
+
+  return [visibilityPermissions.base];
+};
+
+const roleMatchesResource = (
+  role: NpcAccessRole,
+  resource: NpcResource,
+): boolean => {
+  if (role.worlds?.length && !role.worlds.includes(resource.world)) {
+    return false;
+  }
+
+  return matchesNpcSelector(role.npc, resource);
+};
+
+export const evaluateNpcAccess = ({
+  context,
+  resource,
+  visibilityPermissions,
+  actionPermission,
+}: EvaluateNpcAccessOptions): NpcAccessDecision => {
+  if (context.organizationId !== resource.organizationId) {
+    return { visible: false, allowed: false };
+  }
+
+  if (context.isOwner) {
+    return { visible: true, allowed: true };
+  }
+
+  const requiredVisibilityPermissions = getRequiredVisibilityPermissions(
+    resource.npc.type,
+    visibilityPermissions,
+  );
+  const matchingRoles = context.roles.filter(
+    (role) =>
+      roleMatchesResource(role, resource) &&
+      requiredVisibilityPermissions.every((permission) =>
+        role.permissions.includes(permission),
+      ),
+  );
+  const visible = matchingRoles.length > 0;
+
+  if (!visible || !actionPermission) {
+    return { visible, allowed: visible };
+  }
+
+  return {
+    visible,
+    allowed: matchingRoles.some((role) =>
+      role.permissions.includes(actionPermission),
+    ),
+  };
+};
+
 const PERMISSION = {
   LOOTLOG_TIMERS_READ: "LOOTLOG_TIMERS_READ",
   LOOTLOG_TIMERS_TITANS_READ: "LOOTLOG_TIMERS_TITANS_READ",


### PR DESCRIPTION
## Summary

- add a pure strategic NPC access evaluator with one organization/world/role interface
- model NPC id, type, group, level, inclusion, and exclusion selectors
- require visibility and action permission on the same matching policy while preserving owner recovery authority
- keep all production call sites and deployed contracts unchanged

## Verification

- `pnpm --filter @lootlog/api test` (1016 tests)
- `pnpm turbo run build --filter=@lootlog/api...`
- `pnpm --filter @lootlog/api lint` (zero errors; existing warnings)
- `pnpm --filter @lootlog/api-helpers build`
- focused red/green policy and legacy helper tests

Tracks #1267 (delivery slice 1 of 3).
