### PR TITLE
perf(game-client): reduce timer render work

### DIFF
--- a/.changeset/bright-timers-breathe.md
+++ b/.changeset/bright-timers-breathe.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/game-client": patch
+---
+
+Keep the shared timer clock inside live countdown tiles and schedule list removal at the next expiry boundary so one-second ticks no longer repeat list-wide timer work.

--- a/apps/game-client/src/features/timers/components/single-timer.test.tsx
+++ b/apps/game-client/src/features/timers/components/single-timer.test.tsx
@@ -86,6 +86,18 @@ vi.mock("./timer-tooltip", () => ({
   },
 }));
 
+vi.mock("./timer-live-tile", () => ({
+  TimerLiveTile: (props: { label: string; timer: TimerWithTimeLeft }) => {
+    tileSpy(props);
+    return (
+      <div data-testid="tile">
+        <span>{props.label}</span>
+        <span>{`time:${props.timer.maxTimeLeft}`}</span>
+      </div>
+    );
+  },
+}));
+
 vi.mock("@lootlog/api-client/react-query/main/guilds", () => ({
   getGuildsControllerGetGuildPermissionsQueryKey: ({
     guildId,
@@ -174,15 +186,13 @@ describe("SingleTimer", () => {
 
     mockUseTimerDisplay.mockReturnValue({
       isPending: false,
-      isMinSpawnTime: false,
-      hasPassedRedThreshold: false,
       selectedColor: "red",
       customColor: undefined,
       overriddenColor: undefined,
       resetIndicator: "[R] ",
       shortname: "[H]",
       npcDetails: "(120w)",
-      timeLeft: 10_000,
+      countdownMode: "max",
       displayConfig: {
         fontSize: 11,
         singleTimerDisplayMode: "row",
@@ -252,8 +262,6 @@ describe("SingleTimer", () => {
     };
     mockUseTimerDisplay.mockReturnValue({
       isPending: true,
-      isMinSpawnTime: true,
-      hasPassedRedThreshold: false,
       selectedColor: "red",
       customColor: {
         id: "custom-1",
@@ -265,7 +273,7 @@ describe("SingleTimer", () => {
       resetIndicator: "",
       shortname: "[T]",
       npcDetails: "",
-      timeLeft: -500,
+      countdownMode: "min",
       displayConfig: {
         fontSize: 13,
         singleTimerDisplayMode: "column",
@@ -300,6 +308,6 @@ describe("SingleTimer", () => {
         timersGrouping: true,
       }),
     );
-    expect(screen.getByText("time:-500")).toBeVisible();
+    expect(screen.getByText("time:10000")).toBeVisible();
   });
 });

--- a/apps/game-client/src/features/timers/components/single-timer.tsx
+++ b/apps/game-client/src/features/timers/components/single-timer.tsx
@@ -11,14 +11,13 @@ import {
 import type { TimerWithTimeLeft } from "../utils/timers-utils";
 import { cn } from "@/lib/utils";
 import { useTimersStore } from "@/store/timers.store";
-import { parseMsToTime } from "@/utils/parse-ms-to-time";
 import { Loader2 } from "lucide-react";
 import type { FC } from "react";
 import { useTimerActions } from "../hooks/use-timer-actions";
 import { useTimerDisplay } from "../hooks/use-timer-display";
 import { TimerContextMenuContent } from "./timer-context-menu-content";
 import { TimerTooltip } from "./timer-tooltip";
-import { TimerTileView } from "./timer-tile-view";
+import { TimerLiveTile } from "./timer-live-tile";
 import { REQUIRED_DELETE_PERMISSIONS } from "../constants/required-delete-permissions";
 import { useGameStore } from "@/store/game.store";
 import { REQUIRED_RESET_PERMISSIONS } from "@/features/timers/constants/required-reset-permissions";
@@ -31,8 +30,6 @@ type SingleTimerProps = {
   guildPermissions: GuildsControllerGetGuildPermissions200Item[];
   timer: TimerWithTimeLeft;
   settingsKey: string;
-  minTimeLeft?: number;
-  maxTimeLeft?: number;
   isHidden?: boolean;
 };
 
@@ -41,8 +38,6 @@ export const SingleTimer: FC<SingleTimerProps> = ({
   guildNamesById,
   guildPermissions,
   timer,
-  minTimeLeft = 0,
-  maxTimeLeft = 0,
   settingsKey,
   isHidden = false,
 }) => {
@@ -89,17 +84,15 @@ export const SingleTimer: FC<SingleTimerProps> = ({
 
   const {
     isPending,
-    isMinSpawnTime,
-    hasPassedRedThreshold,
     selectedColor,
     customColor,
     overriddenColor,
     resetIndicator,
     shortname,
     npcDetails,
-    timeLeft,
     displayConfig,
-  } = useTimerDisplay(timer, minTimeLeft, maxTimeLeft);
+    countdownMode,
+  } = useTimerDisplay(timer);
 
   return (
     <Tooltip>
@@ -116,7 +109,7 @@ export const SingleTimer: FC<SingleTimerProps> = ({
                   <Loader2 className="ll:h-3 ll:w-3 ll:animate-spin ll:text-orange-500" />
                 </div>
               )}
-              <TimerTileView
+              <TimerLiveTile
                 id={timer.npc.id.toString()}
                 color={
                   customColor || overriddenColor ? undefined : selectedColor
@@ -130,11 +123,10 @@ export const SingleTimer: FC<SingleTimerProps> = ({
                 }
                 displayMode={displayConfig.singleTimerDisplayMode}
                 fontSize={displayConfig.fontSize}
-                hasPassedRedThreshold={hasPassedRedThreshold}
-                isMinSpawnTime={isMinSpawnTime}
                 isPending={isPending}
                 label={`${resetIndicator}${shortname} ${timer.npc.name} ${npcDetails}`}
-                timeLabel={parseMsToTime(timeLeft)}
+                countdownMode={countdownMode}
+                timer={timer}
               />
             </div>
           </ContextMenuTrigger>

--- a/apps/game-client/src/features/timers/components/timer-clock-provider.test.tsx
+++ b/apps/game-client/src/features/timers/components/timer-clock-provider.test.tsx
@@ -1,0 +1,68 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TimerClockProvider, useTimerClockEpoch } from "./timer-clock-provider";
+
+const NOW = new Date("2026-07-20T10:00:00.000Z").getTime();
+
+const TimerClockLabel = ({ index }: { index: number }) => {
+  const epoch = useTimerClockEpoch();
+
+  return <output data-testid={`timer-clock-${index}`}>{epoch}</output>;
+};
+
+describe("TimerClockProvider", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([1, 20, 100])(
+    "updates %i timer labels without rerendering the static parent",
+    (timerCount) => {
+      const parentRenderSpy = vi.fn();
+      const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+      const StaticTimerGrid = () => {
+        parentRenderSpy();
+
+        return (
+          <TimerClockProvider>
+            {Array.from({ length: timerCount }, (_, index) => (
+              <TimerClockLabel key={index} index={index} />
+            ))}
+          </TimerClockProvider>
+        );
+      };
+
+      render(<StaticTimerGrid />);
+
+      expect(parentRenderSpy).toHaveBeenCalledOnce();
+      expect(setIntervalSpy).toHaveBeenCalledOnce();
+
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+
+      expect(parentRenderSpy).toHaveBeenCalledOnce();
+      expect(screen.getByTestId("timer-clock-0")).toHaveTextContent(
+        String(NOW + 1_000),
+      );
+      expect(
+        screen.getByTestId(`timer-clock-${timerCount - 1}`),
+      ).toHaveTextContent(String(NOW + 1_000));
+    },
+  );
+
+  it("does not start the clock when the visible grid is empty", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    render(<div data-testid="empty-grid" />);
+
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/apps/game-client/src/features/timers/components/timer-clock-provider.tsx
+++ b/apps/game-client/src/features/timers/components/timer-clock-provider.tsx
@@ -1,0 +1,24 @@
+import { createContext, type ReactNode, useContext } from "react";
+import { useTimersUpdate } from "../hooks/use-timers-update";
+
+const TimerClockContext = createContext<number | null>(null);
+
+export const TimerClockProvider = ({ children }: { children: ReactNode }) => {
+  const epoch = useTimersUpdate();
+
+  return (
+    <TimerClockContext.Provider value={epoch}>
+      {children}
+    </TimerClockContext.Provider>
+  );
+};
+
+export const useTimerClockEpoch = () => {
+  const epoch = useContext(TimerClockContext);
+
+  if (epoch === null) {
+    throw new Error("useTimerClockEpoch requires TimerClockProvider");
+  }
+
+  return epoch;
+};

--- a/apps/game-client/src/features/timers/components/timer-live-tile.test.tsx
+++ b/apps/game-client/src/features/timers/components/timer-live-tile.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Timer } from "@/api/timers.api";
+import { TimerClockProvider } from "./timer-clock-provider";
+
+vi.mock("./timer-tile-view", () => ({
+  TimerTileView: ({
+    hasPassedRedThreshold,
+    isMinSpawnTime,
+    timeLabel,
+  }: {
+    hasPassedRedThreshold: boolean;
+    isMinSpawnTime: boolean;
+    timeLabel: string;
+  }) => (
+    <output data-testid="live-timer">
+      {`${timeLabel}:${String(isMinSpawnTime)}:${String(hasPassedRedThreshold)}`}
+    </output>
+  ),
+}));
+
+import { TimerLiveTile } from "./timer-live-tile";
+
+const NOW = new Date("2026-07-20T10:00:00.000Z");
+
+const createTimer = (): Timer =>
+  ({
+    guildId: "guild-1",
+    timerKey: "timer-1",
+    world: "gefion",
+    npcId: 10,
+    minSpawnTime: new Date(NOW.getTime() + 4_000).toISOString(),
+    maxSpawnTime: new Date(NOW.getTime() + 5_000).toISOString(),
+    updatedAt: NOW.toISOString(),
+    wasReset: false,
+    npc: { id: 10, name: "Tanroth" },
+  }) as Timer;
+
+describe("TimerLiveTile", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("updates countdown and min/max phases on the shared clock", () => {
+    render(
+      <TimerClockProvider>
+        <TimerLiveTile
+          countdownMode="min"
+          displayMode="row"
+          fontSize={11}
+          label="Tanroth"
+          timer={createTimer()}
+        />
+      </TimerClockProvider>,
+    );
+
+    expect(screen.getByTestId("live-timer")).toHaveTextContent(
+      "00:00:04:false:false",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(screen.getByTestId("live-timer")).toHaveTextContent(
+      "00:00:03:false:false",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(4_000);
+    });
+    expect(screen.getByTestId("live-timer")).toHaveTextContent(
+      "00:00:00:true:false",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(screen.getByTestId("live-timer")).toHaveTextContent(
+      "-00:00:01:true:true",
+    );
+  });
+});

--- a/apps/game-client/src/features/timers/components/timer-live-tile.tsx
+++ b/apps/game-client/src/features/timers/components/timer-live-tile.tsx
@@ -1,0 +1,40 @@
+import type { Timer } from "@/api/timers.api";
+import { parseMsToTime } from "@/utils/parse-ms-to-time";
+import { calculateTimeLeft } from "../utils/timer-helpers";
+import { getTimerTimeLeft } from "../utils/timers-utils";
+import { useTimerClockEpoch } from "./timer-clock-provider";
+import { TimerTileView, type TimerTileViewProps } from "./timer-tile-view";
+
+type TimerLiveTileProps = Omit<
+  TimerTileViewProps,
+  "hasPassedRedThreshold" | "isMinSpawnTime" | "timeLabel"
+> & {
+  countdownMode: "min" | "max";
+  timer: Timer;
+};
+
+export const TimerLiveTile = ({
+  countdownMode,
+  timer,
+  ...tileProps
+}: TimerLiveTileProps) => {
+  const epoch = useTimerClockEpoch();
+  const { maxTimeLeft, minTimeLeft } = getTimerTimeLeft(timer, epoch);
+  const isMinSpawnTime = minTimeLeft < 0;
+  const hasPassedRedThreshold = maxTimeLeft < 0;
+  const timeLeft = calculateTimeLeft(
+    minTimeLeft,
+    maxTimeLeft,
+    countdownMode,
+    isMinSpawnTime,
+  );
+
+  return (
+    <TimerTileView
+      {...tileProps}
+      hasPassedRedThreshold={hasPassedRedThreshold}
+      isMinSpawnTime={isMinSpawnTime}
+      timeLabel={parseMsToTime(timeLeft)}
+    />
+  );
+};

--- a/apps/game-client/src/features/timers/components/timer-tile-view.tsx
+++ b/apps/game-client/src/features/timers/components/timer-tile-view.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import type { TIMERS_COLORS } from "@/features/timers/constants/timer-colors";
 import type { FC } from "react";
 
-type TimerTileViewProps = {
+export type TimerTileViewProps = {
   color?: keyof typeof TIMERS_COLORS | string;
   customBorderColor?: string;
   customBackgroundColor?: string;

--- a/apps/game-client/src/features/timers/components/timers-grid.test.tsx
+++ b/apps/game-client/src/features/timers/components/timers-grid.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TimerWithTimeLeft } from "../utils/timers-utils";
 
 const singleTimerSpy = vi.fn();
@@ -88,10 +88,15 @@ const createTimer = (name: string, guildId = "guild-1"): TimerWithTimeLeft =>
 
 describe("TimersGrid", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     singleTimerSpy.mockReset();
     permissionQueryOptionsSpy.mockClear();
     useQueriesSpy.mockClear();
     mockGuilds = [{ id: "guild-1", name: "Alpha" }];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("passes guild metadata and hidden-state flags to each timer tile", () => {
@@ -156,5 +161,30 @@ describe("TimersGrid", () => {
         guildPermissions: ["LOOTLOG_TIMERS_RESET"],
       }),
     );
+  });
+
+  it("does not repeat permission queries or static tile work on clock ticks", () => {
+    render(
+      <TimersGrid
+        timers={Array.from({ length: 20 }, (_, index) =>
+          createTimer(`Timer ${index}`),
+        )}
+        settingsKey="guild-1"
+        hiddenTimers={[]}
+        minColumnWidth={120}
+      />,
+    );
+
+    expect(permissionQueryOptionsSpy).toHaveBeenCalledOnce();
+    expect(useQueriesSpy).toHaveBeenCalledOnce();
+    expect(singleTimerSpy).toHaveBeenCalledTimes(20);
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(permissionQueryOptionsSpy).toHaveBeenCalledOnce();
+    expect(useQueriesSpy).toHaveBeenCalledOnce();
+    expect(singleTimerSpy).toHaveBeenCalledTimes(20);
   });
 });

--- a/apps/game-client/src/features/timers/components/timers-grid.tsx
+++ b/apps/game-client/src/features/timers/components/timers-grid.tsx
@@ -11,6 +11,7 @@ import {
 } from "@lootlog/api-client/react-query/main/guilds";
 import { useQueries } from "@tanstack/react-query";
 import type { TimerWithTimeLeft } from "../utils/timers-utils";
+import { TimerClockProvider } from "./timer-clock-provider";
 
 type TimersGridProps = {
   timers: TimerWithTimeLeft[];
@@ -60,28 +61,28 @@ export const TimersGrid: FC<TimersGridProps> = ({
   const hiddenTimerNames = new Set(hiddenTimers);
 
   return (
-    <span
-      className="ll:grid ll:gap-0.5 ll:box-border ll:w-full"
-      style={{
-        gridTemplateColumns: `repeat(auto-fit, minmax(${minColumnWidth}px, 1fr))`,
-      }}
-    >
-      {timers.map((timer) => {
-        const isHidden = hiddenTimerNames.has(timer.npc.name);
-        return (
-          <SingleTimer
-            key={`${timer.timerKey}-${timer.guildId}`}
-            guildIds={guildIds}
-            guildNamesById={guildNamesById}
-            guildPermissions={guildPermissionsById[timer.guildId] ?? []}
-            timer={timer}
-            maxTimeLeft={timer.maxTimeLeft}
-            minTimeLeft={timer.minTimeLeft}
-            settingsKey={settingsKey}
-            isHidden={isHidden}
-          />
-        );
-      })}
-    </span>
+    <TimerClockProvider>
+      <span
+        className="ll:grid ll:gap-0.5 ll:box-border ll:w-full"
+        style={{
+          gridTemplateColumns: `repeat(auto-fit, minmax(${minColumnWidth}px, 1fr))`,
+        }}
+      >
+        {timers.map((timer) => {
+          const isHidden = hiddenTimerNames.has(timer.npc.name);
+          return (
+            <SingleTimer
+              key={`${timer.timerKey}-${timer.guildId}`}
+              guildIds={guildIds}
+              guildNamesById={guildNamesById}
+              guildPermissions={guildPermissionsById[timer.guildId] ?? []}
+              timer={timer}
+              settingsKey={settingsKey}
+              isHidden={isHidden}
+            />
+          );
+        })}
+      </span>
+    </TimerClockProvider>
   );
 };

--- a/apps/game-client/src/features/timers/hooks/use-timer-display.test.ts
+++ b/apps/game-client/src/features/timers/hooks/use-timer-display.test.ts
@@ -72,13 +72,11 @@ describe("useTimerDisplay", () => {
 
   it("builds display data for a regular timer with a custom color", () => {
     const { result } = renderHook(() =>
-      useTimerDisplay(createTimer({ wasReset: true }), 5_000, 15_000),
+      useTimerDisplay(createTimer({ wasReset: true })),
     );
 
     expect(result.current).toMatchObject({
       isPending: false,
-      isMinSpawnTime: false,
-      hasPassedRedThreshold: false,
       selectedColor: "custom-red",
       customColor: {
         id: "custom-red",
@@ -89,7 +87,7 @@ describe("useTimerDisplay", () => {
       overriddenColor: undefined,
       resetIndicator: "[R] ",
       npcDetails: " (120w)",
-      timeLeft: 5_000,
+      countdownMode: "min",
     });
     expect(result.current.shortname).toMatch(/^\[.*\]$/);
   });
@@ -104,8 +102,6 @@ describe("useTimerDisplay", () => {
             margonemType: 999,
           },
         }),
-        5_000,
-        15_000,
       ),
     );
 
@@ -122,8 +118,6 @@ describe("useTimerDisplay", () => {
             margonemType: "999" as never,
           },
         }),
-        5_000,
-        15_000,
       ),
     );
 
@@ -139,15 +133,13 @@ describe("useTimerDisplay", () => {
             type: NpcType.ELITE2,
           },
         }),
-        5_000,
-        15_000,
       ),
     );
 
     expect(result.current.shortname).toBe("[E2]");
   });
 
-  it("falls back to the max countdown when the min spawn time already passed and resolves overridden colors", () => {
+  it("resolves pending state and overridden colors without clock data", () => {
     const { result } = renderHook(() =>
       useTimerDisplay(
         createTimer({
@@ -157,22 +149,18 @@ describe("useTimerDisplay", () => {
           },
           isPending: true,
         }),
-        -1_000,
-        -100,
       ),
     );
 
     expect(result.current).toMatchObject({
       isPending: true,
-      isMinSpawnTime: true,
-      hasPassedRedThreshold: true,
       selectedColor: "white",
       customColor: undefined,
       overriddenColor: {
         borderColor: "#111",
         backgroundColor: "#333",
       },
-      timeLeft: -100,
+      countdownMode: "min",
     });
   });
 
@@ -181,7 +169,7 @@ describe("useTimerDisplay", () => {
 
     renderHook(() => {
       renderCount += 1;
-      return useTimerDisplay(createTimer(), 5_000, 15_000);
+      return useTimerDisplay(createTimer());
     });
 
     act(() => {

--- a/apps/game-client/src/features/timers/hooks/use-timer-display.ts
+++ b/apps/game-client/src/features/timers/hooks/use-timer-display.ts
@@ -1,7 +1,7 @@
 import { NPC_NAMES } from "@/constants/margonem";
 import type { Timer } from "@/api/timers.api";
 import { useTimersStore } from "@/store/timers.store";
-import { calculateTimeLeft, getTimerColorConfig } from "../utils/timer-helpers";
+import { getTimerColorConfig } from "../utils/timer-helpers";
 import { useShallow } from "zustand/react/shallow";
 
 const MANUAL_TIMER_MARGONEM_TYPE = 999;
@@ -26,11 +26,7 @@ const getTimerShortname = (timer: Timer, showType: boolean) => {
   return `[${typeShortname ?? "M"}]`;
 };
 
-export const useTimerDisplay = (
-  timer: Timer,
-  minTimeLeft: number,
-  maxTimeLeft: number,
-) => {
+export const useTimerDisplay = (timer: Timer) => {
   const {
     selectedColor,
     customColor,
@@ -55,9 +51,6 @@ export const useTimerDisplay = (
   );
 
   const isPending = timer.isPending ?? false;
-  const isMinSpawnTime = minTimeLeft < 0;
-  const hasPassedRedThreshold = maxTimeLeft < 0;
-
   const resetIndicator = timer.wasReset ? "[R] " : "";
 
   const shortname = getTimerShortname(timer, displayConfig.showType);
@@ -67,24 +60,15 @@ export const useTimerDisplay = (
       ? ` (${timer.npc.lvl}${timer.npc.prof.charAt(0).toLowerCase()})`
       : "";
 
-  const timeLeft = calculateTimeLeft(
-    minTimeLeft,
-    maxTimeLeft,
-    countdownMode,
-    isMinSpawnTime,
-  );
-
   return {
     isPending,
-    isMinSpawnTime,
-    hasPassedRedThreshold,
     selectedColor,
     customColor,
     overriddenColor,
     resetIndicator,
     shortname,
     npcDetails,
-    timeLeft,
     displayConfig,
+    countdownMode,
   };
 };

--- a/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.test.tsx
+++ b/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Timer } from "@/api/timers.api";
+import {
+  getNextTimerRemovalBoundary,
+  useTimerRemovalBoundary,
+} from "./use-timer-removal-boundary";
+
+const NOW = new Date("2026-07-20T10:00:00.000Z").getTime();
+
+const createTimer = (overrides?: Partial<Timer>): Timer =>
+  ({
+    guildId: "guild-1",
+    timerKey: "timer-1",
+    world: "gefion",
+    npcId: 10,
+    minSpawnTime: new Date(NOW + 4_000).toISOString(),
+    maxSpawnTime: new Date(NOW + 5_000).toISOString(),
+    updatedAt: new Date(NOW).toISOString(),
+    wasReset: false,
+    npc: { id: 10, name: "Tanroth" },
+    ...overrides,
+  }) as Timer;
+
+describe("useTimerRemovalBoundary", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses deletedAt or maxSpawnTime plus the removal delay", () => {
+    const timer = createTimer();
+    const deletedTimer = createTimer({
+      deletedAt: new Date(NOW + 2_000).toISOString(),
+    });
+
+    expect(getNextTimerRemovalBoundary([timer], 30_000, NOW)).toBe(
+      NOW + 35_000,
+    );
+    expect(getNextTimerRemovalBoundary([deletedTimer], 30_000, NOW)).toBe(
+      NOW + 32_000,
+    );
+  });
+
+  it("refreshes once at the nearest boundary without a polling interval", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+    let renderCount = 0;
+
+    renderHook(() => {
+      renderCount += 1;
+      useTimerRemovalBoundary([createTimer()], 30_000, true);
+    });
+
+    expect(renderCount).toBe(1);
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(34_999);
+    });
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(renderCount).toBe(2);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not schedule work for an empty or closed presentation", () => {
+    const empty = renderHook(() => useTimerRemovalBoundary([], 30_000, true));
+    const closed = renderHook(() =>
+      useTimerRemovalBoundary([createTimer()], 30_000, false),
+    );
+
+    expect(vi.getTimerCount()).toBe(0);
+    empty.unmount();
+    closed.unmount();
+  });
+});

--- a/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.test.tsx
+++ b/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.test.tsx
@@ -70,6 +70,32 @@ describe("useTimerRemovalBoundary", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("refreshes immediately when the removal boundary passes before the effect", () => {
+    const removalBoundary = NOW + 35_000;
+    let initialRenderCompleted = false;
+    let renderCount = 0;
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockImplementation(() =>
+        initialRenderCompleted ? removalBoundary + 1 : removalBoundary - 1,
+      );
+
+    renderHook(() => {
+      renderCount += 1;
+      useTimerRemovalBoundary([createTimer()], 30_000, true);
+      initialRenderCompleted = true;
+    });
+
+    expect(renderCount).toBe(1);
+
+    act(() => {
+      vi.runOnlyPendingTimers();
+    });
+
+    expect(renderCount).toBe(2);
+    dateNowSpy.mockRestore();
+  });
+
   it("does not schedule work for an empty or closed presentation", () => {
     const empty = renderHook(() => useTimerRemovalBoundary([], 30_000, true));
     const closed = renderHook(() =>

--- a/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.ts
+++ b/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.ts
@@ -32,30 +32,26 @@ export const useTimerRemovalBoundary = (
   timers: Timer[],
   removeTimerAfterMs: number,
   enabled: boolean,
+  renderEpoch = Date.now(),
 ) => {
-  const [, refreshTimers] = useReducer((version: number) => version + 1, 0);
+  const [refreshVersion, refreshTimers] = useReducer(
+    (version: number) => version + 1,
+    0,
+  );
+  const nextBoundary = enabled
+    ? getNextTimerRemovalBoundary(timers, removeTimerAfterMs, renderEpoch)
+    : undefined;
 
   useEffect(() => {
-    if (!enabled || timers.length === 0) {
-      return;
-    }
-
-    const now = Date.now();
-    const nextBoundary = getNextTimerRemovalBoundary(
-      timers,
-      removeTimerAfterMs,
-      now,
-    );
-
     if (nextBoundary === undefined) {
       return;
     }
 
     const timeoutId = window.setTimeout(
       refreshTimers,
-      Math.min(nextBoundary - now, MAX_TIMEOUT_DELAY_MS),
+      Math.min(Math.max(nextBoundary - Date.now(), 0), MAX_TIMEOUT_DELAY_MS),
     );
 
     return () => window.clearTimeout(timeoutId);
-  }, [enabled, removeTimerAfterMs, timers]);
+  }, [nextBoundary, refreshVersion]);
 };

--- a/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.ts
+++ b/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.ts
@@ -1,0 +1,61 @@
+import type { Timer } from "@/api/timers.api";
+import { useEffect, useReducer } from "react";
+
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
+const getTimerRemovalBoundary = (timer: Timer, removeTimerAfterMs: number) => {
+  const expiryTimestamp = timer.deletedAt ?? timer.maxSpawnTime;
+  return new Date(expiryTimestamp).getTime() + removeTimerAfterMs;
+};
+
+export const getNextTimerRemovalBoundary = (
+  timers: Timer[],
+  removeTimerAfterMs: number,
+  now = Date.now(),
+) => {
+  let nextBoundary: number | undefined;
+
+  for (const timer of timers) {
+    const boundary = getTimerRemovalBoundary(timer, removeTimerAfterMs);
+    if (
+      boundary > now &&
+      (nextBoundary === undefined || boundary < nextBoundary)
+    ) {
+      nextBoundary = boundary;
+    }
+  }
+
+  return nextBoundary;
+};
+
+export const useTimerRemovalBoundary = (
+  timers: Timer[],
+  removeTimerAfterMs: number,
+  enabled: boolean,
+) => {
+  const [, refreshTimers] = useReducer((version: number) => version + 1, 0);
+
+  useEffect(() => {
+    if (!enabled || timers.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const nextBoundary = getNextTimerRemovalBoundary(
+      timers,
+      removeTimerAfterMs,
+      now,
+    );
+
+    if (nextBoundary === undefined) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(
+      refreshTimers,
+      Math.min(nextBoundary - now, MAX_TIMEOUT_DELAY_MS),
+    );
+
+    return () => window.clearTimeout(timeoutId);
+  }, [enabled, removeTimerAfterMs, timers]);
+};

--- a/apps/game-client/src/features/timers/timers-countdown.test.tsx
+++ b/apps/game-client/src/features/timers/timers-countdown.test.tsx
@@ -13,6 +13,7 @@ beforeEach(() =>
 );
 
 const testState = vi.hoisted(() => ({
+  contentRenderSpy: vi.fn(),
   timers: [] as Timer[],
 }));
 
@@ -87,11 +88,14 @@ vi.mock("@/features/timers/components/timers-under-bag-actions", () => ({
 }));
 
 vi.mock("@/features/timers/components/timers-content", () => ({
-  TimersContent: ({ sortedTimers }: { sortedTimers: TimerWithTimeLeft[] }) => (
-    <output data-testid="timer-countdown">
-      {sortedTimers[0]?.maxTimeLeft ?? "missing"}
-    </output>
-  ),
+  TimersContent: ({ sortedTimers }: { sortedTimers: TimerWithTimeLeft[] }) => {
+    testState.contentRenderSpy();
+    return (
+      <output data-testid="timer-countdown">
+        {sortedTimers[0]?.maxTimeLeft ?? "missing"}
+      </output>
+    );
+  },
 }));
 
 import { TimersView } from "./timers-view";
@@ -124,6 +128,7 @@ describe("visible timer countdown", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
+    testState.contentRenderSpy.mockReset();
     testState.timers = [createVisibleTimer()];
   });
 
@@ -131,16 +136,25 @@ describe("visible timer countdown", () => {
     vi.useRealTimers();
   });
 
-  it("updates an under-bag timer after every one-second clock tick", () => {
+  it("updates the structural list only at the timer removal boundary", () => {
     render(<TimersView isOpen isUnderBag />);
 
     expect(screen.getByTestId("timer-countdown")).toHaveTextContent("5000");
+    expect(testState.contentRenderSpy).toHaveBeenCalledOnce();
 
     act(() => {
       vi.advanceTimersByTime(1_000);
     });
 
-    expect(screen.getByTestId("timer-countdown")).toHaveTextContent("4000");
+    expect(screen.getByTestId("timer-countdown")).toHaveTextContent("5000");
+    expect(testState.contentRenderSpy).toHaveBeenCalledOnce();
+
+    act(() => {
+      vi.advanceTimersByTime(34_000);
+    });
+
+    expect(screen.getByTestId("timer-countdown")).toHaveTextContent("missing");
+    expect(testState.contentRenderSpy).toHaveBeenCalledTimes(2);
   });
 
   it("does not keep a clock running when under-bag has no visible timer", () => {

--- a/apps/game-client/src/features/timers/timers-view.tsx
+++ b/apps/game-client/src/features/timers/timers-view.tsx
@@ -140,13 +140,15 @@ export const TimersView = ({ isOpen, isUnderBag }: TimersViewProps) => {
   const mergedTimers = generalConfig.timersGrouping
     ? mergeTimers(deduplicatedTimers)
     : normalizeUngroupedTimers(deduplicatedTimers);
+  const timerCalculationEpoch = Date.now();
   useTimerRemovalBoundary(
     mergedTimers,
     generalConfig.removeTimerAfterMs,
     isUnderBag || isOpen,
+    timerCalculationEpoch,
   );
   const activeTimers = filterTimersByExpiredVisibility(
-    calculateTimeLeft(mergedTimers),
+    calculateTimeLeft(mergedTimers, timerCalculationEpoch),
     generalConfig.removeTimerAfterMs,
     alwaysVisibleExpiredTimers,
   );

--- a/apps/game-client/src/features/timers/timers-view.tsx
+++ b/apps/game-client/src/features/timers/timers-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
 import type { Timer } from "@/api/timers.api";
@@ -7,7 +7,7 @@ import { TimersActions } from "@/features/timers/components/timers-actions";
 import { TimersContent } from "@/features/timers/components/timers-content";
 import { TimersUnderBagActions } from "@/features/timers/components/timers-under-bag-actions";
 import { useTimersFiltering } from "@/features/timers/hooks/use-timers-filtering";
-import { useTimersUpdate } from "@/features/timers/hooks/use-timers-update";
+import { useTimerRemovalBoundary } from "@/features/timers/hooks/use-timer-removal-boundary";
 import { UnderBagTimers } from "@/features/timers/under-bag-timers";
 import { calculateColorStatistics } from "@/features/timers/utils/color-statistics";
 import { checkFiltersActive } from "@/features/timers/utils/filters-utils";
@@ -129,10 +129,6 @@ export const TimersView = ({ isOpen, isUnderBag }: TimersViewProps) => {
   const timersRefreshError = Boolean(timersError) && hasTimersResponse;
   const timersRefreshing = timersFetching && hasTimersResponse;
   const [showHiddenTimers, setShowHiddenTimers] = useState(false);
-  const [timerClockEnabled, setTimerClockEnabled] = useState(
-    !isUnderBag && isOpen,
-  );
-  const timerClockEpoch = useTimersUpdate(timerClockEnabled);
   const settingsKey = generalConfig.timersGrouping ? "global" : guildId;
   const filters = timersFilters[settingsKey] ?? DEFAULT_TIMERS_FILTERS;
   const hiddenTimersForSettings = hiddenTimers[settingsKey] ?? [];
@@ -144,8 +140,13 @@ export const TimersView = ({ isOpen, isUnderBag }: TimersViewProps) => {
   const mergedTimers = generalConfig.timersGrouping
     ? mergeTimers(deduplicatedTimers)
     : normalizeUngroupedTimers(deduplicatedTimers);
+  useTimerRemovalBoundary(
+    mergedTimers,
+    generalConfig.removeTimerAfterMs,
+    isUnderBag || isOpen,
+  );
   const activeTimers = filterTimersByExpiredVisibility(
-    calculateTimeLeft(mergedTimers, timerClockEpoch),
+    calculateTimeLeft(mergedTimers),
     generalConfig.removeTimerAfterMs,
     alwaysVisibleExpiredTimers,
   );
@@ -172,10 +173,6 @@ export const TimersView = ({ isOpen, isUnderBag }: TimersViewProps) => {
     expiredTimersAtBottom: true,
     removeTimerAfterMs: generalConfig.removeTimerAfterMs,
   });
-  const shouldEnableTimerClock = isUnderBag ? visibleTimers.length > 0 : isOpen;
-  useEffect(() => {
-    setTimerClockEnabled(shouldEnableTimerClock);
-  }, [shouldEnableTimerClock]);
   const sortedTimers = visibleTimers;
   const colorStatistics = calculateColorStatistics(
     timersColors as Record<string, string>,

--- a/apps/game-client/src/features/timers/timers.test.tsx
+++ b/apps/game-client/src/features/timers/timers.test.tsx
@@ -6,7 +6,6 @@ import { setTestRuntimeGame } from "@/test/test-runtime-window";
 
 const mockUseTimers = vi.fn();
 const mockUseTimersSocket = vi.fn();
-const mockUseTimersUpdate = vi.fn();
 const mockUseTimersFiltering = vi.fn();
 const mockCalculateColorStatistics = vi.fn();
 const mockCheckFiltersActive = vi.fn();
@@ -100,10 +99,6 @@ vi.mock("@/store/timers.store", () => ({
 
 vi.mock("@/features/timers/hooks/use-timers-socket", () => ({
   useTimersSocket: () => mockUseTimersSocket(),
-}));
-
-vi.mock("@/features/timers/hooks/use-timers-update", () => ({
-  useTimersUpdate: (...args: unknown[]) => mockUseTimersUpdate(...args),
 }));
 
 vi.mock("@/features/timers/hooks/use-timers-filtering", () => ({
@@ -200,7 +195,6 @@ describe("Timers", () => {
     });
     mockUseTimers.mockReset();
     mockUseTimersSocket.mockReset();
-    mockUseTimersUpdate.mockReset();
     mockUseTimersFiltering.mockReset();
     mockCalculateColorStatistics.mockReset();
     mockCheckFiltersActive.mockReset();
@@ -293,7 +287,6 @@ describe("Timers", () => {
       | { calculatedTimers: unknown[] }
       | undefined;
     expect(filteringInput?.calculatedTimers).toHaveLength(1);
-    expect(mockUseTimersUpdate).toHaveBeenCalledWith(true);
     expect(mockUseTimersFiltering).toHaveBeenCalledWith(
       expect.objectContaining({
         guildId: "guild-1",
@@ -416,7 +409,6 @@ describe("Timers", () => {
     expect(screen.getByTestId("under-bag")).toBeInTheDocument();
     expect(screen.getByText("TimersUnderBagActions")).toBeInTheDocument();
     expect(screen.queryByTestId("draggable-window")).not.toBeInTheDocument();
-    expect(mockUseTimersUpdate).toHaveBeenCalledWith(true);
     expect(timersContentSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         isUnderBag: true,
@@ -442,7 +434,6 @@ describe("Timers", () => {
 
     render(<Timers />);
 
-    expect(mockUseTimersUpdate).toHaveBeenCalledWith(false);
     expect(timersContentSpy).toHaveBeenCalledWith(
       expect.objectContaining({ sortedTimers: [] }),
     );
@@ -455,7 +446,6 @@ describe("Timers", () => {
 
     expect(mockUseTimersSocket).toHaveBeenCalledOnce();
     expect(mockUseTimers).not.toHaveBeenCalled();
-    expect(mockUseTimersUpdate).not.toHaveBeenCalled();
     expect(timersContentSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/game-client/src/features/timers/utils/timers-utils.ts
+++ b/apps/game-client/src/features/timers/utils/timers-utils.ts
@@ -139,24 +139,32 @@ export const calculateTimeLeft = (
   now = Date.now(),
 ): TimerWithTimeLeft[] => {
   return timers.map((timer) => {
-    const deletedAt = timer.deletedAt ? getTimerEpoch(timer.deletedAt) : null;
-
-    if (deletedAt !== null) {
-      const deletedTimeLeft = deletedAt - now;
-
-      return {
-        ...timer,
-        maxTimeLeft: deletedTimeLeft,
-        minTimeLeft: deletedTimeLeft,
-      };
-    }
-
     return {
       ...timer,
-      maxTimeLeft: getTimerEpoch(timer.maxSpawnTime) - now,
-      minTimeLeft: getTimerEpoch(timer.minSpawnTime) - now,
+      ...getTimerTimeLeft(timer, now),
     };
   });
+};
+
+export const getTimerTimeLeft = (
+  timer: Timer,
+  now = Date.now(),
+): Pick<TimerWithTimeLeft, "maxTimeLeft" | "minTimeLeft"> => {
+  const deletedAt = timer.deletedAt ? getTimerEpoch(timer.deletedAt) : null;
+
+  if (deletedAt !== null) {
+    const deletedTimeLeft = deletedAt - now;
+
+    return {
+      maxTimeLeft: deletedTimeLeft,
+      minTimeLeft: deletedTimeLeft,
+    };
+  }
+
+  return {
+    maxTimeLeft: getTimerEpoch(timer.maxSpawnTime) - now,
+    minTimeLeft: getTimerEpoch(timer.minSpawnTime) - now,
+  };
 };
 
 export const filterTimersByRemovalTime = (


### PR DESCRIPTION
## Summary

- Move the shared one-second clock into visible live timer tiles so ticks do not repeat list-wide filtering, sorting, grouping, color statistics, or permission work.
- Split time-dependent countdown and expiry presentation from static tile data.
- Replace periodic expiry filtering with one timeout scheduled at the next removal boundary.
- Stop the clock when no timer tiles are visible.

## Testing

- pnpm --filter @lootlog/game-client test (240 files, 1284 tests)
- pnpm --filter @lootlog/game-client typecheck
- pnpm --filter @lootlog/game-client lint

## Screenshots or recordings

Not applicable. The timer presentation is unchanged.

## Risks and rollout

No API, protocol, persisted preference, dependency, or Margonem runtime changes. Focused coverage includes shared clock lifecycle, countdown phases, always-visible timers, expiry boundaries, and 1, 20, and 100 timer scenarios.

## Checklist

- [x] A changeset is included
- [x] Relevant tests were added and run
- [x] Migrations, environment variables, documentation, and breaking changes are not required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Live timer tiles now update countdowns continuously and transition accurately between minimum and maximum spawn times.
  - Timer displays remain visible through their countdown and are removed at the correct expiry boundary.
- **Performance Improvements**
  - Countdown updates no longer repeat static tile rendering or permission checks, improving efficiency for timer grids.
- **Bug Fixes**
  - Deleted and expiring timers now use accurate timing information for display and removal.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->