### PR TITLE
fix(web): hide native scrollbars in scroll areas

### DIFF
--- a/.changeset/hide-native-scrollbars.md
+++ b/.changeset/hide-native-scrollbars.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/web": patch
+---
+
+Hide native scrollbars behind the custom Base UI scrollbars on Windows.

--- a/apps/web/src/scrollbars.css
+++ b/apps/web/src/scrollbars.css
@@ -1,41 +1,9 @@
 [data-slot="scroll-area-viewport"] {
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
+  scrollbar-width: none;
 }
 
 [data-slot="scroll-area-viewport"]::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-thumb {
-  background-color: var(--border);
-  border-radius: 9999px;
-  border: 2px solid transparent;
-  background-clip: content-box;
-}
-
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-thumb:hover {
-  background-color: var(--muted-foreground);
-}
-
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-button {
   display: none;
-  width: 0;
-  height: 0;
-}
-
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-button:start:decrement,
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-button:end:increment {
-  display: none;
-}
-
-[data-slot="scroll-area-viewport"]::-webkit-scrollbar-corner {
-  background: transparent;
 }
 
 [data-slot="scroll-area-scrollbar"] {
@@ -54,10 +22,6 @@
   background-color: var(--muted-foreground);
 }
 
-.dark.rias [data-slot="scroll-area-viewport"] {
-  scrollbar-color: oklch(0.4 0.15 15 / 0.4) transparent;
-}
-
 .dark.rias [data-slot="scroll-area-thumb"] {
   background-color: oklch(0.4 0.15 15 / 0.35);
 }
@@ -70,10 +34,6 @@
   box-shadow: 0 0 8px oklch(0.5 0.2 15 / 0.3);
 }
 
-.rukia [data-slot="scroll-area-viewport"] {
-  scrollbar-color: oklch(0.75 0.08 230 / 0.5) transparent;
-}
-
 .rukia [data-slot="scroll-area-thumb"] {
   background-color: oklch(0.75 0.08 230 / 0.4);
 }
@@ -84,10 +44,6 @@
 .rukia [data-slot="scroll-area-thumb"]:hover {
   background-color: oklch(0.7 0.1 220 / 0.6);
   box-shadow: 0 0 6px oklch(0.7 0.12 220 / 0.3);
-}
-
-.dark.rukia [data-slot="scroll-area-viewport"] {
-  scrollbar-color: oklch(0.5 0.1 220 / 0.4) transparent;
 }
 
 .dark.rukia [data-slot="scroll-area-thumb"] {


### PR DESCRIPTION
## Summary

- hide native viewport scrollbars so only the Base UI scrollbars are visible
- remove obsolete native scrollbar styling while preserving Base UI theme colors
- add a patch Changeset for @lootlog/web

## Verification

- pnpm --filter @lootlog/ui test
- pnpm --filter @lootlog/ui lint
- pnpm --filter @lootlog/ui build
- pnpm --filter @lootlog/web lint
- pnpm --filter @lootlog/web build
- browser checks for vertical, horizontal, and two-axis overflow in the default, Rias, and Rukia themes
- browser checks for wheel, keyboard, and thumb-drag scrolling