### PR TITLE
feat: enforce strategic policy on mutations

### DIFF
--- a/.changeset/fair-timers-authorize.md
+++ b/.changeset/fair-timers-authorize.md
@@ -1,0 +1,7 @@
+---
+"@lootlog/api": patch
+"@lootlog/api-client": patch
+"@lootlog/game-client": patch
+---
+
+Require strategic NPC visibility and the resource-specific action permission for timer and loot mutations.

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -932,6 +932,7 @@ paths:
           description: Guild ID
           schema:
             example: guild_123
+            type: string
       responses:
         "200":
           description: List of guild timers
@@ -953,13 +954,6 @@ paths:
       description: Search for NPCs that have been timed in this guild/world, returning their latest respawn configuration
       operationId: TimersController_searchNpcsWithTimerData
       parameters:
-        - name: guildId
-          required: true
-          in: path
-          description: Guild ID
-          schema:
-            example: guild_123
-            type: string
         - name: search
           required: true
           in: query
@@ -983,6 +977,13 @@ paths:
             maximum: 50
             default: 10
             type: number
+        - name: guildId
+          required: true
+          in: path
+          description: Guild ID
+          schema:
+            example: guild_123
+            type: string
       responses:
         "200":
           description: List of NPCs with timer metadata
@@ -1031,19 +1032,19 @@ paths:
       description: Reset a timer for a specific NPC in a guild
       operationId: TimersController_resetTimer
       parameters:
-        - name: guildId
-          required: true
-          in: path
-          description: Guild ID
-          schema:
-            example: guild_123
-            type: string
         - name: timerIdentifier
           required: true
           in: path
           description: Timer key or legacy NPC ID when unambiguous
           schema:
             example: 12345:test boss
+            type: string
+        - name: guildId
+          required: true
+          in: path
+          description: Guild ID
+          schema:
+            example: guild_123
             type: string
       requestBody:
         required: true
@@ -1073,17 +1074,10 @@ paths:
       operationId: TimersController_deleteTimer
       parameters:
         - name: world
-          required: false
+          required: true
           in: query
           description: World name
           schema:
-            type: string
-        - name: guildId
-          required: true
-          in: path
-          description: Guild ID
-          schema:
-            example: guild_123
             type: string
         - name: timerIdentifier
           required: true
@@ -1092,11 +1086,18 @@ paths:
           schema:
             example: 12345:test boss
             type: string
+        - name: guildId
+          required: true
+          in: path
+          description: Guild ID
+          schema:
+            example: guild_123
+            type: string
       responses:
         "200":
           description: Timer deleted successfully
         "403":
-          description: Forbidden - manage permission required
+          description: Forbidden - timer delete permission required
         "404":
           description: Timer not found
       security:
@@ -1115,13 +1116,6 @@ paths:
           description: World name
           schema:
             type: string
-        - name: guildId
-          required: true
-          in: path
-          description: Guild ID
-          schema:
-            example: guild_123
-            type: string
         - name: timerIdentifier
           required: true
           in: path
@@ -1134,6 +1128,13 @@ paths:
           in: query
           description: Result limit
           schema: {}
+        - name: guildId
+          required: true
+          in: path
+          description: Guild ID
+          schema:
+            example: guild_123
+            type: string
       responses:
         "200":
           description: List of timer history entries
@@ -1153,19 +1154,19 @@ paths:
       description: Restore a deleted timer from a timer history entry
       operationId: TimersController_restoreTimerFromHistory
       parameters:
-        - name: guildId
-          required: true
-          in: path
-          description: Guild ID
-          schema:
-            example: guild_123
-            type: string
         - name: historyEntryId
           required: true
           in: path
           description: Timer history entry ID
           schema:
             example: 123
+            type: string
+        - name: guildId
+          required: true
+          in: path
+          description: Guild ID
+          schema:
+            example: guild_123
             type: string
       responses:
         "201":
@@ -1913,7 +1914,7 @@ paths:
         "200":
           description: Loot deleted successfully
         "403":
-          description: Forbidden - admin or manage permission required
+          description: Forbidden - loot manage permission required
         "404":
           description: Loot not found
       security:

--- a/apps/api/src/loots/loots.controller.spec.ts
+++ b/apps/api/src/loots/loots.controller.spec.ts
@@ -431,6 +431,7 @@ describe("LootsController", () => {
         discordId,
         lootId,
         body,
+        [mockRole],
         mockGuild,
       );
 
@@ -438,7 +439,8 @@ describe("LootsController", () => {
         discordId,
         lootId,
         body,
-        guildId: mockGuild.id,
+        guild: mockGuild,
+        roles: [mockRole],
       });
       expect(result).toEqual(mockComment);
     });
