### PR TITLE
Select a single timer NPC type on right click

### DIFF
--- a/.changeset/fuzzy-timers-filter.md
+++ b/.changeset/fuzzy-timers-filter.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/game-client": patch
+---
+
+Allow selecting a single timer NPC type by right-clicking its filter.

--- a/apps/game-client/src/features/timers/components/timers-controls.test.tsx
+++ b/apps/game-client/src/features/timers/components/timers-controls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { InputHTMLAttributes, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -188,6 +188,29 @@ describe("timers controls", () => {
         selectedColors: ["red", "custom-1"],
       }),
     );
+  });
+
+  it("selects only the right-clicked npc type", () => {
+    timersStoreState.timersFilters["guild-1"].selectedNpcTypes = [
+      NpcType.ELITE2,
+      NpcType.ELITE3,
+      NpcType.HERO,
+      NpcType.TITAN,
+    ];
+
+    render(<TimersFilters filtersKey="guild-1" />);
+
+    const elite2Button = screen.getByRole("button", { name: "E2" });
+    const contextMenuEvent = createEvent.contextMenu(elite2Button);
+    fireEvent(elite2Button, contextMenuEvent);
+
+    expect(contextMenuEvent.defaultPrevented).toBe(true);
+    expect(mockSetTimersFilters).toHaveBeenCalledWith("guild-1", {
+      minLvl: 10,
+      maxLvl: 200,
+      selectedNpcTypes: [NpcType.ELITE2],
+      selectedColors: ["red"],
+    });
   });
 
   it("dispatches toolbar actions for regular and under-bag controls", async () => {

--- a/apps/game-client/src/features/timers/components/timers-filters.tsx
+++ b/apps/game-client/src/features/timers/components/timers-filters.tsx
@@ -84,6 +84,17 @@ export const TimersFilters: FC<TimersFiltersProps> = ({ filtersKey }) => {
     });
   };
 
+  const handleSelectOnlyNpcType = (
+    event: React.MouseEvent<HTMLDivElement>,
+    npcType: NpcType,
+  ) => {
+    event.preventDefault();
+    setTimersFilters(filtersKey, {
+      ...filters,
+      selectedNpcTypes: [npcType],
+    });
+  };
+
   const handleToggleColor = (colorId: string) => {
     setTimersFilters(filtersKey, {
       ...filters,
@@ -136,6 +147,7 @@ export const TimersFilters: FC<TimersFiltersProps> = ({ filtersKey }) => {
                 key={type}
                 role="button"
                 onClick={() => handleToggleNpcType(type)}
+                onContextMenu={(event) => handleSelectOnlyNpcType(event, type)}
                 className={cn(
                   "ll:flex ll:items-center ll:justify-center ll:gap-2 ll:hover:bg-gray-400/50 ll:px-1 ll:py-0.5 ll:box-border ll:text-white ll:text-xs",
                   {


### PR DESCRIPTION
## Summary

- select only the right-clicked NPC type in timer filters
- preserve left-click toggle behavior and suppress the browser context menu
- add regression coverage and a patch Changeset for the game client

## Testing

- `pnpm --filter @lootlog/game-client exec vitest run src/features/timers/components/timers-controls.test.tsx`
- `pnpm --filter @lootlog/game-client typecheck`
- `pnpm --filter @lootlog/game-client lint`
- pre-commit suite: 241 test files, 1301 tests passed
