### PR TITLE
fix(ci): restore Changesets v1 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create version PR or publish releases
         id: changesets
-        uses: changesets/action@v2
+        uses: changesets/action@v1
         with:
           publish: pnpm release
           version: pnpm run version


### PR DESCRIPTION
## Summary

- restore `changesets/action@v1` while the repository uses Changesets CLI 2.31.1
- unblock updates to the existing release PR #1258

## Root cause

PR #1262 upgraded the action to v2 without upgrading Changesets CLI to v3 or migrating the action inputs and outputs. Every subsequent `Release` workflow failed before it could update `changeset-release/main`.

The latest failure after PR #1280 reports:

> This version of the Changesets action is designed to work with Changesets CLI v3. Changesets CLI v2 is not supported; use Changesets action v1 instead.

## Verification

- `pnpm exec changeset --version` returns `2.31.1`
- the official v1 action manifest supports the configured inputs and outputs
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- `git diff --check`
- the last successful release workflow used `changesets/action@v1` and updated PR #1258

No Changeset is required because this only repairs CI release configuration.

After this PR merges, the push to `main` should rerun the release workflow and update #1258 with the pending Changesets. Upgrading to Changesets CLI v3 and action v2 should be handled separately.
