### PR TITLE
fix(loots): correct mine NPC levels

### DIFF
--- a/.changeset/clean-mines-report.md
+++ b/.changeset/clean-mines-report.md
@@ -1,0 +1,6 @@
+---
+"@lootlog/api": patch
+"@lootlog/game-client": patch
+---
+
+Correct mine dialog NPC levels for loot visibility and backfill existing NPC snapshots.

--- a/apps/api/prisma/migrations/20260823195000_backfill_mine_npc_levels/migration.sql
+++ b/apps/api/prisma/migrations/20260823195000_backfill_mine_npc_levels/migration.sql
@@ -1,0 +1,34 @@
+WITH "InferredMineNpcLevels" AS (
+  SELECT
+    npc_snapshot."id",
+    MIN(NULLIF(item_snapshot."lvl", 0)) AS "lvl"
+  FROM "NpcSnapshot" AS npc_snapshot
+  INNER JOIN "LootNpc" AS loot_npc
+    ON loot_npc."npcSnapshotId" = npc_snapshot."id"
+  INNER JOIN "Loot" AS loot
+    ON loot."id" = loot_npc."lootId"
+    AND loot."source" = 'DIALOG'
+  INNER JOIN "LootItem" AS loot_item
+    ON loot_item."lootId" = loot."id"
+  INNER JOIN "ItemSnapshot" AS item_snapshot
+    ON item_snapshot."id" = loot_item."itemSnapshotId"
+  WHERE npc_snapshot."lvl" = 0
+    AND npc_snapshot."name" IN (
+      'Pokaźne Złoże',
+      'Large Deposit',
+      'Naładowany kryształ',
+      'Charged Crystal',
+      'Błękitne złoże',
+      'Azure Vein',
+      'Niewydobyty minerał',
+      'Unmined Mineral',
+      'Zamrożony czarodziej',
+      'Frozen Wizard'
+    )
+  GROUP BY npc_snapshot."id"
+  HAVING COUNT(DISTINCT NULLIF(item_snapshot."lvl", 0)) = 1
+)
+UPDATE "NpcSnapshot" AS npc_snapshot
+SET "lvl" = inferred."lvl"
+FROM "InferredMineNpcLevels" AS inferred
+WHERE npc_snapshot."id" = inferred."id";

--- a/apps/game-client/src/processors/loot-event-processor.test.ts
+++ b/apps/game-client/src/processors/loot-event-processor.test.ts
@@ -515,6 +515,66 @@ describe("LootEventProcessor", () => {
     expect(useLootStore.getState().lastLootId).toBe(321);
   });
 
