### PR TITLE
perf(game-client): batch chat updates and stabilize scrolling

### DIFF
--- a/.changeset/quick-chats-gather.md
+++ b/.changeset/quick-chats-gather.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/game-client": patch
+---
+
+Batch chat cache ingress once per organization and frame, keep the first NPC report stable while counting matching reports, render incoming messages without moving the history viewport, and prevent content resizes from snapping an explicit upward scroll back to the bottom.

--- a/apps/game-client/src/features/chat/chat-cache-batcher.ts
+++ b/apps/game-client/src/features/chat/chat-cache-batcher.ts
@@ -1,0 +1,142 @@
+import type { ChatMessage } from "@/api/chat.api";
+import type { QueryClient } from "@tanstack/react-query";
+import {
+  removeChatMessage,
+  updateChatMessage,
+  upsertChatMessage,
+} from "./chat.helpers";
+import { updateChatMessagesCache } from "./chat-query-cache.helpers";
+
+const CHAT_CACHE_FLUSH_TIMEOUT_MS = 50;
+
+type ChatCacheOperation =
+  | { kind: "create"; message: ChatMessage }
+  | { guildId: string; kind: "delete"; messageId: string }
+  | { guildId: string; kind: "update"; message: string; messageId: string }
+  | { guildId: string; kind: "clear" };
+
+type QueuedChatCacheOperation = {
+  afterFlush?: () => void;
+  operation: ChatCacheOperation;
+};
+
+const getOperationGuildId = (operation: ChatCacheOperation) => {
+  return operation.kind === "create"
+    ? operation.message.guildId
+    : operation.guildId;
+};
+
+const applyChatCacheOperations = (
+  messages: ChatMessage[] | undefined,
+  operations: ChatCacheOperation[],
+) => {
+  let nextMessages = messages;
+
+  for (const operation of operations) {
+    switch (operation.kind) {
+      case "create":
+        nextMessages = upsertChatMessage(nextMessages, operation.message);
+        break;
+      case "update":
+        if (nextMessages) {
+          nextMessages = updateChatMessage(
+            nextMessages,
+            operation.messageId,
+            operation.message,
+          );
+        }
+        break;
+      case "delete":
+        if (nextMessages) {
+          nextMessages = removeChatMessage(nextMessages, operation.messageId);
+        }
+        break;
+      case "clear":
+        nextMessages = [];
+        break;
+    }
+  }
+
+  return nextMessages;
+};
+
+export const createChatCacheBatcher = (queryClient: QueryClient) => {
+  let frameId: number | null = null;
+  let timeoutId: number | null = null;
+  let queuedOperations: QueuedChatCacheOperation[] = [];
+
+  const cancelScheduledFlush = () => {
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const flush = () => {
+    if (queuedOperations.length === 0) {
+      cancelScheduledFlush();
+      return;
+    }
+
+    const acceptedOperations = queuedOperations;
+    queuedOperations = [];
+    cancelScheduledFlush();
+    const operationsByGuildId = new Map<string, ChatCacheOperation[]>();
+
+    for (const { operation } of acceptedOperations) {
+      const guildId = getOperationGuildId(operation);
+      const guildOperations = operationsByGuildId.get(guildId);
+      if (guildOperations) {
+        guildOperations.push(operation);
+      } else {
+        operationsByGuildId.set(guildId, [operation]);
+      }
+    }
+
+    for (const [guildId, operations] of operationsByGuildId) {
+      updateChatMessagesCache({
+        guildId,
+        queryClient,
+        updater: (messages) => applyChatCacheOperations(messages, operations),
+      });
+    }
+
+    for (const { afterFlush } of acceptedOperations) {
+      afterFlush?.();
+    }
+  };
+
+  const scheduleFlush = () => {
+    if (frameId === null) {
+      frameId = requestAnimationFrame(flush);
+    }
+    if (timeoutId === null) {
+      timeoutId = window.setTimeout(flush, CHAT_CACHE_FLUSH_TIMEOUT_MS);
+    }
+  };
+
+  return {
+    discardAll() {
+      queuedOperations = [];
+      cancelScheduledFlush();
+    },
+    discardOutsideGuilds(guildIds: readonly string[]) {
+      const accessibleGuildIds = new Set(guildIds);
+      queuedOperations = queuedOperations.filter(({ operation }) =>
+        accessibleGuildIds.has(getOperationGuildId(operation)),
+      );
+      if (queuedOperations.length === 0) {
+        cancelScheduledFlush();
+      }
+    },
+    enqueue(operation: ChatCacheOperation, afterFlush?: () => void) {
+      queuedOperations.push({ afterFlush, operation });
+      scheduleFlush();
+    },
+    flush,
+  };
+};

--- a/apps/game-client/src/features/chat/chat-scroll-controller.test.ts
+++ b/apps/game-client/src/features/chat/chat-scroll-controller.test.ts
@@ -48,7 +48,7 @@ describe("chat scroll controller", () => {
     controller.registerUserScrollIntent({
       clientHeight: 300,
       scrollHeight: 1_300,
-      scrollTop: 927,
+      scrollTop: 928,
     });
     controller.observe({
       clientHeight: 300,
@@ -89,7 +89,7 @@ describe("chat scroll controller", () => {
     controller.registerUserScrollIntent({
       clientHeight: 300,
       scrollHeight: 1_300,
-      scrollTop: 512,
+      scrollTop: 1_000,
     });
     controller.observe({
       clientHeight: 300,
@@ -99,6 +99,27 @@ describe("chat scroll controller", () => {
 
     expect(controller.getMode()).toBe("reading-history");
     expect(scrollCommands).toEqual([{ behavior: "auto", top: 1_000 }]);
+  });
+
+  it("keeps following when explicit input moves toward the physical bottom", () => {
+    const controller = createChatScrollController({
+      applyScroll: () => undefined,
+      nearBottomThreshold: 72,
+    });
+    controller.completeInitialization();
+    controller.registerUserScrollIntent({
+      clientHeight: 300,
+      scrollHeight: 1_300,
+      scrollTop: 900,
+    });
+
+    controller.observe({
+      clientHeight: 300,
+      scrollHeight: 1_300,
+      scrollTop: 950,
+    });
+
+    expect(controller.shouldFollowNewMessages()).toBe(true);
   });
 
   it("preserves a history position without changing it into an animated scroll", () => {
@@ -111,7 +132,7 @@ describe("chat scroll controller", () => {
     controller.registerUserScrollIntent({
       clientHeight: 300,
       scrollHeight: 1_300,
-      scrollTop: 700,
+      scrollTop: 1_000,
     });
     controller.observe({
       clientHeight: 300,
@@ -153,7 +174,7 @@ describe("chat scroll controller", () => {
     controller.registerUserScrollIntent({
       clientHeight: 300,
       scrollHeight: 1_300,
-      scrollTop: 800,
+      scrollTop: 990,
     });
     controller.observe({
       clientHeight: 300,

--- a/apps/game-client/src/features/chat/chat-scroll-controller.ts
+++ b/apps/game-client/src/features/chat/chat-scroll-controller.ts
@@ -43,6 +43,12 @@ export const createChatScrollController = ({
   let mode: ChatScrollMode = "initializing";
   let programmaticTarget: number | null = null;
   let userScrollIntentPending = false;
+  let userScrollIntentStartTop: number | null = null;
+
+  const clearUserScrollIntent = () => {
+    userScrollIntentPending = false;
+    userScrollIntentStartTop = null;
+  };
 
   const scroll = (
     snapshot: ChatScrollSnapshot,
@@ -71,6 +77,10 @@ export const createChatScrollController = ({
       const distanceFromBottom =
         snapshot.scrollHeight - (snapshot.scrollTop + snapshot.clientHeight);
       let missedProgrammaticTarget = false;
+      const userScrolledTowardHistory =
+        userScrollIntentPending &&
+        userScrollIntentStartTop !== null &&
+        snapshot.scrollTop < userScrollIntentStartTop;
 
       if (programmaticTarget !== null) {
         const reachedProgrammaticTarget =
@@ -82,7 +92,7 @@ export const createChatScrollController = ({
           mode = "reading-history";
         }
         if (reachedProgrammaticTarget) {
-          userScrollIntentPending = false;
+          clearUserScrollIntent();
           return;
         }
       }
@@ -91,21 +101,27 @@ export const createChatScrollController = ({
         if (distanceFromBottom <= 2) {
           mode = "following-bottom";
         }
-        userScrollIntentPending = false;
+        clearUserScrollIntent();
         return;
       }
 
       if (
         mode === "following-bottom" &&
-        (userScrollIntentPending || missedProgrammaticTarget) &&
-        distanceFromBottom > nearBottomThreshold
+        ((userScrolledTowardHistory && distanceFromBottom > 2) ||
+          (missedProgrammaticTarget &&
+            distanceFromBottom > nearBottomThreshold))
       ) {
         mode = "reading-history";
-        userScrollIntentPending = false;
+        clearUserScrollIntent();
         return;
       }
-      userScrollIntentPending =
-        userScrollIntentPending && distanceFromBottom > 2;
+      if (
+        userScrollIntentPending &&
+        userScrollIntentStartTop !== null &&
+        snapshot.scrollTop >= userScrollIntentStartTop
+      ) {
+        clearUserScrollIntent();
+      }
     },
     pinToBottom: (snapshot) => {
       const maximumScrollTop = getMaximumScrollTop(snapshot);
@@ -119,8 +135,9 @@ export const createChatScrollController = ({
     preservePosition: (snapshot, top) => {
       scroll(snapshot, "auto", top);
     },
-    registerUserScrollIntent: (_snapshot) => {
+    registerUserScrollIntent: (snapshot) => {
       userScrollIntentPending = true;
+      userScrollIntentStartTop = snapshot.scrollTop;
       programmaticTarget = null;
     },
     requestFollowBottom: () => {

--- a/apps/game-client/src/features/chat/chat.helpers.test.ts
+++ b/apps/game-client/src/features/chat/chat.helpers.test.ts
@@ -282,13 +282,13 @@ describe("chat helpers", () => {
       {
         kind: "date-divider",
         key: "date-divider:2026-01-01",
-        timestamp: "2026-01-01T10:00:30.000Z",
+        timestamp: "2026-01-01T10:00:00.000Z",
       },
       {
         kind: "npc-group",
         key: "npc-group:npc-1",
         count: 2,
-        message: secondNpcMessage,
+        message: firstNpcMessage,
       },
       {
         kind: "npc-group",
@@ -362,19 +362,19 @@ describe("chat helpers", () => {
       {
         kind: "date-divider",
         key: "date-divider:2026-01-01",
-        timestamp: "2026-01-01T10:00:10.000Z",
+        timestamp: "2026-01-01T10:00:00.000Z",
       },
       {
         kind: "npc-group",
         key: "npc-group:npc-a-1",
         count: 2,
-        message: expect.objectContaining({ id: "npc-a-2" }),
+        message: expect.objectContaining({ id: "npc-a-1" }),
       },
       {
         kind: "npc-group",
         key: "npc-group:npc-b-1",
         count: 2,
-        message: expect.objectContaining({ id: "npc-b-2" }),
+        message: expect.objectContaining({ id: "npc-b-1" }),
       },
     ]);
   });
@@ -488,13 +488,60 @@ describe("chat helpers", () => {
       {
         kind: "date-divider",
         key: "date-divider:2026-01-01",
-        timestamp: "2026-01-01T10:00:10.000Z",
+        timestamp: "2026-01-01T10:00:00.000Z",
       },
       {
         kind: "npc-group",
         key: "npc-group:npc-a-1",
         count: 3,
-        message: expect.objectContaining({ id: "npc-a-3" }),
+        message: expect.objectContaining({ id: "npc-a-1", senderId: "user-1" }),
+      },
+    ]);
+  });
+
+  it("keeps the first report stable while counting a fifteen-message NPC burst", () => {
+    const firstMessage = makeChatMessage({
+      id: "npc-0",
+      senderId: "sender-0",
+      message: "",
+      timestamp: "2026-01-01T10:00:00.000Z",
+      type: MessageType.NPC,
+      npc: {
+        id: 10,
+        name: "Hydra",
+        icon: "npc.png",
+        x: 1,
+        y: 2,
+        hpp: 100,
+        location: "Cave",
+        lvl: 50,
+        prof: "m",
+        type: 1,
+        wt: 100,
+      },
+    });
+    const messages = Array.from({ length: 15 }, (_, index) => ({
+      ...firstMessage,
+      id: `npc-${index}`,
+      senderId: `sender-${index % 4}`,
+      timestamp: new Date(
+        new Date(firstMessage.timestamp).getTime() + index * 1_000,
+      ).toISOString(),
+    }));
+
+    const renderables = getChatRenderableMessages(messages);
+
+    expect(renderables).toEqual([
+      {
+        kind: "date-divider",
+        key: "date-divider:2026-01-01",
+        timestamp: firstMessage.timestamp,
+      },
+      {
+        kind: "npc-group",
+        key: "npc-group:npc-0",
+        count: 15,
+        message: firstMessage,
       },
     ]);
   });

--- a/apps/game-client/src/features/chat/chat.helpers.ts
+++ b/apps/game-client/src/features/chat/chat.helpers.ts
@@ -245,8 +245,6 @@ export const getChatRenderableMessages = (
     }
 
     existingGroup.count += 1;
-    existingGroup.message = message;
-    existingGroup.sortTimestamp = timestamp;
   }
 
   renderables.sort((firstRenderable, secondRenderable) => {

--- a/apps/game-client/src/features/chat/components/chat-message-list.test.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.test.tsx
@@ -386,6 +386,26 @@ describe("ChatMessageList", () => {
     );
   });
 
+  it("does not snap a small explicit upward scroll to the bottom when content resizes", () => {
+    renderMessageList(createRenderables(120));
+    const viewport = screen.getByTestId("chat-scroll-viewport");
+    const userScrollTop = viewport.scrollHeight - viewport.clientHeight - 3;
+
+    fireEvent.wheel(viewport, { deltaY: -3 });
+    viewport.scrollTop = userScrollTop;
+    fireEvent.scroll(viewport);
+    scrollRequests.length = 0;
+
+    triggerMessageListResize();
+    flushAnimationFrames(2);
+
+    expect(viewport.scrollTop).toBe(userScrollTop);
+    expect(scrollRequests.at(-1)).toMatchObject({
+      behavior: "auto",
+      top: userScrollTop,
+    });
+  });
+
   it("reflows appearance at the bottom without starting a scroll animation", () => {
     const renderables = createRenderables(120);
     const readableAppearance: ChatAppearanceSettings = {
@@ -525,7 +545,7 @@ describe("ChatMessageList", () => {
       (viewport: HTMLElement) => fireEvent.pointerDown(viewport),
     ],
   ])(
-    "keeps history frozen after %s input moves beyond 72 px",
+    "renders new messages without moving after %s input moves beyond 72 px",
     (_inputMethod, registerIntent) => {
       const initialRenderables = createRenderables(120);
       const { rerender } = renderMessageList(initialRenderables);
@@ -541,26 +561,25 @@ describe("ChatMessageList", () => {
       rerender(createMessageListElement(createRenderables(121)));
 
       expect(viewport.scrollTop).toBe(historyScrollTop);
-      expect(screen.queryByTestId("message-120")).not.toBeInTheDocument();
+      expect(screen.getByTestId("message-120")).toBeInTheDocument();
       expect(scrollRequests).toHaveLength(0);
     },
   );
 
-  it("continues following inside the 72 px bottom zone", () => {
+  it("renders new messages without moving after explicit upward movement inside the 72 px bottom zone", () => {
     const initialRenderables = createRenderables(120);
     const { rerender } = renderMessageList(initialRenderables);
     const viewport = screen.getByTestId("chat-scroll-viewport");
+    const historyScrollTop = viewport.scrollHeight - viewport.clientHeight - 72;
 
     fireEvent.wheel(viewport, { deltaY: -72 });
-    viewport.scrollTop = viewport.scrollHeight - viewport.clientHeight - 72;
+    viewport.scrollTop = historyScrollTop;
     fireEvent.scroll(viewport);
 
     rerender(createMessageListElement(createRenderables(121)));
 
     expect(screen.getByTestId("message-120")).toBeInTheDocument();
-    expect(viewport.scrollTop).toBe(
-      viewport.scrollHeight - viewport.clientHeight,
-    );
+    expect(viewport.scrollTop).toBe(historyScrollTop);
   });
 
   it("shows updates to an existing party gathering while reading history", () => {
@@ -609,7 +628,7 @@ describe("ChatMessageList", () => {
     expect(viewport.scrollTop).toBe(0);
   });
 
-  it("freezes the rendered snapshot when the bounded history evicts an entry", () => {
+  it("preserves the anchor while bounded history replaces its oldest entry", () => {
     const initialRenderables = createRenderables(500);
     const { rerender } = renderMessageList(initialRenderables);
     const viewport = screen.getByTestId("chat-scroll-viewport");
@@ -617,16 +636,21 @@ describe("ChatMessageList", () => {
     viewport.scrollTop = 5_000;
     fireEvent.scroll(viewport);
     const anchoredKey = getFirstVisibleRow()?.dataset.chatRowKey;
+    const anchoredOffset = getFirstVisibleRow()?.getBoundingClientRect().top;
     expect(anchoredKey).toBeDefined();
 
     rerender(createMessageListElement(createRenderables(501).slice(1)));
+    triggerMessageListResize();
+    flushAnimationFrames(2);
 
-    expect(
-      screen
-        .getAllByRole("listitem")
-        .some((row) => row.dataset.chatRowKey === anchoredKey),
-    ).toBe(true);
-    expect(screen.queryByTestId("message-500")).not.toBeInTheDocument();
+    const anchoredRow = screen
+      .getAllByRole("listitem")
+      .find((row) => row.dataset.chatRowKey === anchoredKey);
+    expect(anchoredRow?.getBoundingClientRect().top).toBeCloseTo(
+      anchoredOffset ?? 0,
+    );
+    expect(screen.queryByTestId("message-0")).not.toBeInTheDocument();
+    expect(screen.getByTestId("message-500")).toBeInTheDocument();
   });
 
   it("follows consecutive messages at the bottom without smooth animation", () => {

--- a/apps/game-client/src/features/chat/components/chat-message-list.tsx
+++ b/apps/game-client/src/features/chat/components/chat-message-list.tsx
@@ -10,10 +10,7 @@ import { useEffect, useLayoutEffect, useRef, useState, type FC } from "react";
 import { getChatDensityStyle } from "../chat-density";
 import { createChatScrollController } from "../chat-scroll-controller";
 import { subscribeToChatScrollToMessage } from "../chat-scroll-to-message";
-import {
-  getChatRenderableMessagesSignature,
-  type ChatRenderableMessage,
-} from "../chat.helpers";
+import type { ChatRenderableMessage } from "../chat.helpers";
 import { ChatDateDivider } from "./chat-date-divider";
 import { EmptyState } from "@/components/empty-state";
 import { MessageCircle } from "lucide-react";
@@ -46,31 +43,18 @@ type ChatViewportAnchor = {
   rowKey: string;
 };
 
-const refreshDisplayedChatRenderables = (
-  displayedRenderables: ChatRenderableMessage[],
-  latestRenderables: ChatRenderableMessage[],
-) => {
-  const latestRenderablesByKey = new Map(
-    latestRenderables.map((renderable) => [renderable.key, renderable]),
-  );
-
-  return displayedRenderables.map(
-    (renderable) => latestRenderablesByKey.get(renderable.key) ?? renderable,
-  );
-};
-
 export const ChatMessageList: FC<ChatMessageListProps> = ({
   appearance = CHAT_APPEARANCE_READABLE_PRESET,
   npcTypeColors,
   ariaLabel,
   emptyStateTitle,
   guildNamesById,
-  hasRenderableMessages: latestHasRenderableMessages,
+  hasRenderableMessages,
   membersByGuildId,
   mentionContextsByGuildId,
   onReplyToMessage,
-  renderSignature: latestRenderSignature,
-  renderables: latestRenderables,
+  renderSignature,
+  renderables,
   scrollToBottomRequest = 0,
   selectedGuildId,
 }) => {
@@ -98,49 +82,7 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
       nearBottomThreshold: CHAT_AUTOSCROLL_THRESHOLD_PX,
     }),
   );
-  const [displayedMessages, setDisplayedMessages] = useState({
-    hasRenderableMessages: latestHasRenderableMessages,
-    renderSignature: latestRenderSignature,
-    renderables: latestRenderables,
-  });
-  const { hasRenderableMessages, renderSignature, renderables } =
-    displayedMessages;
   const hasRenderedRows = renderables.length > 0;
-
-  useEffect(() => {
-    const ownMessageScrollRequested =
-      scrollToBottomRequest !== previousScrollToBottomRequestRef.current;
-    const shouldUseLatestMessages =
-      scrollController.getMode() !== "reading-history" ||
-      ownMessageScrollRequested;
-
-    setDisplayedMessages((currentMessages) => {
-      if (shouldUseLatestMessages) {
-        return {
-          hasRenderableMessages: latestHasRenderableMessages,
-          renderSignature: latestRenderSignature,
-          renderables: latestRenderables,
-        };
-      }
-
-      const refreshedRenderables = refreshDisplayedChatRenderables(
-        currentMessages.renderables,
-        latestRenderables,
-      );
-      return {
-        ...currentMessages,
-        renderSignature:
-          getChatRenderableMessagesSignature(refreshedRenderables),
-        renderables: refreshedRenderables,
-      };
-    });
-  }, [
-    latestHasRenderableMessages,
-    latestRenderSignature,
-    latestRenderables,
-    scrollController,
-    scrollToBottomRequest,
-  ]);
 
   getScrollSnapshotRef.current = () => {
     const scrollViewport = scrollAreaRef.current;
@@ -217,18 +159,26 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
     if (!scrollViewport) return;
 
     const updateScrollState = () => {
-      scrollController.observe(getScrollSnapshotRef.current());
+      const snapshot = getScrollSnapshotRef.current();
+      scrollController.observe(snapshot);
       if (scrollController.getMode() === "reading-history") {
         captureViewportAnchorRef.current();
       }
     };
     const registerUserScrollIntent = () => {
-      scrollController.registerUserScrollIntent(getScrollSnapshotRef.current());
+      const snapshot = getScrollSnapshotRef.current();
+      scrollController.registerUserScrollIntent(snapshot);
     };
     const handleWheel = (event: WheelEvent) => {
       if (event.deltaY === 0) return;
       registerUserScrollIntent();
       captureViewportAnchorRef.current();
+    };
+    const handleTouchStart = () => {
+      registerUserScrollIntent();
+    };
+    const handlePointerDown = () => {
+      registerUserScrollIntent();
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
@@ -252,10 +202,10 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
       passive: true,
     });
     scrollViewport.addEventListener("wheel", handleWheel, { passive: true });
-    scrollViewport.addEventListener("touchstart", registerUserScrollIntent, {
+    scrollViewport.addEventListener("touchstart", handleTouchStart, {
       passive: true,
     });
-    scrollViewport.addEventListener("pointerdown", registerUserScrollIntent, {
+    scrollViewport.addEventListener("pointerdown", handlePointerDown, {
       passive: true,
     });
     scrollViewport.addEventListener("keydown", handleKeyDown);
@@ -263,14 +213,8 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
     return () => {
       scrollViewport.removeEventListener("scroll", updateScrollState);
       scrollViewport.removeEventListener("wheel", handleWheel);
-      scrollViewport.removeEventListener(
-        "touchstart",
-        registerUserScrollIntent,
-      );
-      scrollViewport.removeEventListener(
-        "pointerdown",
-        registerUserScrollIntent,
-      );
+      scrollViewport.removeEventListener("touchstart", handleTouchStart);
+      scrollViewport.removeEventListener("pointerdown", handlePointerDown);
       scrollViewport.removeEventListener("keydown", handleKeyDown);
     };
   }, [scrollController]);
@@ -284,7 +228,9 @@ export const ChatMessageList: FC<ChatMessageListProps> = ({
 
       resizeCorrectionFrameRef.current = requestAnimationFrame(() => {
         resizeCorrectionFrameRef.current = null;
-        if (scrollController.shouldFollowNewMessages()) {
+        const shouldFollowNewMessages =
+          scrollController.shouldFollowNewMessages();
+        if (shouldFollowNewMessages) {
           scrollToPhysicalBottomRef.current();
         } else {
           restoreViewportAnchorRef.current();

--- a/apps/game-client/src/features/chat/hooks/use-chat-messages.test.tsx
+++ b/apps/game-client/src/features/chat/hooks/use-chat-messages.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayEvent } from "@/config/gateway";
 import { useChatMessagesListener } from "./use-chat-messages";
 import { useGameStore } from "@/store/game.store";
@@ -66,7 +66,26 @@ vi.mock("@/lib/game", () => ({
 }));
 
 describe("useChatMessagesListener", () => {
+  let frameCallbacks: Map<number, FrameRequestCallback>;
+
   beforeEach(() => {
+    frameCallbacks = new Map();
+    let nextFrameId = 1;
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        const frameId = nextFrameId;
+        nextFrameId += 1;
+        frameCallbacks.set(frameId, callback);
+        return frameId;
+      }),
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((frameId: number) => {
+        frameCallbacks.delete(frameId);
+      }),
+    );
     mocks.handlers.clear();
     mocks.presentNotifications.mockReset();
     mocks.sessionDiscordId = "current-discord";
@@ -97,6 +116,27 @@ describe("useChatMessagesListener", () => {
       map: { id: 1, name: "Map", visibility: 30 },
       world: "pandora",
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const flushAnimationFrame = () => {
+    const callbacks = [...frameCallbacks.values()];
+    frameCallbacks.clear();
+    for (const callback of callbacks) {
+      callback(0);
+    }
+  };
+
+  const createMessage = (id: string, guildId = "guild-1") => ({
+    id,
+    guildId,
+    senderId: `sender-${id}`,
+    message: `Message ${id}`,
+    timestamp: "2026-04-22T10:00:00.000Z",
+    characterData: { nick: `Sender ${id}` },
   });
 
   it("refetches active chat histories after the socket reconnects", () => {
@@ -246,5 +286,176 @@ describe("useChatMessagesListener", () => {
     });
 
     expect(renderCount).toBe(renderCountBeforeMovement);
+  });
+
+  it("publishes a fifteen-message burst to one guild cache once per frame", () => {
+    const onRemoteMessage = vi.fn();
+    renderHook(() => useChatMessagesListener({ onRemoteMessage }));
+    const handler = mocks.handlers.get(GatewayEvent.CHAT_MESSAGE);
+
+    for (let index = 0; index < 15; index += 1) {
+      handler?.(createMessage(String(index)) as never);
+    }
+
+    expect(mocks.queryClient.setQueryData).not.toHaveBeenCalled();
+    expect(onRemoteMessage).not.toHaveBeenCalled();
+
+    act(() => flushAnimationFrame());
+
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledOnce();
+    expect(onRemoteMessage).toHaveBeenCalledTimes(15);
+    const updater = mocks.queryClient.setQueryData.mock.calls[0]?.[1] as (
+      messages: unknown[] | undefined,
+    ) => Array<{ id: string }>;
+    expect(updater([]).map((message) => message.id)).toEqual(
+      Array.from({ length: 15 }, (_, index) => String(index)),
+    );
+  });
+
+  it("folds create, update, delete, and clear operations in receive order", () => {
+    renderHook(() => useChatMessagesListener());
+
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE)?.(
+      createMessage("created") as never,
+    );
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE_UPDATE)?.({
+      guildId: "guild-1",
+      messageId: "created",
+      message: "Edited",
+    } as never);
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE_DELETE)?.({
+      guildId: "guild-1",
+      messageId: "created",
+    } as never);
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGES_CLEAR)?.({
+      guildId: "guild-1",
+    } as never);
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE)?.(
+      createMessage("after-clear") as never,
+    );
+
+    act(() => flushAnimationFrame());
+
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledOnce();
+    const updater = mocks.queryClient.setQueryData.mock.calls[0]?.[1] as (
+      messages: unknown[] | undefined,
+    ) => Array<{ id: string }>;
+    expect(updater([createMessage("existing")])).toEqual([
+      createMessage("after-clear"),
+    ]);
+  });
+
+  it("publishes each organization at most once in the same frame", () => {
+    renderHook(() => useChatMessagesListener());
+    const handler = mocks.handlers.get(GatewayEvent.CHAT_MESSAGE);
+
+    handler?.(createMessage("guild-1-a", "guild-1") as never);
+    handler?.(createMessage("guild-2-a", "guild-2") as never);
+    handler?.(createMessage("guild-1-b", "guild-1") as never);
+    handler?.(createMessage("guild-2-b", "guild-2") as never);
+
+    act(() => flushAnimationFrame());
+
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.queryClient.setQueryData.mock.calls.map((call) => call[0]),
+    ).toEqual([
+      ["/guilds/guild-1/chat-messages"],
+      ["/guilds/guild-2/chat-messages"],
+    ]);
+  });
+
+  it("flushes through the safety timeout when animation frames are paused", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.set(1, callback);
+        return 1;
+      }),
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((frameId: number) => {
+        frameCallbacks.delete(frameId);
+      }),
+    );
+    const { unmount } = renderHook(() => useChatMessagesListener());
+    const handler = mocks.handlers.get(GatewayEvent.CHAT_MESSAGE);
+    handler?.(createMessage("background") as never);
+
+    act(() => {
+      vi.advanceTimersByTime(49);
+    });
+    expect(mocks.queryClient.setQueryData).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledOnce();
+
+    unmount();
+    vi.useRealTimers();
+  });
+
+  it("flushes accepted operations during ordinary cleanup", () => {
+    const { unmount } = renderHook(() => useChatMessagesListener());
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE)?.(
+      createMessage("before-unmount") as never,
+    );
+
+    expect(mocks.queryClient.setQueryData).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledOnce();
+  });
+
+  it("discards pending operations before removing caches on account loss", () => {
+    const { rerender } = renderHook(() => useChatMessagesListener());
+    mocks.queryClient.removeQueries.mockClear();
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE)?.(
+      createMessage("old-account") as never,
+    );
+
+    mocks.sessionDiscordId = undefined;
+    rerender();
+    act(() => flushAnimationFrame());
+
+    expect(mocks.queryClient.removeQueries).toHaveBeenCalledOnce();
+    expect(mocks.queryClient.setQueryData).not.toHaveBeenCalled();
+  });
+
+  it("drops pending operations for a guild before removing its cache", () => {
+    mocks.socketState.joinedGuilds = ["guild-1", "guild-2"];
+    const { rerender } = renderHook(() => useChatMessagesListener());
+    const handler = mocks.handlers.get(GatewayEvent.CHAT_MESSAGE);
+    handler?.(createMessage("kept", "guild-1") as never);
+    handler?.(createMessage("dropped", "guild-2") as never);
+
+    mocks.socketState.joinedGuilds = ["guild-1"];
+    rerender();
+    act(() => flushAnimationFrame());
+
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledOnce();
+    expect(mocks.queryClient.setQueryData.mock.calls[0]?.[0]).toEqual([
+      "/guilds/guild-1/chat-messages",
+    ]);
+  });
+
+  it("keeps accepted messages across a socket reconnect", () => {
+    const { rerender } = renderHook(() => useChatMessagesListener());
+    mocks.handlers.get(GatewayEvent.CHAT_MESSAGE)?.(
+      createMessage("during-reconnect") as never,
+    );
+
+    mocks.socketState.connected = false;
+    rerender();
+    mocks.socketState.connected = true;
+    rerender();
+    act(() => flushAnimationFrame());
+
+    expect(mocks.queryClient.setQueryData).toHaveBeenCalledOnce();
+    expect(mocks.queryClient.invalidateQueries).toHaveBeenCalledOnce();
   });
 });

--- a/apps/game-client/src/features/chat/hooks/use-chat-messages.ts
+++ b/apps/game-client/src/features/chat/hooks/use-chat-messages.ts
@@ -1,7 +1,7 @@
 import { GatewayEvent } from "@/config/gateway";
 import type { ChatMessage } from "@/api/chat.api";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSocket } from "@/contexts/socket-context";
 import {
   getGuildMembersSummaryQueryKey,
@@ -11,11 +11,6 @@ import {
   getMembersControllerGetMeQueryKey,
   membersControllerGetMe,
 } from "@lootlog/api-client/react-query/main/members";
-import {
-  removeChatMessage,
-  updateChatMessage,
-  upsertChatMessage,
-} from "@/features/chat/chat.helpers";
 import { useNotificationPresenter } from "@/features/notifications/hooks/use-notification-presenter";
 import {
   getChatMentionNotificationId,
@@ -30,8 +25,8 @@ import {
   invalidateChatMessagesQueries,
   removeAllChatMessagesQueries,
   removeChatMessagesQueriesOutsideGuilds,
-  updateChatMessagesCache,
 } from "@/features/chat/chat-query-cache.helpers";
+import { createChatCacheBatcher } from "@/features/chat/chat-cache-batcher";
 
 type UseChatMessagesListenerOptions = {
   onRemoteMessage?: (data: ChatMessage) => void;
@@ -45,6 +40,9 @@ export const useChatMessagesListener = (
   const { connected, joined, joinedGuilds, socket } = useSocket();
   const { data: sessionData } = useSession();
   const { presentNotifications } = useNotificationPresenter();
+  const [chatCacheBatcher] = useState(() =>
+    createChatCacheBatcher(queryClient),
+  );
   const runtimeAccountId = useGameStore(
     (state) => state.game?.hero.accountId ?? "",
   );
@@ -60,6 +58,12 @@ export const useChatMessagesListener = (
   const wasConnectedRef = useRef(connected);
   const accountCacheIdentity = `${sessionData?.user?.discordId ?? ""}\u0000${runtimeAccountId}`;
   const previousAccountCacheIdentityRef = useRef(accountCacheIdentity);
+  useEffect(
+    () => () => {
+      chatCacheBatcher.flush();
+    },
+    [chatCacheBatcher],
+  );
   useEffect(() => {
     sessionDiscordIdRef.current = sessionData?.user?.discordId;
     runtimeIdentityRef.current = {
@@ -86,20 +90,24 @@ export const useChatMessagesListener = (
 
   useEffect(() => {
     if (previousAccountCacheIdentityRef.current !== accountCacheIdentity) {
+      chatCacheBatcher.discardAll();
       removeAllChatMessagesQueries(queryClient);
       previousAccountCacheIdentityRef.current = accountCacheIdentity;
     }
-  }, [accountCacheIdentity, queryClient]);
+  }, [accountCacheIdentity, chatCacheBatcher, queryClient]);
 
   useEffect(() => {
     if (!joined) {
       return;
     }
 
+    chatCacheBatcher.discardOutsideGuilds(joinedGuilds);
     removeChatMessagesQueriesOutsideGuilds(queryClient, joinedGuilds);
-  }, [joined, joinedGuilds, queryClient]);
+  }, [chatCacheBatcher, joined, joinedGuilds, queryClient]);
 
-  const handlerRef = useRef<(data: ChatMessage) => void>(() => undefined);
+  const handlerRef = useRef<
+    (data: ChatMessage, afterFlush?: () => void) => void
+  >(() => undefined);
   const mentionNotificationRef = useRef<
     (data: ChatMessage) => void | Promise<void>
   >(() => undefined);
@@ -114,13 +122,8 @@ export const useChatMessagesListener = (
   );
 
   useEffect(() => {
-    handlerRef.current = (data) => {
-      updateChatMessagesCache({
-        guildId: data.guildId,
-        queryClient,
-        updater: (old: ChatMessage[] | undefined) =>
-          upsertChatMessage(old, data),
-      });
+    handlerRef.current = (data, afterFlush) => {
+      chatCacheBatcher.enqueue({ kind: "create", message: data }, afterFlush);
 
       if (!options?.prefetchMembers) {
         return;
@@ -194,42 +197,44 @@ export const useChatMessagesListener = (
       }
     };
     deleteHandlerRef.current = (data) => {
-      updateChatMessagesCache({
+      chatCacheBatcher.enqueue({
         guildId: data.guildId,
-        queryClient,
-        updater: (old: ChatMessage[] | undefined) =>
-          old ? removeChatMessage(old, data.messageId) : old,
+        kind: "delete",
+        messageId: data.messageId,
       });
     };
     updateHandlerRef.current = (data) => {
-      updateChatMessagesCache({
+      chatCacheBatcher.enqueue({
         guildId: data.guildId,
-        queryClient,
-        updater: (old: ChatMessage[] | undefined) =>
-          old ? updateChatMessage(old, data.messageId, data.message) : old,
+        kind: "update",
+        message: data.message,
+        messageId: data.messageId,
       });
     };
     clearHandlerRef.current = (data) => {
-      updateChatMessagesCache({
+      chatCacheBatcher.enqueue({
         guildId: data.guildId,
-        queryClient,
-        updater: [],
+        kind: "clear",
       });
     };
-  }, [options?.prefetchMembers, presentNotifications, queryClient]);
+  }, [
+    chatCacheBatcher,
+    options?.prefetchMembers,
+    presentNotifications,
+    queryClient,
+  ]);
 
   useEffect(() => {
     if (socket?.hasListeners(GatewayEvent.CHAT_MESSAGE) || !connected) return;
 
     const onChatMessage = (data: ChatMessage) => {
-      handlerRef.current(data);
-
-      if (
+      const isRemoteMessage =
         data.senderId !== sessionDiscordIdRef.current &&
-        data.characterData.nick !== runtimeIdentityRef.current.heroName
-      ) {
-        onRemoteMessageRef.current?.(data);
-      }
+        data.characterData.nick !== runtimeIdentityRef.current.heroName;
+      handlerRef.current(
+        data,
+        isRemoteMessage ? () => onRemoteMessageRef.current?.(data) : undefined,
+      );
 
       void mentionNotificationRef.current(data);
     };


### PR DESCRIPTION
## Summary

- Batch create, update, delete, and clear cache operations once per organization and animation frame, with an ordered immutable cache update and a 50 ms background-tab fallback.
- Keep unread accounting per message while React publishes each batch together.
- Preserve the first NPC report metadata and history position while counting every matching report.
- Stop explicit upward scrolling from being pinned back to the bottom by content resizes.
- Render incoming messages while reading history without moving the viewport anchor.

## Testing

- pnpm --filter @lootlog/game-client test (237 files, 1275 tests on this independent branch)
- pnpm --filter @lootlog/game-client typecheck
- pnpm --filter @lootlog/game-client lint
- Focused coverage for ordered cache operations, per-organization batching, reconnect and cleanup behavior, stable NPC grouping, wheel/touch/keyboard/scrollbar history navigation, resize anchoring, bounded history, and incoming messages while scrolled up

## Screenshots or recordings

Not applicable. Chat presentation is unchanged.

## Risks and rollout

No API, Gateway protocol, database, persisted preference, or dependency changes. Cache batching preserves receive order and uses the timeout fallback when animation frames are suspended. Scroll behavior remains pinned at the physical bottom and preserves an explicit history position otherwise.

## Checklist

- [x] A changeset is included
- [x] Relevant tests were added and run
- [x] Migrations, environment variables, documentation, and breaking changes are not required