@@ -450,10 +452,12 @@ describe("LootsController", () => {
     it("should delete a loot", async () => {
       service.deleteLoot.mockResolvedValue(undefined);
 
-      await controller.deleteLoot(lootId, mockGuild);
+      await controller.deleteLoot(lootId, "viewer123", [mockRole], mockGuild);
 
       expect(service.deleteLoot).toHaveBeenCalledWith({
-        guildId: mockGuild.id,
+        guild: mockGuild,
+        viewerDiscordId: "viewer123",
+        roles: [mockRole],
         lootId,
       });
     });

--- a/apps/api/src/loots/loots.controller.ts
+++ b/apps/api/src/loots/loots.controller.ts
@@ -303,17 +303,19 @@ export class LootsController {
     @DiscordId() discordId: string,
     @Param("lootId", new ParseIntPipe()) lootId: number,
     @Body() body: CreateCommentDto,
+    @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
   ) {
     return this.lootsService.createComment({
       discordId,
       lootId,
       body,
-      guildId: guild.id,
+      guild,
+      roles,
     });
   }
 
-  @Permissions(Permission.ADMIN, Permission.LOOTLOG_MANAGE)
+  @Permissions(Permission.LOOTLOG_MANAGE)
   @UseGuards(PermissionsGuard)
   @Delete("/guilds/:guildId/loots/:lootId")
   @ApiOperation({
@@ -328,15 +330,19 @@ export class LootsController {
   })
   @ApiResponse({
     status: 403,
-    description: "Forbidden - admin or manage permission required",
+    description: "Forbidden - loot manage permission required",
   })
   @ApiResponse({ status: 404, description: "Loot not found" })
   deleteLoot(
     @Param("lootId", new ParseIntPipe()) lootId: number,
+    @DiscordId() viewerDiscordId: string,
+    @MemberRoles() roles: Role[],
     @GuildData() guild: Guild,
   ) {
     return this.lootsService.deleteLoot({
-      guildId: guild.id,
+      guild,
+      viewerDiscordId,
+      roles,
       lootId,
     });
   }

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -985,7 +985,21 @@ describe("LootsService", () => {
   });
 
   describe("deleteLoot", () => {
-    const options = { guildId: "guild1", lootId: 1 };
+    const options = {
+      guild: mockGuild,
+      viewerDiscordId: "viewer123",
+      roles: [
+        {
+          permissions: [
+            Permission.LOOTLOG_LOOTS_READ,
+            Permission.LOOTLOG_MANAGE,
+          ],
+          lvlRangeFrom: 1,
+          lvlRangeTo: 500,
+        } as Role,
+      ],
+      lootId: 1,
+    };
 
     it("should delete loot submissions when loot exists", async () => {
       const mockLoot = { id: 1 };
@@ -994,10 +1008,10 @@ describe("LootsService", () => {
       await service.deleteLoot(options);
 
       expect(prismaService.lootSubmission.deleteMany).toHaveBeenCalledWith({
-        where: { lootId: options.lootId, guildId: options.guildId },
+        where: { lootId: options.lootId, guildId: options.guild.id },
       });
       expect(lootStatsService.invalidateCache).toHaveBeenCalledWith([
-        options.guildId,
+        options.guild.id,
       ]);
     });
 
@@ -1008,13 +1022,46 @@ describe("LootsService", () => {
         new ForbiddenException(ErrorKey.CANT_DELETE_LOOT),
       );
     });
+
+    it("requires manage permission on the role that can see the loot", async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.deleteLoot({
+          ...options,
+          roles: [
+            {
+              permissions: [Permission.LOOTLOG_LOOTS_READ],
+              lvlRangeFrom: 1,
+              lvlRangeTo: 500,
+            } as Role,
+            {
+              permissions: [Permission.LOOTLOG_MANAGE],
+              lvlRangeFrom: 1,
+              lvlRangeTo: 500,
+            } as Role,
+          ],
+        }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prismaService.lootSubmission.deleteMany).not.toHaveBeenCalled();
+    });
   });
 
   describe("createComment", () => {
     const options = {
       discordId: "discord123",
       userId: "user123",
-      guildId: "guild1",
+      guild: mockGuild,
+      roles: [
+        {
+          permissions: [
+            Permission.LOOTLOG_LOOTS_READ,
+            Permission.LOOTLOG_LOOTS_WRITE,
+          ],
+          lvlRangeFrom: 1,
+          lvlRangeTo: 500,
+        } as Role,
+      ],
       lootId: 1,
       body: { content: "Test comment" } as CreateCommentDto,
     };
@@ -1037,6 +1084,29 @@ describe("LootsService", () => {
       await expect(service.createComment(options)).rejects.toThrow(
         new ForbiddenException(ErrorKey.CANT_CREATE_COMMENT),
       );
+    });
+
+    it("requires write permission on the role that can see the loot", async () => {
+      prismaService.loot.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.createComment({
+          ...options,
+          roles: [
+            {
+              permissions: [Permission.LOOTLOG_LOOTS_READ],
+              lvlRangeFrom: 1,
+              lvlRangeTo: 500,
+            } as Role,
+            {
+              permissions: [Permission.LOOTLOG_LOOTS_WRITE],
+              lvlRangeFrom: 1,
+              lvlRangeTo: 500,
+            } as Role,
+          ],
+        }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(prismaService.lootComment.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/loots/loots.service.ts
+++ b/apps/api/src/loots/loots.service.ts
@@ -684,40 +684,64 @@ export class LootsService implements OnModuleInit {
     });
   }
 
-  async deleteLoot(options: { guildId: string; lootId: number }) {
-    const { guildId, lootId } = options;
+  async deleteLoot(options: {
+    guild: Guild;
+    viewerDiscordId: string;
+    roles: Role[];
+    lootId: number;
+  }) {
+    const { guild, viewerDiscordId, roles, lootId } = options;
+    const allowed = await this.lootQueryService.canViewLootById(
+      guild,
+      viewerDiscordId,
+      roles,
+      lootId,
+      Permission.LOOTLOG_MANAGE,
+    );
 
-    const loot = await this.prisma.loot.findFirst({
-      where: {
-        id: lootId,
-        lootSubmissions: { some: { guildId } },
-      },
-    });
-
-    if (!loot) {
+    if (!allowed) {
       throw new ForbiddenException(ErrorKey.CANT_DELETE_LOOT);
     }
 
     await this.prisma.lootSubmission.deleteMany({
       where: {
         lootId,
-        guildId,
+        guildId: guild.id,
       },
     });
     await Promise.all([
-      this.invalidateLootsListCache([guildId]),
-      this.invalidateLootStatsCaches([guildId]),
+      this.invalidateLootsListCache([guild.id]),
+      this.invalidateLootStatsCaches([guild.id]),
     ]);
   }
 
   async createComment(options: {
     discordId: string;
-    guildId: string;
+    guild: Guild;
+    roles: Role[];
     lootId: number;
     body: CreateCommentDto;
   }) {
-    const comment = await this.lootCommentService.createComment(options);
-    await this.invalidateLootsListCache([options.guildId]);
+    const { discordId, guild, roles, lootId, body } = options;
+    const allowed = await this.lootQueryService.canViewLootById(
+      guild,
+      discordId,
+      roles,
+      lootId,
+      Permission.LOOTLOG_LOOTS_WRITE,
+    );
+
+    if (!allowed) {
+      throw new ForbiddenException(ErrorKey.CANT_CREATE_COMMENT);
+    }
+
+    const comment = await this.lootCommentService.createComment({
+      discordId,
+      guildId: guild.id,
+      lootId,
+      body,
+    });
+    await this.invalidateLootsListCache([guild.id]);
     return comment;
   }
 

--- a/apps/api/src/loots/services/loot-query.service.ts
+++ b/apps/api/src/loots/services/loot-query.service.ts
@@ -5,6 +5,7 @@ import {
   NpcType,
   Profession,
   type Guild,
+  type Permission,
   type Prisma,
   type Role,
 } from "src/generated/prisma/client";
@@ -329,17 +330,30 @@ export class LootQueryService {
     viewerDiscordId: string,
     roles: Role[],
     lootId: number,
+    actionPermission?: Permission,
   ): Promise<boolean> {
-    const baseWhere = this.buildBaseWhereCondition(
-      guild,
+    const accessContext = createStrategicAccessContext({
+      organizationId: guild.id,
+      ownerId: guild.ownerId,
       viewerDiscordId,
       roles,
-      { cursor: null },
+    });
+    const npcSnapshotVisibilityWhere = buildNpcSnapshotVisibilityWhere(
+      accessContext,
+      LOOT_VISIBILITY_PERMISSIONS,
+      actionPermission,
     );
     const loot = await this.prisma.loot.findFirst({
       where: {
-        ...baseWhere,
         id: lootId,
+        lootSubmissions: { some: { guildId: guild.id } },
+        ...(npcSnapshotVisibilityWhere
+          ? {
+              lootNpcs: {
+                some: { npcSnapshot: npcSnapshotVisibilityWhere },
+              },
+            }
+          : null),
       },
       select: { id: true },
     });

--- a/apps/api/src/shared/permissions/strategic-access-policy.spec.ts
+++ b/apps/api/src/shared/permissions/strategic-access-policy.spec.ts
@@ -81,6 +81,26 @@ describe("strategic access policy adapter", () => {
     });
   });
 
+  it("keeps an action permission on the same matching role", () => {
+    const context = createStrategicAccessContext({
+      organizationId: "guild-1",
+      ownerId: "owner",
+      viewerDiscordId: "member",
+      roles: [
+        createRole({ permissions: [Permission.LOOTLOG_LOOTS_READ] }),
+        createRole({ permissions: [Permission.LOOTLOG_MANAGE] }),
+      ],
+    });
+
+    expect(
+      buildNpcSnapshotVisibilityWhere(
+        context,
+        LOOT_VISIBILITY_PERMISSIONS,
+        Permission.LOOTLOG_MANAGE,
+      ),
+    ).toEqual({ OR: [] });
+  });
+
   it("parameterizes level ranges in the raw SQL condition", () => {
     const context = createStrategicAccessContext({
       organizationId: "guild-1",

--- a/apps/api/src/shared/permissions/strategic-access-policy.ts
+++ b/apps/api/src/shared/permissions/strategic-access-policy.ts
@@ -60,12 +60,28 @@ export const canViewStrategicNpc = (
 ): boolean =>
   evaluateNpcAccess({ context, resource, visibilityPermissions }).visible;
 
+export const canActOnStrategicNpc = (
+  context: NpcAccessContext,
+  resource: NpcResource,
+  visibilityPermissions: NpcVisibilityPermissions,
+  actionPermission: string,
+): boolean =>
+  evaluateNpcAccess({
+    context,
+    resource,
+    visibilityPermissions,
+    actionPermission,
+  }).allowed;
+
 const getVisibleRoles = (
   context: NpcAccessContext,
   visibilityPermissions: NpcVisibilityPermissions,
+  actionPermission?: string,
 ) =>
-  context.roles.filter((role) =>
-    role.permissions.includes(visibilityPermissions.base),
+  context.roles.filter(
+    (role) =>
+      role.permissions.includes(visibilityPermissions.base) &&
+      (!actionPermission || role.permissions.includes(actionPermission)),
   );
 
 const getExcludedNpcTypes = (
@@ -88,37 +104,40 @@ const getExcludedNpcTypes = (
 export const buildNpcSnapshotVisibilityWhere = (
   context: NpcAccessContext,
   visibilityPermissions: NpcVisibilityPermissions,
+  actionPermission?: string,
 ): Prisma.NpcSnapshotWhereInput | null => {
   if (context.isOwner) {
     return null;
   }
 
-  const roleConditions = getVisibleRoles(context, visibilityPermissions).map(
-    (role): Prisma.NpcSnapshotWhereInput => {
-      const levelRange = role.npc?.levelRange ?? {
-        from: DEFAULT_LEVEL_RANGE_FROM,
-        to: DEFAULT_LEVEL_RANGE_TO,
-      };
-      const excludedTypes = getExcludedNpcTypes(
-        role.permissions,
-        visibilityPermissions,
-      );
-      const conditions: Prisma.NpcSnapshotWhereInput[] = [
-        {
-          lvl: {
-            gte: levelRange.from,
-            lte: levelRange.to,
-          },
+  const roleConditions = getVisibleRoles(
+    context,
+    visibilityPermissions,
+    actionPermission,
+  ).map((role): Prisma.NpcSnapshotWhereInput => {
+    const levelRange = role.npc?.levelRange ?? {
+      from: DEFAULT_LEVEL_RANGE_FROM,
+      to: DEFAULT_LEVEL_RANGE_TO,
+    };
+    const excludedTypes = getExcludedNpcTypes(
+      role.permissions,
+      visibilityPermissions,
+    );
+    const conditions: Prisma.NpcSnapshotWhereInput[] = [
+      {
+        lvl: {
+          gte: levelRange.from,
+          lte: levelRange.to,
         },
-      ];
+      },
+    ];
 
-      if (excludedTypes.length > 0) {
-        conditions.push({ type: { notIn: excludedTypes } });
-      }
+    if (excludedTypes.length > 0) {
+      conditions.push({ type: { notIn: excludedTypes } });
+    }
 
-      return { AND: conditions };
-    },
-  );
+    return { AND: conditions };
+  });
 
   return { OR: roleConditions };
 };

--- a/apps/api/src/timers/timers.controller.spec.ts
+++ b/apps/api/src/timers/timers.controller.spec.ts
@@ -5,6 +5,8 @@ import { TimersController } from "./timers.controller";
 import { TimersService } from "./timers.service";
 import { AuthGuard } from "@lootlog/nest-shared";
 import { PermissionsGuard } from "src/shared/permissions/permissions.guard";
+import { Permission } from "src/generated/prisma/client";
+import { PERMISSIONS_KEY } from "src/shared/permissions/permissions.decorator";
 
 describe("TimersController", () => {
   let controller: TimersController;
@@ -67,5 +69,14 @@ describe("TimersController", () => {
       "user-1",
       payload,
     );
+  });
+
+  it("uses the dedicated timer delete permission", () => {
+    expect(
+      Reflect.getMetadata(
+        PERMISSIONS_KEY,
+        TimersController.prototype.deleteTimer,
+      ),
+    ).toEqual([Permission.LOOTLOG_TIMERS_DELETE]);
   });
 });

--- a/apps/api/src/timers/timers.controller.ts
+++ b/apps/api/src/timers/timers.controller.ts
@@ -98,7 +98,12 @@ export class TimersController {
     summary: "Get guild timers",
     description: "Retrieve timers for a specific guild",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ApiQuery({
     name: "world",
     description: "World name filter",
@@ -137,7 +142,12 @@ export class TimersController {
     description:
       "Search for NPCs that have been timed in this guild/world, returning their latest respawn configuration",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ApiQuery({
     name: "search",
     description: "NPC name search term",
@@ -202,7 +212,12 @@ export class TimersController {
     summary: "Reset timer",
     description: "Reset a timer for a specific NPC in a guild",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ApiParam({
     name: "timerIdentifier",
     description: "Timer key or legacy NPC ID when unambiguous",
@@ -220,50 +235,59 @@ export class TimersController {
   @ApiResponse({ status: 404, description: "Timer not found" })
   resetTimer(
     @DiscordId() discordId: string,
-    @Param("guildId") guildId: string,
+    @GuildData() guild: Guild,
+    @MemberRoles() roles: Role[],
     @Param("timerIdentifier") timerIdentifier: string,
     @Body() data: ResetTimerDto,
   ) {
     return this.timersService.resetTimer(
       discordId,
-      guildId,
+      guild,
+      roles,
       timerIdentifier,
       data,
     );
   }
 
-  @Permissions(Permission.LOOTLOG_MANAGE)
+  @Permissions(Permission.LOOTLOG_TIMERS_DELETE)
   @UseGuards(PermissionsGuard)
   @Delete("/guilds/:guildId/timers/:timerIdentifier")
   @ApiOperation({
     summary: "Delete timer",
     description: "Delete a timer for a specific NPC in a guild",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ApiParam({
     name: "timerIdentifier",
     description: "Timer key or legacy NPC ID when unambiguous",
     example: "12345:test boss",
   })
-  @ApiQuery({ name: "world", description: "World name", required: false })
+  @ApiQuery({ name: "world", description: "World name", required: true })
   @ApiResponse({
     status: 200,
     description: "Timer deleted successfully",
   })
   @ApiResponse({
     status: 403,
-    description: "Forbidden - manage permission required",
+    description: "Forbidden - timer delete permission required",
   })
   @ApiResponse({ status: 404, description: "Timer not found" })
   deleteTimer(
     @DiscordId() discordId: string,
+    @GuildData() guild: Guild,
+    @MemberRoles() roles: Role[],
     @Query("world") world: string,
-    @Param("guildId") guildId: string,
     @Param("timerIdentifier") timerIdentifier: string,
   ) {
     return this.timersService.deleteTimer(
       discordId,
-      guildId,
+      guild,
+      roles,
       timerIdentifier,
       world,
     );
@@ -276,7 +300,12 @@ export class TimersController {
     summary: "Get timer action history",
     description: "Retrieve latest action history entries for a guild timer",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ApiParam({
     name: "timerIdentifier",
     description: "Timer key or legacy NPC ID when unambiguous",
@@ -311,7 +340,12 @@ export class TimersController {
     summary: "Restore timer from history",
     description: "Restore a deleted timer from a timer history entry",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ApiParam({
     name: "historyEntryId",
     description: "Timer history entry ID",
@@ -324,12 +358,14 @@ export class TimersController {
   })
   restoreTimerFromHistory(
     @DiscordId() discordId: string,
-    @Param("guildId") guildId: string,
+    @GuildData() guild: Guild,
+    @MemberRoles() roles: Role[],
     @Param("historyEntryId") historyEntryId: string,
   ) {
     return this.timersService.restoreTimerFromHistory(
       discordId,
-      guildId,
+      guild,
+      roles,
       Number.parseInt(historyEntryId, 10),
     );
   }
@@ -341,7 +377,12 @@ export class TimersController {
     summary: "Create manual timer",
     description: "Manually create a timer for a guild",
   })
-  @ApiParam({ name: "guildId", description: "Guild ID", example: "guild_123" })
+  @ApiParam({
+    name: "guildId",
+    description: "Guild ID",
+    example: "guild_123",
+    type: String,
+  })
   @ZodResponse({
     status: 201,
     description: "Manual timer created successfully",

--- a/apps/api/src/timers/timers.service.spec.ts
+++ b/apps/api/src/timers/timers.service.spec.ts
@@ -4,7 +4,11 @@ import { AmqpConnection } from "@golevelup/nestjs-rabbitmq";
 import { TimersService } from "./timers.service";
 import { PrismaService } from "src/db/prisma.service";
 import { GuildsService } from "src/guilds/guilds.service";
-import { BadRequestException, ConflictException } from "@nestjs/common";
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from "@nestjs/common";
 import type { CreateTimerFromGameClientDto } from "src/timers/dto/create-timer-from-game-client.dto";
 import { validateAndCalculateSpawnTimes } from "src/timers/utils/validate-spawn-times";
 import { TIMER_LIMITS } from "src/timers/constants/timer-limits";
@@ -23,10 +27,28 @@ import {
   Permission,
   Profession,
   TimerHistoryAction,
+  type Guild,
+  type Role,
 } from "src/generated/prisma/client";
 
 describe("TimersService", () => {
   let service: TimersService;
+  const mutationGuild = {
+    id: "guild1",
+    ownerId: "owner123",
+  } as Guild;
+  const mutationRoles = [
+    {
+      permissions: [
+        Permission.LOOTLOG_TIMERS_READ,
+        Permission.LOOTLOG_TIMERS_RESET,
+        Permission.LOOTLOG_TIMERS_DELETE,
+        Permission.LOOTLOG_TIMERS_WRITE,
+      ],
+      lvlRangeFrom: 1,
+      lvlRangeTo: 500,
+    } as Role,
+  ];
 
   const mockPrismaService = {
     timer: {
@@ -43,6 +65,7 @@ describe("TimersService", () => {
     },
     timerHistoryEntry: {
       create: mockFn(),
+      findUnique: mockFn(),
       findMany: mockFn(),
       deleteMany: mockFn(),
     },
@@ -161,6 +184,7 @@ describe("TimersService", () => {
     mockPrismaService.timer.findUnique.mockResolvedValue(null);
     mockPrismaService.playerSnapshot.upsert.mockResolvedValue(null);
     mockPrismaService.timerHistoryEntry.create.mockResolvedValue({});
+    mockPrismaService.timerHistoryEntry.findUnique.mockResolvedValue(null);
     mockPrismaService.timerHistoryEntry.findMany.mockResolvedValue([]);
     mockPrismaService.timerHistoryEntry.deleteMany.mockResolvedValue({
       count: 0,
@@ -1088,9 +1112,15 @@ describe("TimersService", () => {
       ]);
       mockPrismaService.timer.update.mockResolvedValue(mockTimer);
 
-      await service.resetTimer("discord123", "guild1", "123", {
-        world: "test-world",
-      });
+      await service.resetTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        {
+          world: "test-world",
+        },
+      );
 
       expect(mockRedisService.deleteByPattern).toHaveBeenCalledWith(
         "timer:list:guild1:*",
@@ -1132,17 +1162,23 @@ describe("TimersService", () => {
         actorCharacterLvl: 300,
       });
 
-      await service.resetTimer("discord123", "guild1", "123", {
-        world: "test-world",
-        actorCharacter: {
-          accountId: "200",
-          characterId: "100",
-          name: "Hero One",
-          prof: "b",
-          icon: "hero.gif",
-          lvl: 300,
+      await service.resetTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        {
+          world: "test-world",
+          actorCharacter: {
+            accountId: "200",
+            characterId: "100",
+            name: "Hero One",
+            prof: "b",
+            icon: "hero.gif",
+            lvl: 300,
+          },
         },
-      });
+      );
 
       expect(mockPrismaService.timer.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1172,9 +1208,15 @@ describe("TimersService", () => {
       ]);
       mockPrismaService.timer.update.mockResolvedValue(mockTimer);
 
-      await service.resetTimer("discord123", "guild1", "123", {
-        world: "test-world",
-      });
+      await service.resetTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        {
+          world: "test-world",
+        },
+      );
 
       expect(mockPrismaService.timer.update).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1208,9 +1250,15 @@ describe("TimersService", () => {
       mockPrismaService.timer.findUnique.mockResolvedValue(manualTimer);
       mockPrismaService.timer.update.mockResolvedValue(manualTimer);
 
-      await service.resetTimer("discord123", "guild1", "123", {
-        world: "test-world",
-      });
+      await service.resetTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        {
+          world: "test-world",
+        },
+      );
 
       expect(mockPrismaService.timerHistoryEntry.create).not.toHaveBeenCalled();
     });
@@ -1223,7 +1271,7 @@ describe("TimersService", () => {
       });
 
       await expect(
-        service.resetTimer("discord123", "guild1", "123", {
+        service.resetTimer("discord123", mutationGuild, mutationRoles, "123", {
           world: "test-world",
         }),
       ).rejects.toMatchObject({
@@ -1243,7 +1291,7 @@ describe("TimersService", () => {
       });
 
       await expect(
-        service.resetTimer("discord123", "guild1", "123", {
+        service.resetTimer("discord123", mutationGuild, mutationRoles, "123", {
           world: "test-world",
         }),
       ).rejects.toMatchObject({
@@ -1255,6 +1303,29 @@ describe("TimersService", () => {
       expect(mockRedisService.deleteByPattern).not.toHaveBeenCalled();
     });
 
+    it("requires reset permission on the role that can see the timer", async () => {
+      mockPrismaService.timer.findMany.mockResolvedValue([mockTimer]);
+      const splitRoles = [
+        {
+          permissions: [Permission.LOOTLOG_TIMERS_READ],
+          lvlRangeFrom: 1,
+          lvlRangeTo: 500,
+        } as Role,
+        {
+          permissions: [Permission.LOOTLOG_TIMERS_RESET],
+          lvlRangeFrom: 1,
+          lvlRangeTo: 500,
+        } as Role,
+      ];
+
+      await expect(
+        service.resetTimer("discord123", mutationGuild, splitRoles, "123", {
+          world: "test-world",
+        }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockRedlock.acquire).not.toHaveBeenCalled();
+    });
+
     it("should invalidate cache when timer is deleted", async () => {
       mockRedisService.deleteByPattern.mockResolvedValue(1);
       mockEventTimerHooksService.findActiveEventHeroByNpc.mockResolvedValue(
@@ -1263,7 +1334,13 @@ describe("TimersService", () => {
       mockPrismaService.timer.findMany.mockResolvedValue([mockTimer]);
       mockPrismaService.timer.update.mockResolvedValue(mockTimer);
 
-      await service.deleteTimer("guild1", "123", "test-world");
+      await service.deleteTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        "test-world",
+      );
 
       expect(mockRedisService.deleteByPattern).toHaveBeenCalledWith(
         "timer:list:guild1:*",
@@ -1277,7 +1354,13 @@ describe("TimersService", () => {
       mockPrismaService.timer.findMany.mockResolvedValue([mockTimer]);
       mockPrismaService.timer.update.mockResolvedValue(mockTimer);
 
-      await service.deleteTimer("guild1", "123", "test-world");
+      await service.deleteTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        "test-world",
+      );
 
       expect(mockPrismaService.timer.update).toHaveBeenCalledWith({
         where: {
@@ -1307,7 +1390,13 @@ describe("TimersService", () => {
       mockPrismaService.timer.findMany.mockResolvedValue([manualTimer]);
       mockPrismaService.timer.delete.mockResolvedValue(manualTimer);
 
-      await service.deleteTimer("guild1", "123", "test-world");
+      await service.deleteTimer(
+        "discord123",
+        mutationGuild,
+        mutationRoles,
+        "123",
+        "test-world",
+      );
 
       expect(mockPrismaService.timerHistoryEntry.create).not.toHaveBeenCalled();
       expect(mockPrismaService.timer.delete).toHaveBeenCalledWith({
@@ -1329,7 +1418,13 @@ describe("TimersService", () => {
       });
 
       await expect(
-        service.deleteTimer("guild1", "123", "test-world"),
+        service.deleteTimer(
+          "discord123",
+          mutationGuild,
+          mutationRoles,
+          "123",
+          "test-world",
+        ),
       ).rejects.toMatchObject({
         response: { message: ErrorKey.EVENT_TIMER_MUST_USE_EVENT_CLOSE },
       });
@@ -1346,13 +1441,66 @@ describe("TimersService", () => {
       });
 
       await expect(
-        service.deleteTimer("guild1", "123", "test-world"),
+        service.deleteTimer(
+          "discord123",
+          mutationGuild,
+          mutationRoles,
+          "123",
+          "test-world",
+        ),
       ).rejects.toMatchObject({
         response: { message: ErrorKey.EVENT_TIMER_MUST_USE_EVENT_CLOSE },
       });
 
       expect(mockPrismaService.timer.delete).not.toHaveBeenCalled();
       expect(mockRedisService.deleteByPattern).not.toHaveBeenCalled();
+    });
+
+    it("requires delete permission on the role that can see the timer", async () => {
+      mockPrismaService.timer.findMany.mockResolvedValue([mockTimer]);
+      const splitRoles = [
+        {
+          permissions: [Permission.LOOTLOG_TIMERS_READ],
+          lvlRangeFrom: 1,
+          lvlRangeTo: 500,
+        } as Role,
+        {
+          permissions: [Permission.LOOTLOG_TIMERS_DELETE],
+          lvlRangeFrom: 1,
+          lvlRangeTo: 500,
+        } as Role,
+      ];
+
+      await expect(
+        service.deleteTimer(
+          "discord123",
+          mutationGuild,
+          splitRoles,
+          "123",
+          "test-world",
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockPrismaService.timer.update).not.toHaveBeenCalled();
+    });
+
+    it("requires write permission and visibility before restoring history", async () => {
+      mockPrismaService.timerHistoryEntry.findUnique.mockResolvedValue({
+        id: 1,
+        guildId: "guild1",
+        world: "test-world",
+        npcId: mockTimer.npcId,
+        npc: mockTimer.npc,
+      });
+
+      await expect(
+        service.restoreTimerFromHistory(
+          "discord123",
+          mutationGuild,
+          [{ ...mutationRoles[0], lvlRangeFrom: 101 } as Role],
+          1,
+        ),
+      ).rejects.toThrow(ForbiddenException);
+      expect(mockPrismaService.timer.upsert).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/timers/timers.service.ts
+++ b/apps/api/src/timers/timers.service.ts
@@ -35,6 +35,7 @@ import { RoutingKey } from "src/enum/routing-key.enum";
 import {
   buildNpcJsonVisibilitySqlCondition,
   buildNpcJsonVisibilityWhere,
+  canActOnStrategicNpc,
   canViewStrategicNpc,
   createStrategicAccessContext,
   TIMER_VISIBILITY_PERMISSIONS,
@@ -1877,6 +1878,43 @@ export class TimersService implements OnModuleInit {
     });
   }
 
+  private assertCanActOnTimer(
+    guild: Guild,
+    viewerDiscordId: string,
+    roles: Role[],
+    timer: Pick<Timer, "guildId" | "world" | "npcId" | "npc">,
+    actionPermission: Permission,
+  ) {
+    const npc = parseNpc(timer.npc);
+    const accessContext = createStrategicAccessContext({
+      organizationId: guild.id,
+      ownerId: guild.ownerId,
+      viewerDiscordId,
+      roles,
+    });
+    const allowed =
+      npc &&
+      canActOnStrategicNpc(
+        accessContext,
+        {
+          organizationId: timer.guildId,
+          world: timer.world,
+          npc: {
+            id: timer.npcId,
+            type: npc.type,
+            group: null,
+            level: npc.lvl,
+          },
+        },
+        TIMER_VISIBILITY_PERMISSIONS,
+        actionPermission,
+      );
+
+    if (!allowed) {
+      throw new ForbiddenException();
+    }
+  }
+
   async getAllTimers(
     discordId: string,
     userId: string,
@@ -2051,9 +2089,11 @@ export class TimersService implements OnModuleInit {
 
   async restoreTimerFromHistory(
     discordId: string,
-    guildId: string,
+    guild: Guild,
+    roles: Role[],
     historyEntryId: number,
   ) {
+    const guildId = guild.id;
     const entry = await this.prisma.timerHistoryEntry.findUnique({
       where: { id: historyEntryId },
       include: {
@@ -2069,6 +2109,14 @@ export class TimersService implements OnModuleInit {
         message: ErrorKey.TIMER_HISTORY_ENTRY_NOT_FOUND,
       });
     }
+
+    this.assertCanActOnTimer(
+      guild,
+      discordId,
+      roles,
+      entry,
+      Permission.LOOTLOG_TIMERS_WRITE,
+    );
 
     if (
       entry.action !== TimerHistoryAction.DELETE ||
@@ -2159,10 +2207,12 @@ export class TimersService implements OnModuleInit {
 
   async resetTimer(
     discordId: string,
-    guildId: string,
+    guild: Guild,
+    roles: Role[],
     timerIdentifier: string,
     data: ResetTimerDto,
   ) {
+    const guildId = guild.id;
     const now = new Date();
     const resolvedTimer = await this.findTimerByIdentifier(
       guildId,
@@ -2173,6 +2223,14 @@ export class TimersService implements OnModuleInit {
     if (!resolvedTimer) {
       throw new NotFoundException({ message: ErrorKey.TIMER_NOT_FOUND });
     }
+
+    this.assertCanActOnTimer(
+      guild,
+      discordId,
+      roles,
+      resolvedTimer,
+      Permission.LOOTLOG_TIMERS_RESET,
+    );
 
     const eventHero = await this.eventTimerHooks.findActiveEventHeroByNpc(
       guildId,
@@ -2285,16 +2343,12 @@ export class TimersService implements OnModuleInit {
 
   async deleteTimer(
     discordId: string,
-    guildId: string,
+    guild: Guild,
+    roles: Role[],
     timerIdentifier: string,
-    world?: string,
+    world: string,
   ) {
-    if (!world) {
-      world = timerIdentifier;
-      timerIdentifier = guildId;
-      guildId = discordId;
-      discordId = "";
-    }
+    const guildId = guild.id;
 
     const resolvedTimer = await this.findTimerByIdentifier(
       guildId,
@@ -2305,6 +2359,14 @@ export class TimersService implements OnModuleInit {
     if (!resolvedTimer) {
       throw new NotFoundException({ message: ErrorKey.TIMER_NOT_FOUND });
     }
+
+    this.assertCanActOnTimer(
+      guild,
+      discordId,
+      roles,
+      resolvedTimer,
+      Permission.LOOTLOG_TIMERS_DELETE,
+    );
 
     const eventHero = await this.eventTimerHooks.findActiveEventHeroByNpc(
       guildId,

--- a/apps/game-client/src/api/timers.api.ts
+++ b/apps/game-client/src/api/timers.api.ts
@@ -234,7 +234,7 @@ export async function fetchTimers(world: string): Promise<Timer[]> {
 export type DeleteTimerOptions = {
   timerKey: string;
   guildId: string;
-  world?: string;
+  world: string;
 };
 
 export async function deleteTimer({
@@ -255,7 +255,7 @@ export async function deleteTimer({
     execute: () =>
       timersControllerDeleteTimer(
         { guildId, timerIdentifier: timerKey },
-        world ? { world } : undefined,
+        { world },
       ),
   });
 }

--- a/apps/game-client/src/features/timers/hooks/use-timer-actions.ts
+++ b/apps/game-client/src/features/timers/hooks/use-timer-actions.ts
@@ -200,7 +200,7 @@ export const useTimerActions = (
         guildId,
         timerIdentifier: timerKey,
       },
-      world ? { world } : undefined,
+      { world },
     ).then(
       () => {
         showRuntimeMessage(

--- a/packages/api-client/src/generated/core/main/timers/timers.ts
+++ b/packages/api-client/src/generated/core/main/timers/timers.ts
@@ -265,7 +265,7 @@ export const timersControllerResetTimer = async ({ guildId, timerIdentifier }: T
 
 
 export const getTimersControllerDeleteTimerUrl = ({ guildId, timerIdentifier }: TimersControllerDeleteTimerPathParameters,
-    params?: TimersControllerDeleteTimerParams,) => {
+    params: TimersControllerDeleteTimerParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -285,7 +285,7 @@ export const getTimersControllerDeleteTimerUrl = ({ guildId, timerIdentifier }: 
  * @summary Delete timer
  */
 export const timersControllerDeleteTimer = async ({ guildId, timerIdentifier }: TimersControllerDeleteTimerPathParameters,
-    params?: TimersControllerDeleteTimerParams, options?: Parameters<typeof mainFetch>[1]): Promise<void> => {
+    params: TimersControllerDeleteTimerParams, options?: Parameters<typeof mainFetch>[1]): Promise<void> => {
 
   return mainFetch<void>(getTimersControllerDeleteTimerUrl({ guildId, timerIdentifier },params),
   {

--- a/packages/api-client/src/generated/models/main/timers-controller-delete-timer-params.ts
+++ b/packages/api-client/src/generated/models/main/timers-controller-delete-timer-params.ts
@@ -10,5 +10,5 @@ export type TimersControllerDeleteTimerParams = {
 /**
  * World name
  */
-world?: string;
+world: string;
 };

--- a/packages/api-client/src/generated/models/main/timers-controller-get-timers-path-parameters.ts
+++ b/packages/api-client/src/generated/models/main/timers-controller-get-timers-path-parameters.ts
@@ -7,5 +7,5 @@
  */
 
 export type TimersControllerGetTimersPathParameters = {
- guildId: unknown,
+ guildId: string,
  }

--- a/packages/api-client/src/generated/react-query/main/timers/timers.ts
+++ b/packages/api-client/src/generated/react-query/main/timers/timers.ts
@@ -897,7 +897,7 @@ export const useTimersControllerResetTimer = <TError = ErrorType<void>,
       return useMutation(getTimersControllerResetTimerMutationOptions(options), queryClient);
     }
     export const getTimersControllerDeleteTimerUrl = ({ guildId, timerIdentifier }: TimersControllerDeleteTimerPathParameters,
-    params?: TimersControllerDeleteTimerParams,) => {
+    params: TimersControllerDeleteTimerParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
@@ -917,7 +917,7 @@ export const useTimersControllerResetTimer = <TError = ErrorType<void>,
  * @summary Delete timer
  */
 export const timersControllerDeleteTimer = async ({ guildId, timerIdentifier }: TimersControllerDeleteTimerPathParameters,
-    params?: TimersControllerDeleteTimerParams, options?: Parameters<typeof mainFetch>[1]): Promise<void> => {
+    params: TimersControllerDeleteTimerParams, options?: Parameters<typeof mainFetch>[1]): Promise<void> => {
 
   return mainFetch<void>(getTimersControllerDeleteTimerUrl({ guildId, timerIdentifier },params),
   {
@@ -933,8 +933,8 @@ export const timersControllerDeleteTimer = async ({ guildId, timerIdentifier }: 
 
 
 export const getTimersControllerDeleteTimerMutationOptions = <TError = ErrorType<void>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, TError,{pathParams: TimersControllerDeleteTimerPathParameters;params?: TimersControllerDeleteTimerParams}, TContext>, request?: SecondParameter<typeof mainFetch>}
-): UseMutationOptions<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, TError,{pathParams: TimersControllerDeleteTimerPathParameters;params?: TimersControllerDeleteTimerParams}, TContext> => {
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, TError,{pathParams: TimersControllerDeleteTimerPathParameters;params: TimersControllerDeleteTimerParams}, TContext>, request?: SecondParameter<typeof mainFetch>}
+): UseMutationOptions<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, TError,{pathParams: TimersControllerDeleteTimerPathParameters;params: TimersControllerDeleteTimerParams}, TContext> => {
 
 const mutationKey = ['timersControllerDeleteTimer'];
 const {mutation: mutationOptions, request: requestOptions} = options ?
@@ -946,7 +946,7 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
 
 
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, {pathParams: TimersControllerDeleteTimerPathParameters;params?: TimersControllerDeleteTimerParams}> = (props) => {
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, {pathParams: TimersControllerDeleteTimerPathParameters;params: TimersControllerDeleteTimerParams}> = (props) => {
           const {pathParams,params} = props ?? {};
 
           return  timersControllerDeleteTimer(pathParams,params,requestOptions)
@@ -967,11 +967,11 @@ const {mutation: mutationOptions, request: requestOptions} = options ?
  * @summary Delete timer
  */
 export const useTimersControllerDeleteTimer = <TError = ErrorType<void>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, TError,{pathParams: TimersControllerDeleteTimerPathParameters;params?: TimersControllerDeleteTimerParams}, TContext>, request?: SecondParameter<typeof mainFetch>}
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof timersControllerDeleteTimer>>, TError,{pathParams: TimersControllerDeleteTimerPathParameters;params: TimersControllerDeleteTimerParams}, TContext>, request?: SecondParameter<typeof mainFetch>}
  , queryClient?: QueryClient): UseMutationResult<
         Awaited<ReturnType<typeof timersControllerDeleteTimer>>,
         TError,
-        {pathParams: TimersControllerDeleteTimerPathParameters;params?: TimersControllerDeleteTimerParams},
+        {pathParams: TimersControllerDeleteTimerPathParameters;params: TimersControllerDeleteTimerParams},
         TContext
       > => {
       return useMutation(getTimersControllerDeleteTimerMutationOptions(options), queryClient);


### PR DESCRIPTION
## Summary
- require NPC visibility and the action permission on the same matching role for timer reset/delete/restore
- apply the same rule to loot comment creation and loot deletion
- align timer deletion with `LOOTLOG_TIMERS_DELETE` and require the world query parameter
- regenerate OpenAPI/api-client output and update game-client consumers

## Verification
- `pnpm --filter @lootlog/api test` (1032 tests)
- `pnpm --filter @lootlog/game-client test` (1238 tests)
- `pnpm turbo build --filter=@lootlog/api --filter=@lootlog/game-client`
- `pnpm --filter @lootlog/api-client api-client:check`
- lint and format checks for API, api-client, and game-client

## Stack
- Base: #1274
- Policy base: #1273
- Tracks: #1267 (Stage 1 mutation and contract slice only)
- Explicitly excludes Stage 2 realtime and organization-local loot-sharing work.