### PR TITLE
feat: enforce strategic visibility on read paths

### DIFF
--- a/.changeset/clean-wolves-observe.md
+++ b/.changeset/clean-wolves-observe.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/api": patch
+---
+
+Apply the canonical strategic NPC visibility policy to timer and loot reads, including search, history, comments, statistics, and event summaries.

--- a/apps/api/src/events/events-catalog.controller.spec.ts
+++ b/apps/api/src/events/events-catalog.controller.spec.ts
@@ -79,6 +79,7 @@ describe("EventsCatalogController", () => {
     const roles = [{ id: "role-1" }];
 
     controller.getWrapped(
+      "viewer-1",
       guild as never,
       "event-1",
       roles as never,
@@ -87,6 +88,7 @@ describe("EventsCatalogController", () => {
 
     expect(mockEventsService.getWrapped).toHaveBeenCalledWith(
       guild,
+      "viewer-1",
       "event-1",
       permissions,
       roles,

--- a/apps/api/src/events/events-catalog.controller.ts
+++ b/apps/api/src/events/events-catalog.controller.ts
@@ -34,6 +34,7 @@ import { GuildData } from "src/shared/decorators/guild-data.decorator";
 import { MemberPermissions } from "src/shared/decorators/member-permissions.decorator";
 import { MemberRoles } from "src/shared/decorators/member-roles.decorator";
 import { AuthGuard } from "@lootlog/nest-shared";
+import { DiscordId } from "@lootlog/nest-shared/decorators";
 import { Permissions } from "src/shared/permissions/permissions.decorator";
 import { PermissionsGuard } from "src/shared/permissions/permissions.guard";
 
@@ -196,6 +197,7 @@ export class EventsCatalogController {
   })
   @ApiResponse({ status: 404, description: "Event not found" })
   getWrapped(
+    @DiscordId() viewerDiscordId: string,
     @GuildData() guildData: Guild,
     @Param("eventId") eventId: string,
     @MemberRoles() roles: Role[] = [],
@@ -203,6 +205,7 @@ export class EventsCatalogController {
   ) {
     return this.eventsService.getWrapped(
       guildData,
+      viewerDiscordId,
       eventId,
       permissions,
       roles,

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -86,11 +86,18 @@ export class EventsService {
 
   getWrapped(
     guild: Guild,
+    viewerDiscordId: string,
     eventId: string,
     permissions: Permission[],
     roles: Role[],
   ): Promise<EventWrappedResponseDto> {
-    return this.wrappedService.getWrapped(guild, eventId, permissions, roles);
+    return this.wrappedService.getWrapped(
+      guild,
+      viewerDiscordId,
+      eventId,
+      permissions,
+      roles,
+    );
   }
 
   updateEvent(guildId: string, eventId: string, data: UpdateEventDto) {

--- a/apps/api/src/events/services/event-wrapped.service.spec.ts
+++ b/apps/api/src/events/services/event-wrapped.service.spec.ts
@@ -126,7 +126,13 @@ describe("EventWrappedService", () => {
     };
     mockRedisService.getOrSetJsonBestEffort.mockResolvedValue(cachedResponse);
 
-    const result = await service.getWrapped(guild, "event-1", [], []);
+    const result = await service.getWrapped(
+      guild,
+      "viewer-1",
+      "event-1",
+      [],
+      [],
+    );
 
     expect(result).toEqual(cachedResponse);
     expect(mockPrismaService.event.findFirst).not.toHaveBeenCalled();
@@ -289,7 +295,13 @@ describe("EventWrappedService", () => {
       },
     ]);
 
-    const result = await service.getWrapped(guild, "event-1", [], []);
+    const result = await service.getWrapped(
+      guild,
+      "viewer-1",
+      "event-1",
+      [],
+      [],
+    );
 
     expect(result.event.name).toBe("Gwiazda");
     expect(result.overview.totalKills).toBe(2);

--- a/apps/api/src/events/services/event-wrapped.service.ts
+++ b/apps/api/src/events/services/event-wrapped.service.ts
@@ -116,6 +116,7 @@ export class EventWrappedService {
 
   getWrapped(
     guild: Guild,
+    viewerDiscordId: string,
     eventId: string,
     permissions: Permission[],
     roles: Role[],
@@ -123,7 +124,11 @@ export class EventWrappedService {
     const cacheKey = getEventWrappedCacheKey(
       guild.id,
       eventId,
-      this.buildVisibilityCacheScope(permissions, roles),
+      this.buildVisibilityCacheScope(
+        guild.ownerId === viewerDiscordId,
+        permissions,
+        roles,
+      ),
     );
 
     return this.redis.getOrSetJsonBestEffort({
@@ -132,12 +137,19 @@ export class EventWrappedService {
       onError: (error) =>
         this.logger.warn("Event wrapped cache unavailable", error),
       factory: () =>
-        this.getWrappedUncached(guild, eventId, permissions, roles),
+        this.getWrappedUncached(
+          guild,
+          viewerDiscordId,
+          eventId,
+          permissions,
+          roles,
+        ),
     });
   }
 
   private async getWrappedUncached(
     guild: Guild,
+    viewerDiscordId: string,
     eventId: string,
     permissions: Permission[],
     roles: Role[],
@@ -238,7 +250,7 @@ export class EventWrappedService {
         }) as Promise<AssignmentRow[]>,
         this.getEventLoots({
           guild,
-          permissions,
+          viewerDiscordId,
           roles,
           world: event.world,
           heroNames: event.heroNpcs.map((hero) => hero.npcName),
@@ -424,8 +436,13 @@ export class EventWrappedService {
     return response;
   }
 
-  private buildVisibilityCacheScope(permissions: Permission[], roles: Role[]) {
+  private buildVisibilityCacheScope(
+    isOwner: boolean,
+    permissions: Permission[],
+    roles: Role[],
+  ) {
     const visibilityScope = {
+      isOwner,
       permissions: [...permissions].sort(),
       roles: roles
         .map((role) => ({
@@ -465,7 +482,7 @@ export class EventWrappedService {
 
   private getEventLoots(params: {
     guild: Guild;
-    permissions: Permission[];
+    viewerDiscordId: string;
     roles: Role[];
     world: string;
     heroNames: string[];
@@ -482,7 +499,7 @@ export class EventWrappedService {
     ): Promise<LootQueryResult[]> => {
       const batch = await this.lootsService.fetchLootsByGuildId(
         params.guild,
-        params.permissions,
+        params.viewerDiscordId,
         params.roles,
         {
           limit: 100,

--- a/apps/api/src/loots/loots.controller.spec.ts
+++ b/apps/api/src/loots/loots.controller.spec.ts
@@ -23,6 +23,7 @@ import { LootsService } from "./loots.service";
 import { LootStatsService } from "./services/loot-stats.service";
 
 describe("LootsController", () => {
+  const viewerDiscordId = "viewer123";
   let controller: LootsController;
   let service: {
     createLoot: Mock;
@@ -184,7 +185,7 @@ describe("LootsController", () => {
       );
 
       expect(fetchLootsParamTypes[3]).toBe(FetchLootsParamsDto);
-      expect(getLootStatsParamTypes[1]).toBe(LootStatsQueryDto);
+      expect(getLootStatsParamTypes[3]).toBe(LootStatsQueryDto);
       expect(createLootParamTypes[2]).toBe(CreateLootDto);
       expect(createCommentParamTypes[2]).toBe(CreateCommentDto);
       expect(resolveLootItemParamTypes[3]).toBe(ResolveLootItemParamsDto);
@@ -278,7 +279,7 @@ describe("LootsController", () => {
       service.fetchLootsByGuildId.mockResolvedValue(mockLoots);
 
       const result = await controller.fetchLootsByGuildId(
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         mockGuild,
         params,
@@ -286,7 +287,7 @@ describe("LootsController", () => {
 
       expect(service.fetchLootsByGuildId).toHaveBeenCalledWith(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         params,
       );
@@ -297,7 +298,7 @@ describe("LootsController", () => {
       service.fetchLootsByGuildId.mockResolvedValue([]);
 
       const result = await controller.fetchLootsByGuildId(
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         mockGuild,
         params,
@@ -325,7 +326,7 @@ describe("LootsController", () => {
       service.resolveLootItemByHid.mockResolvedValue(mockItem);
 
       const result = await controller.resolveLootItemByHid(
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         mockGuild,
         query,
@@ -333,7 +334,7 @@ describe("LootsController", () => {
 
       expect(service.resolveLootItemByHid).toHaveBeenCalledWith(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         query,
       );
@@ -354,14 +355,14 @@ describe("LootsController", () => {
 
       const result = await controller.fetchLootById(
         lootId,
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         mockGuild,
       );
 
       expect(service.fetchLootById).toHaveBeenCalledWith(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        viewerDiscordId,
         [mockRole],
         lootId,
       );
@@ -392,11 +393,18 @@ describe("LootsController", () => {
       ];
       service.getComments.mockResolvedValue(mockComments as never);
 
-      const result = await controller.getComments(lootId, mockGuild);
+      const result = await controller.getComments(
+        lootId,
+        viewerDiscordId,
+        [mockRole],
+        mockGuild,
+      );
 
       expect(service.getComments).toHaveBeenCalledWith({
         lootId,
-        guildId: mockGuild.id,
+        guild: mockGuild,
+        viewerDiscordId,
+        roles: [mockRole],
       });
       expect(result).toEqual(mockComments);
     });

--- a/apps/api/src/loots/loots.controller.ts
+++ b/apps/api/src/loots/loots.controller.ts
@@ -33,7 +33,6 @@ import { UpdateLootDto } from "src/loots/dto/update-loot.dto";
 import { LootsService } from "src/loots/loots.service";
 import { LootStatsService } from "src/loots/services/loot-stats.service";
 import { GuildData } from "src/shared/decorators/guild-data.decorator";
-import { MemberPermissions } from "src/shared/decorators/member-permissions.decorator";
 import { MemberRoles } from "src/shared/decorators/member-roles.decorator";
 import { CountResponseDto } from "src/shared/dto/common-response.dto";
 import { LootCommentResponseDto } from "src/shared/dto/loot-comment-response.dto";
@@ -75,14 +74,14 @@ export class LootsController {
     description: "Forbidden - insufficient permissions",
   })
   fetchLootsByGuildId(
-    @MemberPermissions() permissions: Permission[],
+    @DiscordId() viewerDiscordId: string,
     @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
     @Query() query: FetchLootsParamsDto,
   ) {
     return this.lootsService.fetchLootsByGuildId(
       guild,
-      permissions,
+      viewerDiscordId,
       roles,
       query,
     );
@@ -107,9 +106,16 @@ export class LootsController {
     status: 403,
     description: "Forbidden - insufficient permissions",
   })
-  getLootStats(@GuildData() guild: Guild, @Query() query: LootStatsQueryDto) {
+  getLootStats(
+    @DiscordId() viewerDiscordId: string,
+    @MemberRoles() roles: Role[],
+    @GuildData() guild: Guild,
+    @Query() query: LootStatsQueryDto,
+  ) {
     return this.lootStatsService.getLootStats(
-      guild.id,
+      guild,
+      viewerDiscordId,
+      roles,
       query.period ?? "7d",
       query.world,
       query.npcTypes ? query.npcTypes.split(",") : undefined,
@@ -136,14 +142,14 @@ export class LootsController {
     description: "Forbidden - insufficient permissions",
   })
   async countLootsByGuildId(
-    @MemberPermissions() permissions: Permission[],
+    @DiscordId() viewerDiscordId: string,
     @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
     @Query() query: FetchLootsParamsDto,
   ) {
     const count = await this.lootsService.countLootsByGuildId(
       guild,
-      permissions,
+      viewerDiscordId,
       roles,
       {
         ...query,
@@ -174,15 +180,20 @@ export class LootsController {
     description: "Forbidden - insufficient permissions",
   })
   resolveLootItemByHid(
-    @MemberPermissions() permissions: Permission[],
+    @DiscordId() viewerDiscordId: string,
     @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
     @Query() query: ResolveLootItemParamsDto,
   ) {
-    return this.lootsService.resolveLootItemByHid(guild, permissions, roles, {
-      hid: query.hid,
-      world: query.world,
-    });
+    return this.lootsService.resolveLootItemByHid(
+      guild,
+      viewerDiscordId,
+      roles,
+      {
+        hid: query.hid,
+        world: query.world,
+      },
+    );
   }
 
   @Permissions(Permission.LOOTLOG_LOOTS_READ)
@@ -206,11 +217,16 @@ export class LootsController {
   @ApiResponse({ status: 404, description: "Loot not found" })
   fetchLootById(
     @Param("lootId", new ParseIntPipe()) lootId: number,
-    @MemberPermissions() permissions: Permission[],
+    @DiscordId() viewerDiscordId: string,
     @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
   ) {
-    return this.lootsService.fetchLootById(guild, permissions, roles, lootId);
+    return this.lootsService.fetchLootById(
+      guild,
+      viewerDiscordId,
+      roles,
+      lootId,
+    );
   }
 
   @Post("/loots")
@@ -252,11 +268,15 @@ export class LootsController {
   @ApiResponse({ status: 404, description: "Loot not found" })
   getComments(
     @Param("lootId", new ParseIntPipe()) lootId: number,
+    @DiscordId() viewerDiscordId: string,
+    @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
   ) {
     return this.lootsService.getComments({
       lootId,
-      guildId: guild.id,
+      guild,
+      viewerDiscordId,
+      roles,
     });
   }
 

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -930,7 +930,9 @@ describe("LootsService", () => {
 
   describe("getComments", () => {
     const options = {
-      guildId: "guild1",
+      guild: mockGuild,
+      viewerDiscordId: "viewer123",
+      roles: [] as Role[],
       lootId: 1,
     };
 
@@ -947,12 +949,13 @@ describe("LootsService", () => {
           },
         },
       ];
+      prismaService.loot.findFirst.mockResolvedValue({ id: options.lootId });
       prismaService.lootComment.findMany.mockResolvedValue(mockComments);
 
       const result = await service.getComments(options);
 
       expect(prismaService.lootComment.findMany).toHaveBeenCalledWith({
-        where: { guildId: options.guildId, lootId: options.lootId },
+        where: { guildId: options.guild.id, lootId: options.lootId },
         orderBy: { createdAt: "desc" },
         include: {
           member: {
@@ -969,6 +972,15 @@ describe("LootsService", () => {
         },
       });
       expect(result).toEqual(mockComments);
+    });
+
+    it("does not return comments when the loot is hidden", async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+
+      await expect(service.getComments(options)).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(prismaService.lootComment.findMany).not.toHaveBeenCalled();
     });
   });
 
@@ -1342,7 +1354,7 @@ describe("LootsService", () => {
 
       const result = await service.fetchLootsByGuildId(
         mockGuild,
-        [],
+        "viewer123",
         [],
         params,
       );
@@ -1376,7 +1388,7 @@ describe("LootsService", () => {
 
       const result = await service.fetchLootsByGuildId(
         mockGuild,
-        [],
+        "viewer123",
         [],
         params,
       );
@@ -1393,7 +1405,7 @@ describe("LootsService", () => {
 
       const result = await service.fetchLootsByGuildId(
         mockGuild,
-        [],
+        "viewer123",
         [],
         params,
       );
@@ -1405,7 +1417,7 @@ describe("LootsService", () => {
     it("should apply ranged loot filters to the Prisma query", async () => {
       prismaService.loot.findMany.mockResolvedValue([]);
 
-      await service.fetchLootsByGuildId(mockGuild, [], [], {
+      await service.fetchLootsByGuildId(mockGuild, "viewer123", [], {
         ...params,
         npcLevelMin: 10,
         npcLevelMax: 20,
@@ -1470,7 +1482,7 @@ describe("LootsService", () => {
     it("should apply item profession filters to the Prisma query", async () => {
       prismaService.loot.findMany.mockResolvedValue([]);
 
-      await service.fetchLootsByGuildId(mockGuild, [], [], {
+      await service.fetchLootsByGuildId(mockGuild, "viewer123", [], {
         ...params,
         professions: [Profession.HUNTER, Profession.TRACKER, "INVALID"],
       });
@@ -1517,7 +1529,7 @@ describe("LootsService", () => {
     it("should ignore invalid item profession filters", async () => {
       prismaService.loot.findMany.mockResolvedValue([]);
 
-      await service.fetchLootsByGuildId(mockGuild, [], [], {
+      await service.fetchLootsByGuildId(mockGuild, "viewer123", [], {
         ...params,
         professions: ["INVALID"],
       });
@@ -1544,7 +1556,7 @@ describe("LootsService", () => {
     it("should use item profession filters when counting loots", async () => {
       prismaService.loot.count.mockResolvedValue(0);
 
-      await service.countLootsByGuildId(mockGuild, [], [], {
+      await service.countLootsByGuildId(mockGuild, "viewer123", [], {
         ...params,
         professions: [Profession.HUNTER],
       });
@@ -1617,7 +1629,7 @@ describe("LootsService", () => {
 
       const result = await service.resolveLootItemByHid(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        "viewer123",
         [role],
         { hid: "abc123", world: "testworld" },
       );
@@ -1647,14 +1659,7 @@ describe("LootsService", () => {
                         expect.objectContaining({
                           AND: expect.arrayContaining([
                             {
-                              OR: expect.arrayContaining([
-                                { lvl: { gte: 10 } },
-                              ]),
-                            },
-                            {
-                              OR: expect.arrayContaining([
-                                { lvl: { lte: 60 } },
-                              ]),
+                              lvl: { gte: 10, lte: 60 },
                             },
                           ]),
                         }),
@@ -1689,7 +1694,7 @@ describe("LootsService", () => {
     it("should return null when HID is blank", async () => {
       const result = await service.resolveLootItemByHid(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        "viewer123",
         [role],
         { hid: "   ", world: "testworld" },
       );
@@ -1735,7 +1740,7 @@ describe("LootsService", () => {
 
       const result = await service.fetchLootById(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        "viewer123",
         [role],
         lootId,
       );
@@ -1758,23 +1763,15 @@ describe("LootsService", () => {
                         expect.objectContaining({
                           AND: expect.arrayContaining([
                             {
-                              OR: expect.arrayContaining([
-                                { lvl: { gte: 10 } },
-                              ]),
-                            },
-                            {
-                              OR: expect.arrayContaining([
-                                { lvl: { lte: 60 } },
-                              ]),
+                              lvl: { gte: 10, lte: 60 },
                             },
                             {
                               type: {
-                                not: NpcType.TITAN,
-                              },
-                            },
-                            {
-                              type: {
-                                notIn: [NpcType.HERO, NpcType.EVENT_HERO],
+                                notIn: [
+                                  NpcType.TITAN,
+                                  NpcType.HERO,
+                                  NpcType.EVENT_HERO,
+                                ],
                               },
                             },
                           ]),
@@ -1800,13 +1797,44 @@ describe("LootsService", () => {
 
       const result = await service.fetchLootById(
         mockGuild,
-        [Permission.LOOTLOG_LOOTS_READ],
+        "viewer123",
         [role],
         lootId,
       );
 
       expect(result).toBeNull();
       expect(prismaService.lootComment.count).not.toHaveBeenCalled();
+    });
+
+    it("does not let administrators bypass loot NPC visibility", async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+      const administratorRole = {
+        ...role,
+        permissions: [Permission.ADMIN],
+      };
+
+      await service.fetchLootById(
+        mockGuild,
+        "administrator123",
+        [administratorRole],
+        lootId,
+      );
+
+      expect(prismaService.loot.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            AND: expect.arrayContaining([
+              {
+                lootNpcs: {
+                  some: {
+                    npcSnapshot: { OR: [] },
+                  },
+                },
+              },
+            ]),
+          }),
+        }),
+      );
     });
   });
 });

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -229,12 +229,12 @@ export class LootsService implements OnModuleInit {
 
   private getLootsListCacheKey(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     params: FetchLootsParamsDto,
   ) {
     const visibilityScope = {
-      permissions: [...permissions].sort(),
+      isOwner: guild.ownerId === viewerDiscordId,
       roles: roles
         .map((role) => ({
           id: role.id,
@@ -660,8 +660,28 @@ export class LootsService implements OnModuleInit {
     }
   }
 
-  getComments(options: { guildId: string; lootId: number }) {
-    return this.lootCommentService.getComments(options);
+  async getComments(options: {
+    guild: Guild;
+    viewerDiscordId: string;
+    roles: Role[];
+    lootId: number;
+  }) {
+    const { guild, viewerDiscordId, roles, lootId } = options;
+    const visible = await this.lootQueryService.canViewLootById(
+      guild,
+      viewerDiscordId,
+      roles,
+      lootId,
+    );
+
+    if (!visible) {
+      throw new ForbiddenException();
+    }
+
+    return this.lootCommentService.getComments({
+      guildId: guild.id,
+      lootId,
+    });
   }
 
   async deleteLoot(options: { guildId: string; lootId: number }) {
@@ -824,7 +844,7 @@ export class LootsService implements OnModuleInit {
 
   async fetchLootsByGuildId(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     params: FetchLootsParamsDto,
   ) {
@@ -832,14 +852,14 @@ export class LootsService implements OnModuleInit {
       const loots = await this.redisService.getOrSetJsonBestEffort<
         CachedLootQueryResult[]
       >({
-        key: this.getLootsListCacheKey(guild, permissions, roles, params),
+        key: this.getLootsListCacheKey(guild, viewerDiscordId, roles, params),
         ttlSeconds: LOOTS_LIST_CACHE_TTL_SECONDS,
         onError: (error) =>
           this.logger.warn("Loots list cache unavailable", { error }),
         factory: () =>
           this.lootQueryService.fetchLootsByGuildId(
             guild,
-            permissions,
+            viewerDiscordId,
             roles,
             params,
           ),
@@ -850,7 +870,7 @@ export class LootsService implements OnModuleInit {
 
     return this.lootQueryService.fetchLootsByGuildId(
       guild,
-      permissions,
+      viewerDiscordId,
       roles,
       params,
     );
@@ -858,13 +878,13 @@ export class LootsService implements OnModuleInit {
 
   countLootsByGuildId(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     params: FetchLootsParamsDto,
   ) {
     return this.lootQueryService.countLootsByGuildId(
       guild,
-      permissions,
+      viewerDiscordId,
       roles,
       params,
     );
@@ -872,13 +892,13 @@ export class LootsService implements OnModuleInit {
 
   fetchLootById(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     lootId: number,
   ) {
     return this.lootQueryService.fetchLootById(
       guild,
-      permissions,
+      viewerDiscordId,
       roles,
       lootId,
     );
@@ -886,13 +906,13 @@ export class LootsService implements OnModuleInit {
 
   resolveLootItemByHid(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     options: { hid: string; world?: string },
   ) {
     return this.lootQueryService.resolveLootItemByHid(
       guild,
-      permissions,
+      viewerDiscordId,
       roles,
       options,
     );

--- a/apps/api/src/loots/services/loot-query.service.ts
+++ b/apps/api/src/loots/services/loot-query.service.ts
@@ -3,7 +3,6 @@ import { PrismaService } from "src/db/prisma.service";
 import {
   ItemRarity,
   NpcType,
-  Permission,
   Profession,
   type Guild,
   type Prisma,
@@ -15,7 +14,11 @@ import type { LootNpcDto } from "src/loots/dto/loot-npc.dto";
 import type { LootQueryResult } from "src/loots/dto/loot-query-result.dto";
 import { LootShareResponseSchema } from "src/shared/dto/loot-response.dto";
 import { DEFAULT_PAGE_LIMIT } from "../config/pagination";
-import { isAdministrativeUser } from "src/shared/permissions/is-administrative-user";
+import {
+  buildNpcSnapshotVisibilityWhere,
+  createStrategicAccessContext,
+  LOOT_VISIBILITY_PERMISSIONS,
+} from "src/shared/permissions/strategic-access-policy";
 import {
   getProfByShortname,
   getShortnameByProf,
@@ -54,7 +57,7 @@ export class LootQueryService {
 
   async fetchLootsByGuildId(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     {
       cursor = null,
@@ -84,26 +87,31 @@ export class LootQueryService {
       return [];
     }
 
-    const baseWhere = this.buildBaseWhereCondition(guild, permissions, roles, {
-      npcTypes,
-      npcs,
-      players,
-      rarities,
-      professions,
-      npcLevelMin,
-      npcLevelMax,
-      itemLevelMin,
-      itemLevelMax,
-      playerLevelMin,
-      playerLevelMax,
-      search,
-      world,
-      hid,
-      itemSnapshotIds,
-      cursor,
-      createdAtMin,
-      createdAtMax,
-    });
+    const baseWhere = this.buildBaseWhereCondition(
+      guild,
+      viewerDiscordId,
+      roles,
+      {
+        npcTypes,
+        npcs,
+        players,
+        rarities,
+        professions,
+        npcLevelMin,
+        npcLevelMax,
+        itemLevelMin,
+        itemLevelMax,
+        playerLevelMin,
+        playerLevelMax,
+        search,
+        world,
+        hid,
+        itemSnapshotIds,
+        cursor,
+        createdAtMin,
+        createdAtMax,
+      },
+    );
 
     const lootsWithRelations = await this.prisma.loot.findMany({
       where: baseWhere,
@@ -173,7 +181,7 @@ export class LootQueryService {
 
   async countLootsByGuildId(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     {
       npcTypes = [],
@@ -201,26 +209,31 @@ export class LootQueryService {
       return 0;
     }
 
-    const baseWhere = this.buildBaseWhereCondition(guild, permissions, roles, {
-      npcTypes,
-      npcs,
-      players,
-      rarities,
-      professions,
-      npcLevelMin,
-      npcLevelMax,
-      itemLevelMin,
-      itemLevelMax,
-      playerLevelMin,
-      playerLevelMax,
-      search,
-      world,
-      hid,
-      itemSnapshotIds,
-      cursor: null,
-      createdAtMin,
-      createdAtMax,
-    });
+    const baseWhere = this.buildBaseWhereCondition(
+      guild,
+      viewerDiscordId,
+      roles,
+      {
+        npcTypes,
+        npcs,
+        players,
+        rarities,
+        professions,
+        npcLevelMin,
+        npcLevelMax,
+        itemLevelMin,
+        itemLevelMax,
+        playerLevelMin,
+        playerLevelMax,
+        search,
+        world,
+        hid,
+        itemSnapshotIds,
+        cursor: null,
+        createdAtMin,
+        createdAtMax,
+      },
+    );
 
     return this.prisma.loot.count({
       where: baseWhere,
@@ -229,13 +242,18 @@ export class LootQueryService {
 
   async fetchLootById(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     lootId: number,
   ): Promise<LootQueryResult | null> {
-    const baseWhere = this.buildBaseWhereCondition(guild, permissions, roles, {
-      cursor: null,
-    });
+    const baseWhere = this.buildBaseWhereCondition(
+      guild,
+      viewerDiscordId,
+      roles,
+      {
+        cursor: null,
+      },
+    );
 
     const loot = await this.prisma.loot.findFirst({
       where: {
@@ -306,9 +324,32 @@ export class LootQueryService {
     };
   }
 
+  async canViewLootById(
+    guild: Guild,
+    viewerDiscordId: string,
+    roles: Role[],
+    lootId: number,
+  ): Promise<boolean> {
+    const baseWhere = this.buildBaseWhereCondition(
+      guild,
+      viewerDiscordId,
+      roles,
+      { cursor: null },
+    );
+    const loot = await this.prisma.loot.findFirst({
+      where: {
+        ...baseWhere,
+        id: lootId,
+      },
+      select: { id: true },
+    });
+
+    return loot !== null;
+  }
+
   async resolveLootItemByHid(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     options: { hid: string; world?: string },
   ): Promise<LootItemDto | null> {
@@ -318,11 +359,16 @@ export class LootQueryService {
       return null;
     }
 
-    const baseWhere = this.buildBaseWhereCondition(guild, permissions, roles, {
-      cursor: null,
-      hid,
-      world: options.world,
-    });
+    const baseWhere = this.buildBaseWhereCondition(
+      guild,
+      viewerDiscordId,
+      roles,
+      {
+        cursor: null,
+        hid,
+        world: options.world,
+      },
+    );
 
     const loot = await this.prisma.loot.findFirst({
       where: baseWhere,
@@ -369,7 +415,7 @@ export class LootQueryService {
 
   private buildBaseWhereCondition(
     guild: Guild,
-    permissions: Permission[],
+    viewerDiscordId: string,
     roles: Role[],
     {
       npcTypes = [],
@@ -411,15 +457,25 @@ export class LootQueryService {
       createdAtMax?: string;
     },
   ): Prisma.LootWhereInput {
-    const filteredRoles = roles.filter((role) =>
-      role.permissions.includes(Permission.LOOTLOG_LOOTS_READ),
+    const accessContext = createStrategicAccessContext({
+      organizationId: guild.id,
+      ownerId: guild.ownerId,
+      viewerDiscordId,
+      roles,
+    });
+    const npcSnapshotVisibilityWhere = buildNpcSnapshotVisibilityWhere(
+      accessContext,
+      LOOT_VISIBILITY_PERMISSIONS,
     );
-    const administrativeUser = isAdministrativeUser(permissions);
-
-    const levelRangesCondition = this.buildLevelRangesCondition(
-      filteredRoles,
-      administrativeUser,
-    );
+    const visibilityCondition = npcSnapshotVisibilityWhere
+      ? {
+          lootNpcs: {
+            some: {
+              npcSnapshot: npcSnapshotVisibilityWhere,
+            },
+          },
+        }
+      : null;
     const playersCondition = this.buildPlayersCondition(players);
     const npcsCondition = this.buildNpcsCondition(npcs);
     const npcTypesCondition = this.buildNpcTypesCondition(npcTypes);
@@ -470,7 +526,7 @@ export class LootQueryService {
       npcLevelsCondition,
       itemLevelsCondition,
       playerLevelsCondition,
-      levelRangesCondition,
+      visibilityCondition,
       searchCondition,
       hidCondition,
       itemSnapshotIdsCondition,
@@ -486,86 +542,6 @@ export class LootQueryService {
 
   private parseLootShare(lootShare: Prisma.JsonValue) {
     return LootShareResponseSchema.parse(lootShare);
-  }
-
-  private buildLevelRangesCondition(
-    filteredRoles: Role[],
-    administrativeUser: boolean,
-  ): Prisma.LootWhereInput | null {
-    if (filteredRoles.length === 0 || administrativeUser) {
-      return null;
-    }
-
-    const npcVisibilityPerRole: Prisma.NpcSnapshotWhereInput[] = [];
-
-    for (const role of filteredRoles) {
-      const roleCondition = this.buildRoleVisibilityCondition(role);
-      if (roleCondition) {
-        npcVisibilityPerRole.push(roleCondition);
-      }
-    }
-
-    if (npcVisibilityPerRole.length === 0) {
-      return null;
-    }
-
-    return {
-      lootNpcs: {
-        some: {
-          npcSnapshot: {
-            OR: npcVisibilityPerRole,
-          },
-        },
-      },
-    };
-  }
-
-  private buildRoleVisibilityCondition(
-    role: Role,
-  ): Prisma.NpcSnapshotWhereInput | null {
-    const hasReadTitans = role.permissions?.includes(
-      Permission.LOOTLOG_LOOTS_TITANS_READ,
-    );
-    const hasReadHeroes = role.permissions?.includes(
-      Permission.LOOTLOG_LOOTS_HEROES_READ,
-    );
-
-    const lvlFrom = Number(role.lvlRangeFrom ?? 0);
-    const lvlTo = Number(role.lvlRangeTo ?? 500);
-
-    const npcConstraints: Prisma.NpcSnapshotWhereInput[] = [];
-
-    npcConstraints.push({
-      OR: [{ lvl: { gte: lvlFrom } }, ...(lvlFrom <= 0 ? [{ lvl: null }] : [])],
-    });
-
-    npcConstraints.push({
-      OR: [{ lvl: { lte: lvlTo } }, ...(lvlTo >= 0 ? [{ lvl: null }] : [])],
-    });
-
-    if (!hasReadTitans) {
-      npcConstraints.push({
-        type: {
-          not: NpcType.TITAN,
-        },
-      });
-    }
-
-    if (!hasReadHeroes) {
-      npcConstraints.push({
-        type: {
-          notIn: [NpcType.HERO, NpcType.EVENT_HERO],
-        },
-      });
-    }
-
-    if (npcConstraints.length === 0) {
-      return null;
-    }
-
-    return {
-      AND: npcConstraints,
-    };
   }
 
   private buildPlayersCondition(

--- a/apps/api/src/loots/services/loot-stats.service.spec.ts
+++ b/apps/api/src/loots/services/loot-stats.service.spec.ts
@@ -1,0 +1,90 @@
+import type { Mock } from "vitest";
+import {
+  NpcType,
+  Permission,
+  type Guild,
+  type Role,
+} from "src/generated/prisma/client";
+import { LootStatsService } from "./loot-stats.service";
+
+const guild = {
+  id: "guild-1",
+  ownerId: "owner",
+} as Guild;
+
+const createRole = (permissions: Permission[]): Role =>
+  ({
+    id: "role-1",
+    guildId: guild.id,
+    permissions,
+    lvlRangeFrom: 10,
+    lvlRangeTo: 60,
+  }) as Role;
+
+describe("LootStatsService strategic visibility", () => {
+  let queryRawUnsafe: Mock;
+  let service: LootStatsService;
+
+  beforeEach(() => {
+    queryRawUnsafe = vi
+      .fn<() => Promise<unknown[]>>()
+      .mockResolvedValueOnce([
+        {
+          total_loots: 0n,
+          total_items: 0n,
+          legendary_items: 0n,
+          heroic_items: 0n,
+          avg_item_level: null,
+        },
+      ])
+      .mockResolvedValue([]);
+    const redis = {
+      getJson: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+      getOrSetJson: vi
+        .fn<
+          (options: { factory: () => Promise<unknown> }) => Promise<unknown>
+        >()
+        .mockImplementation((options) => options.factory()),
+      deleteByPattern: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+    };
+
+    service = new LootStatsService(
+      { $queryRawUnsafe: queryRawUnsafe } as never,
+      redis as never,
+    );
+  });
+
+  it("applies the same parameterized level and tier predicate to every aggregate", async () => {
+    await service.getLootStats(
+      guild,
+      "member",
+      [createRole([Permission.LOOTLOG_LOOTS_READ])],
+      "all",
+    );
+
+    expect(queryRawUnsafe).toHaveBeenCalledTimes(6);
+    for (const [query, guildId, levelFrom, levelTo] of queryRawUnsafe.mock
+      .calls) {
+      expect(query).toContain(
+        "AND ((ns.lvl BETWEEN $2 AND $3 AND ns.type NOT IN ('TITAN', 'HERO', 'EVENT_HERO')))",
+      );
+      expect([guildId, levelFrom, levelTo]).toEqual([guild.id, 10, 60]);
+    }
+  });
+
+  it("does not treat an administrator role as strategic data visibility", async () => {
+    await service.getLootStats(
+      guild,
+      "administrator",
+      [createRole([Permission.ADMIN])],
+      "all",
+      undefined,
+      [NpcType.TITAN],
+    );
+
+    expect(queryRawUnsafe).toHaveBeenCalledTimes(6);
+    for (const [query] of queryRawUnsafe.mock.calls) {
+      expect(query).toContain("AND FALSE");
+    }
+  });
+});

--- a/apps/api/src/loots/services/loot-stats.service.ts
+++ b/apps/api/src/loots/services/loot-stats.service.ts
@@ -1,7 +1,18 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { PrismaService } from "src/db/prisma.service";
 import { RedisService } from "@lootlog/nest-shared/redis";
-import { NpcType, type ItemRarity } from "src/generated/prisma/client";
+import {
+  NpcType,
+  type Guild,
+  type ItemRarity,
+  type Role,
+} from "src/generated/prisma/client";
+import type { NpcAccessContext } from "@lootlog/api-helpers/permissions";
+import {
+  buildNpcVisibilitySqlCondition,
+  createStrategicAccessContext,
+  LOOT_VISIBILITY_PERMISSIONS,
+} from "src/shared/permissions/strategic-access-policy";
 import type {
   Period,
   LootStatsResponse,
@@ -42,14 +53,23 @@ export class LootStatsService {
   }
 
   async getLootStats(
-    guildId: string,
+    guild: Guild,
+    viewerDiscordId: string,
+    roles: Role[],
     period: Period = "7d",
     world?: string,
     npcTypes?: string[],
     excludeColossus?: boolean,
   ): Promise<LootStatsResponse> {
+    const accessContext = createStrategicAccessContext({
+      organizationId: guild.id,
+      ownerId: guild.ownerId,
+      viewerDiscordId,
+      roles,
+    });
     const cacheKey = this.buildCacheKey(
-      guildId,
+      guild.id,
+      accessContext,
       period,
       world,
       npcTypes,
@@ -84,21 +104,24 @@ export class LootStatsService {
           topItems,
         ] = await Promise.all([
           this.getOverview(
-            guildId,
+            guild.id,
+            accessContext,
             dateFrom,
             world,
             npcTypeFilter,
             excludeColossus,
           ),
           this.getByRarity(
-            guildId,
+            guild.id,
+            accessContext,
             dateFrom,
             world,
             npcTypeFilter,
             excludeColossus,
           ),
           this.getTimeline(
-            guildId,
+            guild.id,
+            accessContext,
             dateFrom,
             period,
             world,
@@ -106,21 +129,24 @@ export class LootStatsService {
             excludeColossus,
           ),
           this.getTopNpcs(
-            guildId,
+            guild.id,
+            accessContext,
             dateFrom,
             world,
             npcTypeFilter,
             excludeColossus,
           ),
           this.getTopContributors(
-            guildId,
+            guild.id,
+            accessContext,
             dateFrom,
             world,
             npcTypeFilter,
             excludeColossus,
           ),
           this.getTopLegendaryItems(
-            guildId,
+            guild.id,
+            accessContext,
             dateFrom,
             world,
             npcTypeFilter,
@@ -142,12 +168,27 @@ export class LootStatsService {
 
   private buildCacheKey(
     guildId: string,
+    accessContext: NpcAccessContext,
     period: Period,
     world?: string,
     npcTypes?: string[],
     excludeColossus?: boolean,
   ): string {
-    const parts = ["loot-stats", guildId, period];
+    const visibilityScope = Buffer.from(
+      JSON.stringify({
+        isOwner: accessContext.isOwner,
+        roles: accessContext.roles
+          .map((role) => ({
+            permissions: [...role.permissions].sort(),
+            npc: role.npc,
+            worlds: role.worlds ? [...role.worlds].sort() : undefined,
+          }))
+          .sort((leftRole, rightRole) =>
+            JSON.stringify(leftRole).localeCompare(JSON.stringify(rightRole)),
+          ),
+      }),
+    ).toString("base64url");
+    const parts = ["loot-stats", guildId, visibilityScope, period];
     if (world) parts.push(world);
     if (npcTypes?.length) parts.push(npcTypes.sort().join(","));
     if (excludeColossus) parts.push("no-colossus");
@@ -159,6 +200,7 @@ export class LootStatsService {
     world?: string,
     npcTypes?: NpcType[],
     excludeColossus?: boolean,
+    requiresNpcVisibility = false,
   ) {
     const dateParamIndex = this.getDateFilterParamIndex();
     const worldParamIndex = this.getWorldFilterParamIndex(dateFrom);
@@ -176,7 +218,11 @@ export class LootStatsService {
     const excludeColossusCondition = excludeColossus
       ? `AND ns.type != 'COLOSSUS'`
       : "";
-    const needsNpcFilter = !!(npcTypes?.length || excludeColossus);
+    const needsNpcFilter = !!(
+      npcTypes?.length ||
+      excludeColossus ||
+      requiresNpcVisibility
+    );
 
     return {
       dateCondition,
@@ -226,6 +272,20 @@ export class LootStatsService {
     return params;
   }
 
+  private appendVisibilityCondition(
+    params: (string | Date | string[] | number)[],
+    accessContext: NpcAccessContext,
+  ): string {
+    const visibilityCondition = buildNpcVisibilitySqlCondition(
+      accessContext,
+      LOOT_VISIBILITY_PERMISSIONS,
+      "ns",
+      params.length + 1,
+    );
+    params.push(...visibilityCondition.params);
+    return visibilityCondition.sql;
+  }
+
   private getDateFromPeriod(period: Period): Date | null {
     if (period === "all") return null;
 
@@ -246,6 +306,7 @@ export class LootStatsService {
 
   private async getOverview(
     guildId: string,
+    accessContext: NpcAccessContext,
     dateFrom: Date | null,
     world?: string,
     npcTypes?: NpcType[],
@@ -257,8 +318,18 @@ export class LootStatsService {
       npcTypeCondition,
       excludeColossusCondition,
       needsNpcFilter,
-    } = this.buildFilterConditions(dateFrom, world, npcTypes, excludeColossus);
+    } = this.buildFilterConditions(
+      dateFrom,
+      world,
+      npcTypes,
+      excludeColossus,
+      !accessContext.isOwner,
+    );
     const params = this.buildFilterParams(guildId, dateFrom, world, npcTypes);
+    const visibilityCondition = this.appendVisibilityCondition(
+      params,
+      accessContext,
+    );
 
     const result = await this.prisma.$queryRawUnsafe<
       Array<{
@@ -283,6 +354,7 @@ export class LootStatsService {
           ${worldCondition}
           ${npcTypeCondition}
           ${excludeColossusCondition}
+          ${visibilityCondition}
         )
         SELECT
           COUNT(DISTINCT l.id) as total_loots,
@@ -327,6 +399,7 @@ export class LootStatsService {
 
   private async getByRarity(
     guildId: string,
+    accessContext: NpcAccessContext,
     dateFrom: Date | null,
     world?: string,
     npcTypes?: NpcType[],
@@ -338,8 +411,18 @@ export class LootStatsService {
       npcTypeCondition,
       excludeColossusCondition,
       needsNpcFilter,
-    } = this.buildFilterConditions(dateFrom, world, npcTypes, excludeColossus);
+    } = this.buildFilterConditions(
+      dateFrom,
+      world,
+      npcTypes,
+      excludeColossus,
+      !accessContext.isOwner,
+    );
     const params = this.buildFilterParams(guildId, dateFrom, world, npcTypes);
+    const visibilityCondition = this.appendVisibilityCondition(
+      params,
+      accessContext,
+    );
 
     const result = await this.prisma.$queryRawUnsafe<
       Array<{
@@ -361,6 +444,7 @@ export class LootStatsService {
           ${worldCondition}
           ${npcTypeCondition}
           ${excludeColossusCondition}
+          ${visibilityCondition}
         )
         SELECT
           isnap.rarity,
@@ -405,6 +489,7 @@ export class LootStatsService {
 
   private async getTimeline(
     guildId: string,
+    accessContext: NpcAccessContext,
     dateFrom: Date | null,
     period: Period,
     world?: string,
@@ -417,9 +502,19 @@ export class LootStatsService {
       npcTypeCondition,
       excludeColossusCondition,
       needsNpcFilter,
-    } = this.buildFilterConditions(dateFrom, world, npcTypes, excludeColossus);
+    } = this.buildFilterConditions(
+      dateFrom,
+      world,
+      npcTypes,
+      excludeColossus,
+      !accessContext.isOwner,
+    );
     const truncUnit = this.getTimelineTruncUnit(period);
     const params = this.buildFilterParams(guildId, dateFrom, world, npcTypes);
+    const visibilityCondition = this.appendVisibilityCondition(
+      params,
+      accessContext,
+    );
 
     const result = await this.prisma.$queryRawUnsafe<
       Array<{
@@ -442,6 +537,7 @@ export class LootStatsService {
           ${worldCondition}
           ${npcTypeCondition}
           ${excludeColossusCondition}
+          ${visibilityCondition}
         )
         SELECT
           date_trunc('${truncUnit}', vl."createdAt") as date,
@@ -520,6 +616,7 @@ export class LootStatsService {
 
   private async getTopNpcs(
     guildId: string,
+    accessContext: NpcAccessContext,
     dateFrom: Date | null,
     world?: string,
     npcTypes?: NpcType[],
@@ -534,6 +631,10 @@ export class LootStatsService {
     } = this.buildFilterConditions(dateFrom, world, npcTypes, excludeColossus);
     const params: (string | Date | string[] | number)[] =
       this.buildFilterParams(guildId, dateFrom, world, npcTypes);
+    const visibilityCondition = this.appendVisibilityCondition(
+      params,
+      accessContext,
+    );
     const limitParamIndex = params.length + 1;
     params.push(limit);
 
@@ -582,6 +683,7 @@ export class LootStatsService {
         ${worldCondition}
         ${npcTypeCondition}
         ${excludeColossusCondition}
+        ${visibilityCondition}
       )
       SELECT
         rn."npcId" as npc_id,
@@ -621,6 +723,7 @@ export class LootStatsService {
 
   private async getTopContributors(
     guildId: string,
+    accessContext: NpcAccessContext,
     dateFrom: Date | null,
     world?: string,
     npcTypes?: NpcType[],
@@ -633,9 +736,19 @@ export class LootStatsService {
       npcTypeCondition,
       excludeColossusCondition,
       needsNpcFilter,
-    } = this.buildFilterConditions(dateFrom, world, npcTypes, excludeColossus);
+    } = this.buildFilterConditions(
+      dateFrom,
+      world,
+      npcTypes,
+      excludeColossus,
+      !accessContext.isOwner,
+    );
     const params: (string | Date | string[] | number)[] =
       this.buildFilterParams(guildId, dateFrom, world, npcTypes);
+    const visibilityCondition = this.appendVisibilityCondition(
+      params,
+      accessContext,
+    );
     const limitParamIndex = params.length + 1;
     params.push(limit);
 
@@ -666,6 +779,7 @@ export class LootStatsService {
           ${worldCondition}
           ${npcTypeCondition}
           ${excludeColossusCondition}
+          ${visibilityCondition}
         )
         SELECT
           m.id as member_id,
@@ -731,6 +845,7 @@ export class LootStatsService {
 
   private async getTopLegendaryItems(
     guildId: string,
+    accessContext: NpcAccessContext,
     dateFrom: Date | null,
     world?: string,
     npcTypes?: NpcType[],
@@ -745,6 +860,10 @@ export class LootStatsService {
     } = this.buildFilterConditions(dateFrom, world, npcTypes, excludeColossus);
     const params: (string | Date | string[] | number)[] =
       this.buildFilterParams(guildId, dateFrom, world, npcTypes);
+    const visibilityCondition = this.appendVisibilityCondition(
+      params,
+      accessContext,
+    );
     const limitParamIndex = params.length + 1;
     params.push(limit);
 
@@ -787,6 +906,7 @@ export class LootStatsService {
         ${worldCondition}
         ${npcTypeCondition}
         ${excludeColossusCondition}
+        ${visibilityCondition}
       )
       SELECT
         isnap."itemId" as item_id,

--- a/apps/api/src/shared/permissions/strategic-access-policy.spec.ts
+++ b/apps/api/src/shared/permissions/strategic-access-policy.spec.ts
@@ -1,0 +1,110 @@
+import { NpcType, Permission } from "src/generated/prisma/client";
+import {
+  buildNpcSnapshotVisibilityWhere,
+  buildNpcVisibilitySqlCondition,
+  canViewStrategicNpc,
+  createStrategicAccessContext,
+  LOOT_VISIBILITY_PERMISSIONS,
+} from "./strategic-access-policy";
+
+const createRole = (options?: {
+  permissions?: Permission[];
+  lvlRangeFrom?: number | null;
+  lvlRangeTo?: number | null;
+}) => ({
+  permissions: options?.permissions ?? [Permission.LOOTLOG_LOOTS_READ],
+  lvlRangeFrom: options?.lvlRangeFrom ?? 1,
+  lvlRangeTo: options?.lvlRangeTo ?? 500,
+});
+
+describe("strategic access policy adapter", () => {
+  it("derives owner authority from identity instead of expanded permissions", () => {
+    const administrator = createStrategicAccessContext({
+      organizationId: "guild-1",
+      ownerId: "owner",
+      viewerDiscordId: "administrator",
+      roles: [createRole({ permissions: [Permission.ADMIN] })],
+    });
+    const owner = createStrategicAccessContext({
+      organizationId: "guild-1",
+      ownerId: "owner",
+      viewerDiscordId: "owner",
+      roles: [],
+    });
+    const titan = {
+      organizationId: "guild-1",
+      world: "Aether",
+      npc: {
+        id: 100,
+        type: NpcType.TITAN,
+        group: null,
+        level: 300,
+      },
+    };
+
+    expect(
+      canViewStrategicNpc(administrator, titan, LOOT_VISIBILITY_PERMISSIONS),
+    ).toBe(false);
+    expect(canViewStrategicNpc(owner, titan, LOOT_VISIBILITY_PERMISSIONS)).toBe(
+      true,
+    );
+  });
+
+  it("builds the same role-local level and tier restrictions for Prisma", () => {
+    const context = createStrategicAccessContext({
+      organizationId: "guild-1",
+      ownerId: "owner",
+      viewerDiscordId: "member",
+      roles: [
+        createRole({
+          permissions: [
+            Permission.LOOTLOG_LOOTS_READ,
+            Permission.LOOTLOG_LOOTS_TITANS_READ,
+          ],
+          lvlRangeFrom: 250,
+          lvlRangeTo: 350,
+        }),
+      ],
+    });
+
+    expect(
+      buildNpcSnapshotVisibilityWhere(context, LOOT_VISIBILITY_PERMISSIONS),
+    ).toEqual({
+      OR: [
+        {
+          AND: [
+            { lvl: { gte: 250, lte: 350 } },
+            { type: { notIn: [NpcType.HERO, NpcType.EVENT_HERO] } },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parameterizes level ranges in the raw SQL condition", () => {
+    const context = createStrategicAccessContext({
+      organizationId: "guild-1",
+      ownerId: "owner",
+      viewerDiscordId: "member",
+      roles: [
+        createRole({
+          permissions: [Permission.LOOTLOG_LOOTS_READ],
+          lvlRangeFrom: 10,
+          lvlRangeTo: 60,
+        }),
+      ],
+    });
+
+    expect(
+      buildNpcVisibilitySqlCondition(
+        context,
+        LOOT_VISIBILITY_PERMISSIONS,
+        "ns",
+        4,
+      ),
+    ).toEqual({
+      sql: "AND ((ns.lvl BETWEEN $4 AND $5 AND ns.type NOT IN ('TITAN', 'HERO', 'EVENT_HERO')))",
+      params: [10, 60],
+    });
+  });
+});

--- a/apps/api/src/shared/permissions/strategic-access-policy.ts
+++ b/apps/api/src/shared/permissions/strategic-access-policy.ts
@@ -1,0 +1,255 @@
+import {
+  evaluateNpcAccess,
+  type NpcAccessContext,
+  type NpcResource,
+  type NpcVisibilityPermissions,
+} from "@lootlog/api-helpers/permissions";
+import { NpcType, Permission, type Prisma } from "src/generated/prisma/client";
+
+type StrategicRole = {
+  permissions: readonly Permission[];
+  lvlRangeFrom: number | null;
+  lvlRangeTo: number | null;
+};
+
+type CreateStrategicAccessContextOptions = {
+  organizationId: string;
+  ownerId: string;
+  viewerDiscordId: string;
+  roles: readonly StrategicRole[];
+};
+
+export const TIMER_VISIBILITY_PERMISSIONS = {
+  base: Permission.LOOTLOG_TIMERS_READ,
+  heroes: Permission.LOOTLOG_TIMERS_HEROES_READ,
+  titans: Permission.LOOTLOG_TIMERS_TITANS_READ,
+} satisfies NpcVisibilityPermissions;
+
+export const LOOT_VISIBILITY_PERMISSIONS = {
+  base: Permission.LOOTLOG_LOOTS_READ,
+  heroes: Permission.LOOTLOG_LOOTS_HEROES_READ,
+  titans: Permission.LOOTLOG_LOOTS_TITANS_READ,
+} satisfies NpcVisibilityPermissions;
+
+const DEFAULT_LEVEL_RANGE_FROM = 0;
+const DEFAULT_LEVEL_RANGE_TO = 500;
+
+export const createStrategicAccessContext = ({
+  organizationId,
+  ownerId,
+  viewerDiscordId,
+  roles,
+}: CreateStrategicAccessContextOptions): NpcAccessContext => ({
+  organizationId,
+  isOwner: ownerId === viewerDiscordId,
+  roles: roles.map((role) => ({
+    permissions: role.permissions,
+    npc: {
+      levelRange: {
+        from: role.lvlRangeFrom ?? DEFAULT_LEVEL_RANGE_FROM,
+        to: role.lvlRangeTo ?? DEFAULT_LEVEL_RANGE_TO,
+      },
+    },
+  })),
+});
+
+export const canViewStrategicNpc = (
+  context: NpcAccessContext,
+  resource: NpcResource,
+  visibilityPermissions: NpcVisibilityPermissions,
+): boolean =>
+  evaluateNpcAccess({ context, resource, visibilityPermissions }).visible;
+
+const getVisibleRoles = (
+  context: NpcAccessContext,
+  visibilityPermissions: NpcVisibilityPermissions,
+) =>
+  context.roles.filter((role) =>
+    role.permissions.includes(visibilityPermissions.base),
+  );
+
+const getExcludedNpcTypes = (
+  permissions: readonly string[],
+  visibilityPermissions: NpcVisibilityPermissions,
+): NpcType[] => {
+  const excludedTypes: NpcType[] = [];
+
+  if (!permissions.includes(visibilityPermissions.titans)) {
+    excludedTypes.push(NpcType.TITAN);
+  }
+
+  if (!permissions.includes(visibilityPermissions.heroes)) {
+    excludedTypes.push(NpcType.HERO, NpcType.EVENT_HERO);
+  }
+
+  return excludedTypes;
+};
+
+export const buildNpcSnapshotVisibilityWhere = (
+  context: NpcAccessContext,
+  visibilityPermissions: NpcVisibilityPermissions,
+): Prisma.NpcSnapshotWhereInput | null => {
+  if (context.isOwner) {
+    return null;
+  }
+
+  const roleConditions = getVisibleRoles(context, visibilityPermissions).map(
+    (role): Prisma.NpcSnapshotWhereInput => {
+      const levelRange = role.npc?.levelRange ?? {
+        from: DEFAULT_LEVEL_RANGE_FROM,
+        to: DEFAULT_LEVEL_RANGE_TO,
+      };
+      const excludedTypes = getExcludedNpcTypes(
+        role.permissions,
+        visibilityPermissions,
+      );
+      const conditions: Prisma.NpcSnapshotWhereInput[] = [
+        {
+          lvl: {
+            gte: levelRange.from,
+            lte: levelRange.to,
+          },
+        },
+      ];
+
+      if (excludedTypes.length > 0) {
+        conditions.push({ type: { notIn: excludedTypes } });
+      }
+
+      return { AND: conditions };
+    },
+  );
+
+  return { OR: roleConditions };
+};
+
+export const buildNpcJsonVisibilityWhere = (
+  context: NpcAccessContext,
+  visibilityPermissions: NpcVisibilityPermissions,
+) => {
+  if (context.isOwner) {
+    return null;
+  }
+
+  const roleConditions = getVisibleRoles(context, visibilityPermissions).map(
+    (role) => {
+      const levelRange = role.npc?.levelRange ?? {
+        from: DEFAULT_LEVEL_RANGE_FROM,
+        to: DEFAULT_LEVEL_RANGE_TO,
+      };
+      const excludedTypes = getExcludedNpcTypes(
+        role.permissions,
+        visibilityPermissions,
+      );
+      const conditions = [
+        { npc: { path: ["lvl"], gte: levelRange.from } },
+        { npc: { path: ["lvl"], lte: levelRange.to } },
+        ...excludedTypes.map((npcType) => ({
+          npc: { path: ["type"], not: npcType },
+        })),
+      ];
+
+      return { AND: conditions };
+    },
+  );
+
+  return { OR: roleConditions };
+};
+
+export const buildNpcVisibilitySqlCondition = (
+  context: NpcAccessContext,
+  visibilityPermissions: NpcVisibilityPermissions,
+  tableAlias: string,
+  firstParameterIndex: number,
+): { sql: string; params: number[] } => {
+  if (!/^[a-z][a-z0-9_]*$/.test(tableAlias)) {
+    throw new Error("Invalid SQL table alias");
+  }
+
+  if (context.isOwner) {
+    return { sql: "", params: [] };
+  }
+
+  const params: number[] = [];
+  const roleConditions = getVisibleRoles(context, visibilityPermissions).map(
+    (role) => {
+      const levelRange = role.npc?.levelRange ?? {
+        from: DEFAULT_LEVEL_RANGE_FROM,
+        to: DEFAULT_LEVEL_RANGE_TO,
+      };
+      const levelFromParameter = firstParameterIndex + params.length;
+      params.push(levelRange.from);
+      const levelToParameter = firstParameterIndex + params.length;
+      params.push(levelRange.to);
+      const excludedTypes = getExcludedNpcTypes(
+        role.permissions,
+        visibilityPermissions,
+      );
+      const typeCondition = excludedTypes.length
+        ? ` AND ${tableAlias}.type NOT IN (${excludedTypes
+            .map((npcType) => `'${npcType}'`)
+            .join(", ")})`
+        : "";
+
+      return `(${tableAlias}.lvl BETWEEN $${levelFromParameter} AND $${levelToParameter}${typeCondition})`;
+    },
+  );
+
+  if (roleConditions.length === 0) {
+    return { sql: "AND FALSE", params };
+  }
+
+  return {
+    sql: `AND (${roleConditions.join(" OR ")})`,
+    params,
+  };
+};
+
+export const buildNpcJsonVisibilitySqlCondition = (
+  context: NpcAccessContext,
+  visibilityPermissions: NpcVisibilityPermissions,
+  tableAlias: string,
+  firstParameterIndex: number,
+): { sql: string; params: number[] } => {
+  if (!/^[a-z][a-z0-9_]*$/.test(tableAlias)) {
+    throw new Error("Invalid SQL table alias");
+  }
+
+  if (context.isOwner) {
+    return { sql: "", params: [] };
+  }
+
+  const params: number[] = [];
+  const roleConditions = getVisibleRoles(context, visibilityPermissions).map(
+    (role) => {
+      const levelRange = role.npc?.levelRange ?? {
+        from: DEFAULT_LEVEL_RANGE_FROM,
+        to: DEFAULT_LEVEL_RANGE_TO,
+      };
+      const levelFromParameter = firstParameterIndex + params.length;
+      params.push(levelRange.from);
+      const levelToParameter = firstParameterIndex + params.length;
+      params.push(levelRange.to);
+      const excludedTypes = getExcludedNpcTypes(
+        role.permissions,
+        visibilityPermissions,
+      );
+      const typeCondition = excludedTypes.length
+        ? ` AND ${tableAlias}."npc"->>'type' NOT IN (${excludedTypes
+            .map((npcType) => `'${npcType}'`)
+            .join(", ")})`
+        : "";
+
+      return `((${tableAlias}."npc"->>'lvl')::int BETWEEN $${levelFromParameter} AND $${levelToParameter}${typeCondition})`;
+    },
+  );
+
+  if (roleConditions.length === 0) {
+    return { sql: "AND FALSE", params };
+  }
+
+  return {
+    sql: `AND (${roleConditions.join(" OR ")})`,
+    params,
+  };
+};

--- a/apps/api/src/timers/timers.controller.ts
+++ b/apps/api/src/timers/timers.controller.ts
@@ -21,7 +21,6 @@ import { DiscordId, UserId } from "@lootlog/nest-shared/decorators";
 import { ZodResponse } from "nestjs-zod";
 import { type Guild, Permission, type Role } from "src/generated/prisma/client";
 import { GuildData } from "src/shared/decorators/guild-data.decorator";
-import { MemberPermissions } from "src/shared/decorators/member-permissions.decorator";
 import { MemberRoles } from "src/shared/decorators/member-roles.decorator";
 import { TimerResponseDto } from "src/shared/dto/timer-response.dto";
 import { AuthGuard } from "@lootlog/nest-shared";
@@ -117,15 +116,15 @@ export class TimersController {
   getTimers(
     @Query("world") world: string,
     @UserId() userId: string,
-    @MemberPermissions() permissions: Permission[],
+    @DiscordId() viewerDiscordId: string,
     @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
   ) {
     return this.timersService.getTimers(
       userId,
+      viewerDiscordId,
       { world },
       guild,
-      permissions,
       roles,
     );
   }
@@ -160,11 +159,15 @@ export class TimersController {
     description: "Forbidden - insufficient permissions",
   })
   searchNpcsWithTimerData(
-    @Param("guildId") guildId: string,
+    @DiscordId() viewerDiscordId: string,
+    @MemberRoles() roles: Role[],
+    @GuildData() guild: Guild,
     @Query() query: SearchTimersNpcsDto,
   ) {
     return this.timersService.searchNpcsWithTimerData(
-      guildId,
+      guild,
+      viewerDiscordId,
+      roles,
       query.world,
       query.search,
       query.limit,
@@ -289,14 +292,14 @@ export class TimersController {
   getTimerHistory(
     @Query("world") world: string,
     @Query("limit") limit: string | undefined,
-    @Param("guildId") guildId: string,
     @Param("timerIdentifier") timerIdentifier: string,
-    @MemberPermissions() permissions: Permission[],
+    @DiscordId() viewerDiscordId: string,
     @MemberRoles() roles: Role[],
+    @GuildData() guild: Guild,
   ) {
-    return this.timersService.getTimerHistory(guildId, world, timerIdentifier, {
+    return this.timersService.getTimerHistory(guild, world, timerIdentifier, {
       limit: limit ? Number.parseInt(limit, 10) : undefined,
-      permissions,
+      viewerDiscordId,
       roles,
     });
   }

--- a/apps/api/src/timers/timers.service.spec.ts
+++ b/apps/api/src/timers/timers.service.spec.ts
@@ -51,6 +51,7 @@ describe("TimersService", () => {
     },
     $transaction: mockFn(),
     $queryRaw: mockFn(),
+    $queryRawUnsafe: mockFn(),
   };
 
   const mockAmqpConnection = {
@@ -1410,7 +1411,7 @@ describe("TimersService", () => {
 
     it("returns actor character data from the timers API", async () => {
       mockGuildsService.getGuildsForRequiredPermissions.mockResolvedValue([
-        { id: "guild1" },
+        { id: "guild1", ownerId: "discord123" },
       ]);
       mockGuildsService.getMultipleGuildsPermissions.mockResolvedValue([
         {
@@ -1442,7 +1443,7 @@ describe("TimersService", () => {
 
     it("filters active timers by default", async () => {
       mockGuildsService.getGuildsForRequiredPermissions.mockResolvedValue([
-        { id: "guild1" },
+        { id: "guild1", ownerId: "discord123" },
       ]);
       mockGuildsService.getMultipleGuildsPermissions.mockResolvedValue([
         {
@@ -1549,7 +1550,7 @@ describe("TimersService", () => {
       const deletedAt = new Date("2026-05-03T08:15:00.000Z");
 
       mockGuildsService.getGuildsForRequiredPermissions.mockResolvedValue([
-        { id: "guild1" },
+        { id: "guild1", ownerId: "discord123" },
       ]);
       mockGuildsService.getMultipleGuildsPermissions.mockResolvedValue([
         {
@@ -1587,9 +1588,9 @@ describe("TimersService", () => {
 
       const result = await service.getTimers(
         "user123",
+        "discord123",
         { world: "test-world" },
-        { id: "guild1" } as never,
-        [Permission.OWNER],
+        { id: "guild1", ownerId: "discord123" } as never,
         [],
       );
 
@@ -1606,6 +1607,26 @@ describe("TimersService", () => {
       });
       expect(mockPrismaService.timer.findMany).not.toHaveBeenCalled();
       expect(mockRedisService.getOrSetJson).not.toHaveBeenCalled();
+    });
+
+    it("does not let administrators bypass timer NPC visibility", async () => {
+      mockRedisService.getJson.mockResolvedValue([timer]);
+
+      const result = await service.getTimers(
+        "user123",
+        "administrator123",
+        { world: "test-world" },
+        { id: "guild1", ownerId: "owner123" } as never,
+        [
+          {
+            permissions: [Permission.ADMIN],
+            lvlRangeFrom: 1,
+            lvlRangeTo: 500,
+          },
+        ] as never,
+      );
+
+      expect(result).toEqual([]);
     });
 
     it("returns guild name in timer history responses", async () => {
@@ -1637,11 +1658,11 @@ describe("TimersService", () => {
       ]);
 
       const result = await service.getTimerHistory(
-        "guild1",
+        { id: "guild1", ownerId: "discord123" } as never,
         "test-world",
         timer.timerKey,
         {
-          permissions: [Permission.OWNER],
+          viewerDiscordId: "discord123",
           roles: [],
         },
       );
@@ -1654,7 +1675,7 @@ describe("TimersService", () => {
 
     it("returns recent history for the requested accessible guild only", async () => {
       mockGuildsService.getGuildsForRequiredPermissions.mockResolvedValue([
-        { id: "guild1" },
+        { id: "guild1", ownerId: "discord123" },
         { id: "guild2" },
       ]);
       mockGuildsService.getMultipleGuildsPermissions.mockResolvedValue([
@@ -1887,18 +1908,20 @@ describe("TimersService", () => {
     ];
 
     it("should search NPCs with timer data", async () => {
-      mockPrismaService.$queryRaw = mockFn<
+      mockPrismaService.$queryRawUnsafe = mockFn<
         () => Promise<unknown>
       >().mockResolvedValue(mockTimersQueryResult);
 
       const result = await service.searchNpcsWithTimerData(
-        "guild1",
+        { id: "guild1", ownerId: "discord123" } as never,
+        "discord123",
+        [],
         "test-world",
         "Test",
         10,
       );
 
-      expect(mockPrismaService.$queryRaw).toHaveBeenCalled();
+      expect(mockPrismaService.$queryRawUnsafe).toHaveBeenCalled();
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual({
         npcId: 123,
@@ -1916,10 +1939,12 @@ describe("TimersService", () => {
     });
 
     it("should handle empty search results", async () => {
-      mockPrismaService.$queryRaw = mockFn().mockResolvedValue([]);
+      mockPrismaService.$queryRawUnsafe = mockFn().mockResolvedValue([]);
 
       const result = await service.searchNpcsWithTimerData(
-        "guild1",
+        { id: "guild1", ownerId: "discord123" } as never,
+        "discord123",
+        [],
         "test-world",
         "NonExistentNPC",
         10,
@@ -1938,11 +1963,13 @@ describe("TimersService", () => {
         },
       ];
 
-      mockPrismaService.$queryRaw =
+      mockPrismaService.$queryRawUnsafe =
         mockFn().mockResolvedValue(invalidTimerData);
 
       const result = await service.searchNpcsWithTimerData(
-        "guild1",
+        { id: "guild1", ownerId: "discord123" } as never,
+        "discord123",
+        [],
         "test-world",
         "Invalid",
         10,
@@ -1952,13 +1979,46 @@ describe("TimersService", () => {
     });
 
     it("should use default limit when not provided", async () => {
-      mockPrismaService.$queryRaw = mockFn<
+      mockPrismaService.$queryRawUnsafe = mockFn<
         () => Promise<unknown>
       >().mockResolvedValue(mockTimersQueryResult);
 
-      await service.searchNpcsWithTimerData("guild1", "test-world", "Test");
+      await service.searchNpcsWithTimerData(
+        { id: "guild1", ownerId: "discord123" } as never,
+        "discord123",
+        [],
+        "test-world",
+        "Test",
+      );
 
-      expect(mockPrismaService.$queryRaw).toHaveBeenCalled();
+      expect(mockPrismaService.$queryRawUnsafe).toHaveBeenCalled();
+    });
+
+    it("pushes denied administrator visibility into NPC search SQL", async () => {
+      mockPrismaService.$queryRawUnsafe.mockResolvedValue([]);
+
+      await service.searchNpcsWithTimerData(
+        { id: "guild1", ownerId: "owner123" } as never,
+        "administrator123",
+        [
+          {
+            permissions: [Permission.ADMIN],
+            lvlRangeFrom: 1,
+            lvlRangeTo: 500,
+          },
+        ] as never,
+        "test-world",
+        "Test",
+      );
+
+      expect(mockPrismaService.$queryRawUnsafe).toHaveBeenCalledWith(
+        expect.stringContaining("AND FALSE"),
+        "guild1",
+        "test-world",
+        "%Test%",
+        "999",
+        10,
+      );
     });
   });
 

--- a/apps/api/src/timers/timers.service.ts
+++ b/apps/api/src/timers/timers.service.ts
@@ -32,8 +32,14 @@ import { DEFAULT_RESPAWN_RANDOMNESS } from "src/timers/constants/respawn";
 import type { CreateManualTimerDto } from "src/timers/dto/create-manual-timer.dto";
 import { generateUniqueIntId } from "src/shared/utils/generate-unique-int-id";
 import { RoutingKey } from "src/enum/routing-key.enum";
-import { isAdministrativeUser } from "src/shared/permissions/is-administrative-user";
-import { canViewNpcTimer } from "@lootlog/api-helpers/permissions";
+import {
+  buildNpcJsonVisibilitySqlCondition,
+  buildNpcJsonVisibilityWhere,
+  canViewStrategicNpc,
+  createStrategicAccessContext,
+  TIMER_VISIBILITY_PERMISSIONS,
+} from "src/shared/permissions/strategic-access-policy";
+import type { NpcAccessContext } from "@lootlog/api-helpers/permissions";
 import type { CreateTimerFromGameClientDto } from "src/timers/dto/create-timer-from-game-client.dto";
 import { validateAndCalculateSpawnTimes } from "src/timers/utils/validate-spawn-times";
 import { TIMER_LIMITS, TIMER_TYPES } from "src/timers/constants/timer-limits";
@@ -1798,13 +1804,18 @@ export class TimersService implements OnModuleInit {
 
   async getTimers(
     userId: string,
+    viewerDiscordId: string,
     { world }: GetTimersDto,
     guild: Guild,
-    permissions: Permission[],
     roles: Role[],
   ) {
     const now = new Date();
-    const administrativeUser = isAdministrativeUser(permissions);
+    const accessContext = createStrategicAccessContext({
+      organizationId: guild.id,
+      ownerId: guild.ownerId,
+      viewerDiscordId,
+      roles,
+    });
     const alwaysVisibleExpiredTimerKeys =
       await this.getAlwaysVisibleExpiredTimerKeys(userId, world);
     const cacheKey = this.getTimersCacheKey(guild.id, userId, world);
@@ -1813,11 +1824,9 @@ export class TimersService implements OnModuleInit {
 
     if (cached !== null) {
       this.logger.log({ level: "debug", message: `Cache hit for ${cacheKey}` });
-      return this.filterTimersByPermissions(
-        cached,
-        administrativeUser,
-        roles,
-      ).map((timer) => this.mapTimerResponse(timer));
+      return this.filterTimersByPermissions(cached, accessContext).map(
+        (timer) => this.mapTimerResponse(timer),
+      );
     }
 
     this.logger.log({ level: "debug", message: `Cache miss for ${cacheKey}` });
@@ -1838,22 +1847,33 @@ export class TimersService implements OnModuleInit {
         }),
     });
 
-    return this.filterTimersByPermissions(
-      timers,
-      administrativeUser,
-      roles,
-    ).map((timer) => this.mapTimerResponse(timer));
+    return this.filterTimersByPermissions(timers, accessContext).map((timer) =>
+      this.mapTimerResponse(timer),
+    );
   }
 
   private filterTimersByPermissions(
     timers: TimerWithOptionalMember[],
-    administrativeUser: boolean,
-    roles: Role[],
+    accessContext: NpcAccessContext,
   ): TimerWithOptionalMember[] {
-    if (administrativeUser) return timers;
     return timers.filter((timer) => {
       const npc = parseNpc(timer.npc);
-      return canViewNpcTimer(npc, roles);
+      if (!npc) return false;
+
+      return canViewStrategicNpc(
+        accessContext,
+        {
+          organizationId: timer.guildId,
+          world: timer.world,
+          npc: {
+            id: timer.npcId,
+            type: npc.type,
+            group: null,
+            level: npc.lvl,
+          },
+        },
+        TIMER_VISIBILITY_PERMISSIONS,
+      );
     });
   }
 
@@ -1899,29 +1919,32 @@ export class TimersService implements OnModuleInit {
         (p) => p.guild.id === guild.id,
       );
 
-      const permissions = guildPermissionsAndRoles?.permissions ?? [];
       const roles = guildPermissionsAndRoles?.roles ?? [];
-      const administrativeUser = isAdministrativeUser(permissions);
       const guildTimers = timersByGuild[guild.id] ?? [];
-
-      return this.filterTimersByPermissions(
-        guildTimers,
-        administrativeUser,
+      const accessContext = createStrategicAccessContext({
+        organizationId: guild.id,
+        ownerId: guild.ownerId,
+        viewerDiscordId: discordId,
         roles,
-      ).map((timer) => this.mapTimerResponse(timer));
+      });
+
+      return this.filterTimersByPermissions(guildTimers, accessContext).map(
+        (timer) => this.mapTimerResponse(timer),
+      );
     });
   }
 
   async getTimerHistory(
-    guildId: string,
+    guild: Guild,
     world: string,
     timerIdentifier: string,
     options: {
       limit?: number;
-      permissions: Permission[];
+      viewerDiscordId: string;
       roles: Role[];
     },
   ) {
+    const guildId = guild.id;
     const limit =
       options.limit && options.limit > 0 ? Math.min(options.limit, 20) : 5;
     const resolvedTimer = await this.findTimerByIdentifier(
@@ -1930,13 +1953,23 @@ export class TimersService implements OnModuleInit {
       timerIdentifier,
     );
     const timerKey = resolvedTimer?.timerKey ?? timerIdentifier;
-    const administrativeUser = isAdministrativeUser(options.permissions);
+    const accessContext = createStrategicAccessContext({
+      organizationId: guildId,
+      ownerId: guild.ownerId,
+      viewerDiscordId: options.viewerDiscordId,
+      roles: options.roles,
+    });
+    const visibilityWhere = buildNpcJsonVisibilityWhere(
+      accessContext,
+      TIMER_VISIBILITY_PERMISSIONS,
+    );
 
     const entries = await this.prisma.timerHistoryEntry.findMany({
       where: {
         guildId,
         world,
         timerKey,
+        ...visibilityWhere,
       },
       orderBy: { createdAt: "desc" },
       take: limit,
@@ -1949,15 +1982,7 @@ export class TimersService implements OnModuleInit {
       },
     });
 
-    return entries
-      .filter((entry) => {
-        if (administrativeUser) {
-          return true;
-        }
-
-        return canViewNpcTimer(parseNpc(entry.npc), options.roles);
-      })
-      .map((entry) => this.mapTimerHistoryResponse(entry));
+    return entries.map((entry) => this.mapTimerHistoryResponse(entry));
   }
 
   async getRecentTimerHistory(
@@ -1977,46 +2002,51 @@ export class TimersService implements OnModuleInit {
       throw new ForbiddenException();
     }
 
-    const hasGuildAccess = guilds.some((guild) => guild.id === guildId);
+    const guild = guilds.find(
+      (candidateGuild) => candidateGuild.id === guildId,
+    );
 
-    if (!hasGuildAccess) {
+    if (!guild) {
       throw new ForbiddenException();
     }
 
-    const [entries, [guildPermissionsAndRoles]] = await Promise.all([
-      this.prisma.timerHistoryEntry.findMany({
-        where: {
-          guildId,
-          world,
-        },
-        orderBy: { createdAt: "desc" },
-        take: limit,
-        include: {
-          guild: {
-            select: { name: true },
-          },
-          actorMember: true,
-          actorCharacter: true,
-          timerCreatedBy: true,
-          timerActorCharacter: true,
-        },
-      }),
-      this.guildsService.getMultipleGuildsPermissions(discordId, [guildId]),
-    ]);
+    const [guildPermissionsAndRoles] =
+      await this.guildsService.getMultipleGuildsPermissions(discordId, [
+        guildId,
+      ]);
 
-    const permissions = guildPermissionsAndRoles?.permissions ?? [];
     const roles = guildPermissionsAndRoles?.roles ?? [];
-    const administrativeUser = isAdministrativeUser(permissions);
+    const accessContext = createStrategicAccessContext({
+      organizationId: guildId,
+      ownerId: guild.ownerId,
+      viewerDiscordId: discordId,
+      roles,
+    });
+    const visibilityWhere = buildNpcJsonVisibilityWhere(
+      accessContext,
+      TIMER_VISIBILITY_PERMISSIONS,
+    );
 
-    return entries
-      .filter((entry) => {
-        if (administrativeUser) {
-          return true;
-        }
+    const entries = await this.prisma.timerHistoryEntry.findMany({
+      where: {
+        guildId,
+        world,
+        ...visibilityWhere,
+      },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      include: {
+        guild: {
+          select: { name: true },
+        },
+        actorMember: true,
+        actorCharacter: true,
+        timerCreatedBy: true,
+        timerActorCharacter: true,
+      },
+    });
 
-        return canViewNpcTimer(parseNpc(entry.npc), roles);
-      })
-      .map((entry) => this.mapTimerHistoryResponse(entry));
+    return entries.map((entry) => this.mapTimerHistoryResponse(entry));
   }
 
   async restoreTimerFromHistory(
@@ -2371,14 +2401,30 @@ export class TimersService implements OnModuleInit {
   }
 
   async searchNpcsWithTimerData(
-    guildId: string,
+    guild: Guild,
+    viewerDiscordId: string,
+    roles: Role[],
     world: string,
     search: string,
     limit = 10,
   ) {
     const limitNum = Number(limit) || 10;
     const manualTimerType = String(TIMER_TYPES.CUSTOM_MANUAL);
-    const timers = await this.prisma.$queryRaw<Timer[]>`
+    const accessContext = createStrategicAccessContext({
+      organizationId: guild.id,
+      ownerId: guild.ownerId,
+      viewerDiscordId,
+      roles,
+    });
+    const visibilityCondition = buildNpcJsonVisibilitySqlCondition(
+      accessContext,
+      TIMER_VISIBILITY_PERMISSIONS,
+      "t",
+      5,
+    );
+    const limitParameterIndex = 5 + visibilityCondition.params.length;
+    const timers = await this.prisma.$queryRawUnsafe<Timer[]>(
+      `
       SELECT DISTINCT ON (t."timerKey")
         t."npc",
         t."npcId",
@@ -2386,14 +2432,22 @@ export class TimersService implements OnModuleInit {
         t."latestRespBaseSeconds",
         t."latestRespawnRandomness"
       FROM "Timer" t
-      WHERE t."guildId" = ${guildId}
-        AND t."world" = ${world}
+      WHERE t."guildId" = $1
+        AND t."world" = $2
         AND t."deletedAt" IS NULL
-        AND t."npc"->>'name' ILIKE ${"%" + search + "%"}
-        AND COALESCE(t."npc"->>'margonemType', '0') != ${manualTimerType}
+        AND t."npc"->>'name' ILIKE $3
+        AND COALESCE(t."npc"->>'margonemType', '0') != $4
+        ${visibilityCondition.sql}
       ORDER BY t."timerKey", t."updatedAt" DESC
-      LIMIT ${limitNum}
-    `;
+      LIMIT $${limitParameterIndex}
+    `,
+      guild.id,
+      world,
+      `%${search}%`,
+      manualTimerType,
+      ...visibilityCondition.params,
+      limitNum,
+    );
 
     return timers
       .map((timer) => {


### PR DESCRIPTION
## Summary
- adapt the canonical NPC access policy to persisted guild roles
- enforce strategic visibility across timer and loot lists, details, counts, search, comments, history, stats, and event wrapped loot reads
- remove ADMIN as a strategic-data bypass while preserving organization-owner recovery access
- scope read caches by the effective strategic policy

## Verification
- `pnpm --filter @lootlog/api test` (1025 tests)
- `pnpm turbo build --filter=@lootlog/api`
- `pnpm --filter @lootlog/api lint` (existing warnings only)
- `pnpm oxfmt --check apps/api/src .changeset/clean-wolves-observe.md`

## Stack
- Base: #1273
- Tracks: #1267 (Stage 1 read slice only)
- Explicitly excludes Stage 2 realtime and loot-sharing scope.