+  it("uses the configured level for a known mine npc", async () => {
+    setDialogNpcContext(279097, {
+      ...createRuntimeNpc(279097, "Zamrożony czarodziej"),
+      level: 0,
+    });
+    mockGetLoot.mockReturnValue([
+      { id: 7, name: "Fiolka magicznego pyłu", stat: "lvl=1;rarity=unique" },
+    ]);
+    mockCreateLoot.mockResolvedValue({ id: 321 });
+
+    processor.handleDialogLoot(createDialogLootEvent([279097]));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCreateLoot).toHaveBeenCalledTimes(1);
+    expect(mockCreateLoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        npcs: [
+          expect.objectContaining({
+            id: 279097,
+            lvl: 300,
+            name: "Zamrożony czarodziej",
+          }),
+        ],
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("preserves level zero for an unknown dialog npc", async () => {
+    setDialogNpcContext(501, {
+      ...createRuntimeNpc(501, "Nieznany dialog"),
+      level: 0,
+    });
+    mockGetLoot.mockReturnValue([
+      { id: 7, name: "Nagroda", stat: "lvl=300;rarity=unique" },
+    ]);
+    mockCreateLoot.mockResolvedValue({ id: 321 });
+
+    processor.handleDialogLoot(createDialogLootEvent([501]));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCreateLoot).toHaveBeenCalledTimes(1);
+    expect(mockCreateLoot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        npcs: [
+          expect.objectContaining({
+            id: 501,
+            lvl: 0,
+            name: "Nieznany dialog",
+          }),
+        ],
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("attributes dialog loot to the talked npc instead of unrelated npcs_del entries", async () => {
     setDialogNpcContext(501);
     mockGetLoot.mockReturnValue([{ id: 7, name: "Łup" }]);

--- a/apps/game-client/src/processors/loot-event-processor.ts
+++ b/apps/game-client/src/processors/loot-event-processor.ts
@@ -25,6 +25,7 @@ import type {
   RuntimeNpc,
 } from "@/lib/margonem-runtime/runtime.types";
 import { useGameStore } from "@/store/game.store";
+import { resolveDialogLootNpcLevel } from "@/utils/game/resolve-dialog-loot-npc-level";
 
 export class LootEventProcessor {
   handleLootFromBattle(
@@ -216,7 +217,10 @@ export class LootEventProcessor {
         hpp: 0,
         type: npcData.type,
         wt: npcData.weight,
-        lvl: npcData.level,
+        lvl: resolveDialogLootNpcLevel({
+          npcName: npcData.name,
+          npcLevel: npcData.level,
+        }),
         location: mapName,
       },
     ];

--- a/apps/game-client/src/utils/game/resolve-dialog-loot-npc-level.test.ts
+++ b/apps/game-client/src/utils/game/resolve-dialog-loot-npc-level.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveDialogLootNpcLevel } from "./resolve-dialog-loot-npc-level";
+
+const MINE_NPC_CASES = [
+  ["Pokaźne Złoże", 43],
+  ["Large Deposit", 43],
+  ["Naładowany kryształ", 64],
+  ["Charged Crystal", 64],
+  ["Błękitne złoże", 83],
+  ["Azure Vein", 83],
+  ["Niewydobyty minerał", 114],
+  ["Unmined Mineral", 114],
+  ["Zamrożony czarodziej", 300],
+  ["Frozen Wizard", 300],
+] as const;
+
+describe("resolveDialogLootNpcLevel", () => {
+  it.each(MINE_NPC_CASES)(
+    "uses the configured level for %s",
+    (npcName, expectedLevel) => {
+      expect(
+        resolveDialogLootNpcLevel({
+          npcName,
+          npcLevel: 0,
+        }),
+      ).toBe(expectedLevel);
+    },
+  );
+
+  it("preserves a positive level reported by Margonem", () => {
+    expect(
+      resolveDialogLootNpcLevel({
+        npcName: "Zamrożony czarodziej",
+        npcLevel: 299,
+      }),
+    ).toBe(299);
+  });
+
+  it("does not infer a level for an unknown dialog npc", () => {
+    expect(
+      resolveDialogLootNpcLevel({
+        npcName: "Nieznany dialog",
+        npcLevel: 0,
+      }),
+    ).toBe(0);
+  });
+});

--- a/apps/game-client/src/utils/game/resolve-dialog-loot-npc-level.ts
+++ b/apps/game-client/src/utils/game/resolve-dialog-loot-npc-level.ts
@@ -1,0 +1,26 @@
+const MINE_DIALOG_NPC_LEVELS: Readonly<Record<string, number>> = {
+  "Pokaźne Złoże": 43,
+  "Large Deposit": 43,
+  "Naładowany kryształ": 64,
+  "Charged Crystal": 64,
+  "Błękitne złoże": 83,
+  "Azure Vein": 83,
+  "Niewydobyty minerał": 114,
+  "Unmined Mineral": 114,
+  "Zamrożony czarodziej": 300,
+  "Frozen Wizard": 300,
+};
+
+type ResolveDialogLootNpcLevelOptions = {
+  npcName: string;
+  npcLevel: number;
+};
+
+export const resolveDialogLootNpcLevel = ({
+  npcName,
+  npcLevel,
+}: ResolveDialogLootNpcLevelOptions): number => {
+  if (npcLevel !== 0) return npcLevel;
+
+  return MINE_DIALOG_NPC_LEVELS[npcName] ?? npcLevel;
+};


### PR DESCRIPTION
## Summary

- Map the confirmed Polish and English mine dialog NPC names to levels 43, 64, 83, 114, and 300 when Margonem reports level zero.
- Preserve positive Margonem NPC levels and leave unknown level-zero dialog NPCs unchanged.
- Backfill existing `NpcSnapshot` rows from linked dialog loot only when their positive item levels resolve to one value.
- Add patch Changesets for the API and game client.

## Rollout

Release the game client before applying the API migration. Existing short-lived loot caches can expire naturally.

## Verification

- Game client: 241 test files and 1300 tests passed.
- API: 100 test files and 1002 tests passed.
- Game client typecheck, lint, formatting, and runtime replay benchmark passed.
- API lint and build passed.
- Migration dry run found 241 eligible snapshots and the expected levels: 43, 64, 83, 114, and 300.
- Authorization checks include level 300 loot and exclude it when the allowed range ends at 299.