### PR TITLE
fix(game-client): restore always-visible timer ordering

### DIFF
--- a/.changeset/fix-always-visible-timer-order.md
+++ b/.changeset/fix-always-visible-timer-order.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/game-client": patch
+---
+
+Keep always-visible expired timers ordered at the bottom after the configured removal delay while preserving boundary-only timer list updates.

--- a/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.test.tsx
+++ b/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.test.tsx
@@ -50,12 +50,13 @@ describe("useTimerRemovalBoundary", () => {
     const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
     let renderCount = 0;
 
-    renderHook(() => {
+    const { result } = renderHook(() => {
       renderCount += 1;
-      useTimerRemovalBoundary([createTimer()], 30_000, true);
+      return useTimerRemovalBoundary([createTimer()], 30_000, true);
     });
 
     expect(renderCount).toBe(1);
+    expect(result.current).toBe(NOW);
     expect(setIntervalSpy).not.toHaveBeenCalled();
 
     act(() => {
@@ -67,6 +68,7 @@ describe("useTimerRemovalBoundary", () => {
       vi.advanceTimersByTime(1);
     });
     expect(renderCount).toBe(2);
+    expect(result.current).toBe(NOW + 35_000);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.ts
+++ b/apps/game-client/src/features/timers/hooks/use-timer-removal-boundary.ts
@@ -32,14 +32,18 @@ export const useTimerRemovalBoundary = (
   timers: Timer[],
   removeTimerAfterMs: number,
   enabled: boolean,
-  renderEpoch = Date.now(),
+  initialEpoch = Date.now(),
 ) => {
-  const [refreshVersion, refreshTimers] = useReducer(
-    (version: number) => version + 1,
-    0,
+  const [timerCalculationEpoch, refreshTimers] = useReducer(
+    () => Date.now(),
+    initialEpoch,
   );
   const nextBoundary = enabled
-    ? getNextTimerRemovalBoundary(timers, removeTimerAfterMs, renderEpoch)
+    ? getNextTimerRemovalBoundary(
+        timers,
+        removeTimerAfterMs,
+        timerCalculationEpoch,
+      )
     : undefined;
 
   useEffect(() => {
@@ -53,5 +57,7 @@ export const useTimerRemovalBoundary = (
     );
 
     return () => window.clearTimeout(timeoutId);
-  }, [nextBoundary, refreshVersion]);
+  }, [nextBoundary, timerCalculationEpoch]);
+
+  return timerCalculationEpoch;
 };

--- a/apps/game-client/src/features/timers/timers-countdown.test.tsx
+++ b/apps/game-client/src/features/timers/timers-countdown.test.tsx
@@ -13,6 +13,7 @@ beforeEach(() =>
 );
 
 const testState = vi.hoisted(() => ({
+  alwaysVisibleExpiredTimers: {} as Record<string, string[]>,
   contentRenderSpy: vi.fn(),
   timers: [] as Timer[],
 }));
@@ -39,7 +40,7 @@ vi.mock("@/store/timers.store", () => ({
   useTimersStore: () => ({
     hiddenTimers: {},
     pinnedTimers: {},
-    alwaysVisibleExpiredTimers: {},
+    alwaysVisibleExpiredTimers: testState.alwaysVisibleExpiredTimers,
     generalConfig: {
       removeTimerAfterMs: 30_000,
       timersGrouping: false,
@@ -91,9 +92,14 @@ vi.mock("@/features/timers/components/timers-content", () => ({
   TimersContent: ({ sortedTimers }: { sortedTimers: TimerWithTimeLeft[] }) => {
     testState.contentRenderSpy();
     return (
-      <output data-testid="timer-countdown">
-        {sortedTimers[0]?.maxTimeLeft ?? "missing"}
-      </output>
+      <>
+        <output data-testid="timer-countdown">
+          {sortedTimers[0]?.maxTimeLeft ?? "missing"}
+        </output>
+        <output data-testid="timer-order">
+          {sortedTimers.map((timer) => timer.timerKey).join(",")}
+        </output>
+      </>
     );
   },
 }));
@@ -124,10 +130,24 @@ const createVisibleTimer = (): Timer => ({
   } as never,
 });
 
+const createLaterTimer = (): Timer => ({
+  ...createVisibleTimer(),
+  timerKey: "timer-2",
+  npcId: 11,
+  minSpawnTime: new Date(NOW.getTime() + 59_000).toISOString(),
+  maxSpawnTime: new Date(NOW.getTime() + 60_000).toISOString(),
+  npc: {
+    ...createVisibleTimer().npc,
+    id: 11,
+    name: "Mushita",
+  },
+});
+
 describe("visible timer countdown", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
+    testState.alwaysVisibleExpiredTimers = {};
     testState.contentRenderSpy.mockReset();
     testState.timers = [createVisibleTimer()];
   });
@@ -155,6 +175,25 @@ describe("visible timer countdown", () => {
 
     expect(screen.getByTestId("timer-countdown")).toHaveTextContent("missing");
     expect(testState.contentRenderSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("moves an always-visible expired timer below active timers at the removal boundary", () => {
+    testState.alwaysVisibleExpiredTimers = { gefion: ["timer-1"] };
+    testState.timers = [createVisibleTimer(), createLaterTimer()];
+
+    render(<TimersView isOpen isUnderBag />);
+
+    expect(screen.getByTestId("timer-order")).toHaveTextContent(
+      "timer-1,timer-2",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(35_000);
+    });
+
+    expect(screen.getByTestId("timer-order")).toHaveTextContent(
+      "timer-2,timer-1",
+    );
   });
 
   it("does not keep a clock running when under-bag has no visible timer", () => {

--- a/apps/game-client/src/features/timers/timers-view.tsx
+++ b/apps/game-client/src/features/timers/timers-view.tsx
@@ -140,12 +140,10 @@ export const TimersView = ({ isOpen, isUnderBag }: TimersViewProps) => {
   const mergedTimers = generalConfig.timersGrouping
     ? mergeTimers(deduplicatedTimers)
     : normalizeUngroupedTimers(deduplicatedTimers);
-  const timerCalculationEpoch = Date.now();
-  useTimerRemovalBoundary(
+  const timerCalculationEpoch = useTimerRemovalBoundary(
     mergedTimers,
     generalConfig.removeTimerAfterMs,
     isUnderBag || isOpen,
-    timerCalculationEpoch,
   );
   const activeTimers = filterTimersByExpiredVisibility(
     calculateTimeLeft(mergedTimers, timerCalculationEpoch),


### PR DESCRIPTION
## Summary

- Return a reactive calculation epoch from `useTimerRemovalBoundary` so React Compiler invalidates timer expiration calculations at the configured boundary.
- Move always-visible expired timers below active timers after `removeTimerAfterMs` without restoring one-second parent renders.
- Add regression coverage and a patch Changeset.

## Related issue

None.

## Testing

- `pnpm --filter @lootlog/game-client test` — 240 files and 1286 tests passed.
- `pnpm --filter @lootlog/game-client typecheck`
- `pnpm --filter @lootlog/game-client lint`
- Production Vite build verified that `timerCalculationEpoch` remains a dependency of expiration filtering after React Compiler transformation.

## Screenshots or recordings

Not applicable.

## Risks and rollout

Low. The change keeps boundary-only updates and does not alter timer APIs, persisted settings, or the timer clock interval.

## Checklist

- [x] A changeset is included, or this change does not require one
- [x] Relevant tests were added or run, or testing is not applicable
- [x] Migrations, environment variables, documentation, and breaking changes are covered when applicable