### PR TITLE
Manage frontend traffic routing across environments

### DIFF
--- a/.changeset/fuzzy-bears-route.md
+++ b/.changeset/fuzzy-bears-route.md
@@ -1,0 +1,9 @@
+---
+"@lootlog/docs": patch
+"@lootlog/landing": patch
+"@lootlog/traffic-splitter": patch
+---
+
+Namespace static assets and manage the `dev.lootlog.pl` traffic splitter from
+the repository so Landing, Docs, and Web development deployments load the
+correct documents, scripts, and styles.

--- a/.changeset/fuzzy-bears-route.md
+++ b/.changeset/fuzzy-bears-route.md
@@ -4,6 +4,7 @@
 "@lootlog/traffic-splitter": patch
 ---
 
-Namespace static assets and manage the `dev.lootlog.pl` traffic splitter from
-the repository so Landing, Docs, and Web development deployments load the
-correct documents, scripts, and styles.
+Namespace static assets and manage the shared development and production
+traffic-splitter code from the repository. Keep the Workers independently
+deployable, promote the production splitter before frontend artifacts, and
+verify public CSS and JavaScript before closing the rollback boundary.

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -182,7 +182,7 @@ jobs:
         env:
           ARTIFACT_PATH: ${{ matrix.artifactPath }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ matrix.kind == 'worker' && secrets.CLOUDFLARE_WORKERS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           CONFIG_PATH: ${{ matrix.configPath }}
           KIND: ${{ matrix.kind }}
           PACKAGE_NAME: ${{ matrix.packageName }}

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -182,13 +182,18 @@ jobs:
         env:
           ARTIFACT_PATH: ${{ matrix.artifactPath }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ matrix.kind == 'worker' && secrets.CLOUDFLARE_WORKERS_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ matrix.kind == 'worker' && secrets.CLOUDFLARE_WORKERS_API_TOKEN || matrix.kind == 'pages' && secrets.CLOUDFLARE_API_TOKEN || '' }}
           CONFIG_PATH: ${{ matrix.configPath }}
           KIND: ${{ matrix.kind }}
           PACKAGE_NAME: ${{ matrix.packageName }}
           PROJECT: ${{ matrix.project }}
           WRANGLER_ENV: ${{ matrix.environment }}
         run: |
+          if [[ -z "$CLOUDFLARE_API_TOKEN" ]]; then
+            echo "::error::Missing Cloudflare API token for $KIND deployment."
+            exit 1
+          fi
+
           case "$KIND" in
             pages)
               pnpm exec wrangler pages deploy "$ARTIFACT_PATH" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,19 +449,33 @@ jobs:
               '{configPath: $configPath, kind: $kind, previousId: $previousId, project: $project}' \
               >> "$ROLLBACK_STATE"
 
-            if [[ "$package_name" == "@lootlog/wiki" ]]; then
-              pnpm exec wrangler deploy "$artifact_path/server/index.js" \
-                --config "$config_path" \
-                --env="" \
-                --assets "$artifact_path/client" \
-                --keep-vars
-            else
-              pnpm exec wrangler deploy \
-                --config "$config_path" \
-                --env="" \
-                --keep-vars
-            fi
-          done < <(jq -c '.[]' <<< "$CLOUDFLARE_MATRIX")
+            case "$package_name" in
+              @lootlog/traffic-splitter)
+                pnpm exec wrangler deploy "$artifact_path/index.js" \
+                  --config "$config_path" \
+                  --env="" \
+                  --name "$project" \
+                  --keep-vars
+                ;;
+              @lootlog/wiki)
+                pnpm exec wrangler deploy "$artifact_path/server/index.js" \
+                  --config "$config_path" \
+                  --env="" \
+                  --assets "$artifact_path/client" \
+                  --keep-vars
+                ;;
+              *)
+                pnpm exec wrangler deploy \
+                  --config "$config_path" \
+                  --env="" \
+                  --keep-vars
+                ;;
+            esac
+          done < <(
+            jq -c \
+              'sort_by(if .packageName == "@lootlog/traffic-splitter" then 0 else 1 end)[]' \
+              <<< "$CLOUDFLARE_MATRIX"
+          )
 
       - name: Smoke-check public Cloudflare routes
         if: needs.release.outputs.cloudflare-matrix != '[]'
@@ -484,6 +498,12 @@ jobs:
             fetch https://lootlog.pl/privacy-policy | grep -q 'Polityka prywatności'
             fetch https://lootlog.pl/terms-of-service | grep -q 'Regulamin serwisu'
             fetch https://lootlog.pl/brand/lootlog-social.png >/dev/null
+            node tools/release/verify-public-static-assets.mjs \
+              https://lootlog.pl \
+              /landing-assets \
+              / \
+              /privacy-policy \
+              /terms-of-service
           fi
 
           if jq -e '.[] | select(.packageName == "@lootlog/docs")' <<< "$CLOUDFLARE_MATRIX" >/dev/null; then
@@ -492,6 +512,11 @@ jobs:
             fetch https://docs.lootlog.pl/docs/installation | grep -q 'Instalacja'
             fetch https://docs.lootlog.pl/api/search | jq -e '.type == "advanced"' >/dev/null
             fetch https://docs.lootlog.pl/brand/favicon.svg >/dev/null
+            node tools/release/verify-public-static-assets.mjs \
+              https://docs.lootlog.pl \
+              /docs-assets \
+              /docs \
+              /docs/installation
           fi
 
       - name: Checkout infra repository

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -187,8 +187,11 @@ The development hostname `dev.lootlog.pl` is owned by the
 their independently deployed development origins. Landing and Docs generated
 assets use the distinct `/landing-assets` and `/docs-assets` namespaces; Web
 continues to own `/assets`. The Worker retains referer-based routing for cached
-pre-migration `/assets` documents during development rollouts. Its Wrangler
-configuration is the source of truth for the existing custom domain.
+pre-migration `/assets` documents during development rollouts. It redirects
+Landing and Docs legacy assets into origin-tagged aliases; cached untagged
+parents are identified with HEAD probes against only the three configured
+origins. Its Wrangler configuration is the source of truth for the existing
+custom domain.
 
 Docker Compose supports local infrastructure. `docker-compose.prod.yml` is not
 a supported production model and should be retired or clearly marked legacy.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,6 +41,7 @@ organization operations.
 | `@lootlog/web`               | Authenticated personal and organization web app                                                                      | Generated API client, gateway        |
 | `@lootlog/landing`           | Product introduction and legal pages                                                                                 | Static TanStack Start client output  |
 | `@lootlog/docs`              | User documentation                                                                                                   | Static TanStack Start client output  |
+| `@lootlog/traffic-splitter`  | Development-only edge routing for `dev.lootlog.pl`                                                                   | Cloudflare Worker and static origins |
 | `@lootlog/wiki`              | Public Margonem knowledge and search                                                                                 | Search API                           |
 | `@lootlog/developer`         | Future developer surface; currently not a supported product                                                          | Static frontend                      |
 
@@ -180,6 +181,14 @@ Managed production uses immutable release artifacts:
 - Cloudflare applications use checksummed artifacts built by the release;
 - the Changesets version PR creates release versions and artifacts;
 - production rollback reuses an existing artifact instead of rebuilding it.
+
+The development hostname `dev.lootlog.pl` is owned by the
+`@lootlog/traffic-splitter` Worker. It routes Landing, Docs, and Web requests to
+their independently deployed development origins. Landing and Docs generated
+assets use the distinct `/landing-assets` and `/docs-assets` namespaces; Web
+continues to own `/assets`. The Worker retains referer-based routing for cached
+pre-migration `/assets` documents during development rollouts. Its Wrangler
+configuration is the source of truth for the existing custom domain.
 
 Docker Compose supports local infrastructure. `docker-compose.prod.yml` is not
 a supported production model and should be retired or clearly marked legacy.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,22 +28,22 @@ organization operations.
 
 ## Deployable applications
 
-| Workspace                    | Responsibility                                                                                                       | Primary state or dependency          |
-| ---------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `@lootlog/api`               | Organizations, members, loot, kills, timers, reservations, chat, notifications, events, documents, and configuration | Lootlog PostgreSQL, Redis, RabbitMQ  |
-| `@lootlog/auth`              | Discord sign-in, sessions, JWT/JWKS, provider tokens                                                                 | Users PostgreSQL, Redis, Better Auth |
-| `@lootlog/gateway`           | Socket.IO authentication, rooms, presence, and real-time fan-out                                                     | Redis adapter, RabbitMQ              |
-| `@lootlog/battlelog-service` | Battle ingestion, storage, retrieval, and statistics                                                                 | Battle PostgreSQL, R2                |
-| `@lootlog/activity`          | Durable organization activity and audit records                                                                      | TimescaleDB                          |
-| `@lootlog/search`            | Public item, NPC, and player search projections                                                                      | Meilisearch                          |
-| `@lootlog/discord-bot`       | Discord membership synchronization, notifications, and commands                                                      | Discord, API, RabbitMQ               |
-| `@lootlog/game-client`       | Margonem runtime integration and in-game UI                                                                          | Browser runtime, APIs, gateway       |
-| `@lootlog/web`               | Authenticated personal and organization web app                                                                      | Generated API client, gateway        |
-| `@lootlog/landing`           | Product introduction and legal pages                                                                                 | Static TanStack Start client output  |
-| `@lootlog/docs`              | User documentation                                                                                                   | Static TanStack Start client output  |
-| `@lootlog/traffic-splitter`  | Development-only edge routing for `dev.lootlog.pl`                                                                   | Cloudflare Worker and static origins |
-| `@lootlog/wiki`              | Public Margonem knowledge and search                                                                                 | Search API                           |
-| `@lootlog/developer`         | Future developer surface; currently not a supported product                                                          | Static frontend                      |
+| Workspace                    | Responsibility                                                                                                       | Primary state or dependency           |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `@lootlog/api`               | Organizations, members, loot, kills, timers, reservations, chat, notifications, events, documents, and configuration | Lootlog PostgreSQL, Redis, RabbitMQ   |
+| `@lootlog/auth`              | Discord sign-in, sessions, JWT/JWKS, provider tokens                                                                 | Users PostgreSQL, Redis, Better Auth  |
+| `@lootlog/gateway`           | Socket.IO authentication, rooms, presence, and real-time fan-out                                                     | Redis adapter, RabbitMQ               |
+| `@lootlog/battlelog-service` | Battle ingestion, storage, retrieval, and statistics                                                                 | Battle PostgreSQL, R2                 |
+| `@lootlog/activity`          | Durable organization activity and audit records                                                                      | TimescaleDB                           |
+| `@lootlog/search`            | Public item, NPC, and player search projections                                                                      | Meilisearch                           |
+| `@lootlog/discord-bot`       | Discord membership synchronization, notifications, and commands                                                      | Discord, API, RabbitMQ                |
+| `@lootlog/game-client`       | Margonem runtime integration and in-game UI                                                                          | Browser runtime, APIs, gateway        |
+| `@lootlog/web`               | Authenticated personal and organization web app                                                                      | Generated API client, gateway         |
+| `@lootlog/landing`           | Product introduction and legal pages                                                                                 | Static TanStack Start client output   |
+| `@lootlog/docs`              | User documentation                                                                                                   | Static TanStack Start client output   |
+| `@lootlog/traffic-splitter`  | Shared edge routing for `dev.lootlog.pl` and `lootlog.pl`                                                            | Cloudflare Workers and static origins |
+| `@lootlog/wiki`              | Public Margonem knowledge and search                                                                                 | Search API                            |
+| `@lootlog/developer`         | Future developer surface; currently not a supported product                                                          | Static frontend                       |
 
 Packages contain generated clients, shared API helpers, battle processing,
 Margonem models, scoring, instrumentation, UI, socket parsing, configuration,
@@ -182,16 +182,22 @@ Managed production uses immutable release artifacts:
 - the Changesets version PR creates release versions and artifacts;
 - production rollback reuses an existing artifact instead of rebuilding it.
 
-The development hostname `dev.lootlog.pl` is owned by the
-`@lootlog/traffic-splitter` Worker. It routes Landing, Docs, and Web requests to
-their independently deployed development origins. Landing and Docs generated
-assets use the distinct `/landing-assets` and `/docs-assets` namespaces; Web
-continues to own `/assets`. The Worker retains referer-based routing for cached
-pre-migration `/assets` documents during development rollouts. It redirects
-Landing and Docs legacy assets into origin-tagged aliases; cached untagged
-parents are identified with HEAD probes against only the three configured
-origins. Its Wrangler configuration is the source of truth for the existing
-custom domain.
+The `@lootlog/traffic-splitter` route table serves `dev.lootlog.pl` and
+`lootlog.pl` through separate Cloudflare Workers and origin sets. Merges to
+`main` deploy only the Wrangler `develop` environment. Production uses the
+top-level environment and changes only after release approval. Landing and Docs
+generated assets use the distinct `/landing-assets` and `/docs-assets`
+namespaces; Web continues to own `/assets`. The route table retains
+referer-based routing for cached pre-migration `/assets` documents and accepts
+legacy `/_next` assets during coordinated rollouts. Landing and Docs legacy
+assets are redirected into origin-tagged aliases; cached untagged parents are
+identified with HEAD probes against only the three configured origins.
+
+Production promotes the compatible splitter artifact before Landing and Docs,
+then verifies their generated CSS and JavaScript through the public domains. A
+failed deployment or smoke check rolls frontend applications back before the
+splitter. Both Workers' Wrangler configuration in this repository is the source
+of truth for their custom domains.
 
 Docker Compose supports local infrastructure. `docker-compose.prod.yml` is not
 a supported production model and should be retired or clearly marked legacy.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ apps/
 ├── gateway/             Socket.IO presence and real-time fan-out
 ├── landing/             Public product site and legal pages
 ├── search/              Meilisearch-backed public search API
+├── traffic-splitter/    Development edge router for dev.lootlog.pl
 ├── web/                 Authenticated React web app
 └── wiki/                Public Margonem knowledge app
 
@@ -125,6 +126,11 @@ Workspace-specific commands are documented in each app or package README.
 Changesets version private workspaces and create immutable release artifacts.
 Merging an ordinary feature pull request may deploy development environments
 but does not create a production release.
+
+`dev.lootlog.pl` is served by the repository-owned
+`@lootlog/traffic-splitter` Worker. The GitHub `dev` environment uses the
+dedicated `CLOUDFLARE_WORKERS_API_TOKEN` secret for Worker scripts and custom
+domain updates; Pages deployments continue to use `CLOUDFLARE_API_TOKEN`.
 
 The Changesets version pull request is the release gate. Its merge creates tags,
 GitHub Releases, container images, and Cloudflare artifacts. Production

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ apps/
 ├── gateway/             Socket.IO presence and real-time fan-out
 ├── landing/             Public product site and legal pages
 ├── search/              Meilisearch-backed public search API
-├── traffic-splitter/    Development edge router for dev.lootlog.pl
+├── traffic-splitter/    Shared edge router for dev.lootlog.pl and lootlog.pl
 ├── web/                 Authenticated React web app
 └── wiki/                Public Margonem knowledge app
 
@@ -127,16 +127,20 @@ Changesets version private workspaces and create immutable release artifacts.
 Merging an ordinary feature pull request may deploy development environments
 but does not create a production release.
 
-`dev.lootlog.pl` is served by the repository-owned
-`@lootlog/traffic-splitter` Worker. The GitHub `dev` environment uses the
-dedicated `CLOUDFLARE_WORKERS_API_TOKEN` secret for Worker scripts and custom
-domain updates; Pages deployments continue to use `CLOUDFLARE_API_TOKEN`.
+`dev.lootlog.pl` and `lootlog.pl` use the same repository-owned
+`@lootlog/traffic-splitter` implementation but remain separate Cloudflare
+Workers. Merges to `main` can update only the development Worker. The GitHub
+`dev` environment uses the dedicated `CLOUDFLARE_WORKERS_API_TOKEN` secret for
+Worker scripts and custom-domain updates; Pages deployments continue to use
+`CLOUDFLARE_API_TOKEN`.
 
 The Changesets version pull request is the release gate. Its merge creates tags,
 GitHub Releases, container images, and Cloudflare artifacts. Production
 promotion requires environment approval. Container services deploy through
 GitOps and ArgoCD; Cloudflare apps deploy the checksummed artifacts produced by
-the release. Rollbacks reuse existing artifacts.
+the release. The production splitter is promoted before the frontend artifacts
+and rolled back after them if public asset checks fail. Rollbacks reuse
+existing artifacts.
 
 Do not use `docker-compose.prod.yml` as production documentation. Self-hosting
 is community-supported until the project ships a tested distribution.

--- a/apps/docs/PRODUCT.md
+++ b/apps/docs/PRODUCT.md
@@ -10,6 +10,8 @@ and verifies it. Follow the Read mode in `DESIGN.md`.
 The app uses TanStack Start with the Fumadocs Vite integration. Every guide,
 the root redirect, and the search index are prerendered into `dist/client`; the
 deployed Assets Worker does not execute server functions at runtime.
+Generated assets use `/docs-assets` so `dev.lootlog.pl` can route them without
+colliding with Landing or Web assets.
 
 Merges to `main` deploy the affected Docs artifact to the isolated
 `lootlog-docs-develop` Worker. Production continues to use `lootlog-docs` and

--- a/apps/docs/scripts/verify-static-build.mjs
+++ b/apps/docs/scripts/verify-static-build.mjs
@@ -4,6 +4,11 @@ import path from "node:path";
 
 const clientDirectory = path.resolve("dist/client");
 const contentDirectory = path.resolve("content/docs");
+const artifactBaseUrl = new URL("https://static-artifact.invalid");
+
+function isLocalAssetReference(reference) {
+  return new URL(reference, artifactBaseUrl).origin === artifactBaseUrl.origin;
+}
 
 const rootDocument = await readFile(
   path.join(clientDirectory, "index.html"),
@@ -54,7 +59,7 @@ await Promise.all(
     const generatedAssetReferences = Array.from(
       document.matchAll(/(?:href|src)="([^"]+\.(?:css|js)(?:[?#][^"]*)?)"/gu),
       ([, reference]) => reference,
-    );
+    ).filter(isLocalAssetReference);
     assert.ok(
       generatedAssetReferences.length > 0,
       `${routePath} does not reference generated CSS or JavaScript`,

--- a/apps/docs/scripts/verify-static-build.mjs
+++ b/apps/docs/scripts/verify-static-build.mjs
@@ -51,16 +51,21 @@ await Promise.all(
       `${routePath} lacks its visible description`,
     );
     assert.match(document, /class="[^"]*docs-body/u);
-    assert.match(
-      document,
-      /(?:href|src)="\/docs-assets\/[^"]+\.(?:css|js)"/u,
-      `${routePath} does not use the Docs asset namespace`,
+    const generatedAssetReferences = Array.from(
+      document.matchAll(/(?:href|src)="([^"]+\.(?:css|js)(?:[?#][^"]*)?)"/gu),
+      ([, reference]) => reference,
     );
-    assert.doesNotMatch(
-      document,
-      /(?:href|src)="\/assets\//u,
-      `${routePath} uses the shared asset namespace`,
+    assert.ok(
+      generatedAssetReferences.length > 0,
+      `${routePath} does not reference generated CSS or JavaScript`,
     );
+    for (const reference of generatedAssetReferences) {
+      assert.match(
+        reference,
+        /^\/docs-assets\//u,
+        `${routePath} references a generated asset outside the Docs namespace: ${reference}`,
+      );
+    }
   }),
 );
 

--- a/apps/docs/scripts/verify-static-build.mjs
+++ b/apps/docs/scripts/verify-static-build.mjs
@@ -13,6 +13,11 @@ const rootDocument = await readFile(
 assert.match(rootDocument, /http-equiv="refresh" content="0;url=\/docs"/u);
 assert.match(rootDocument, /window\.location\.replace\("\/docs"\)/u);
 assert.match(rootDocument, /href="\/docs"/u);
+assert.doesNotMatch(
+  rootDocument,
+  /(?:href|src)="\/assets\//u,
+  "root redirect uses the shared asset namespace",
+);
 
 const contentFiles = (await readdir(contentDirectory))
   .filter((fileName) => fileName.endsWith(".mdx"))
@@ -46,6 +51,16 @@ await Promise.all(
       `${routePath} lacks its visible description`,
     );
     assert.match(document, /class="[^"]*docs-body/u);
+    assert.match(
+      document,
+      /(?:href|src)="\/docs-assets\/[^"]+\.(?:css|js)"/u,
+      `${routePath} does not use the Docs asset namespace`,
+    );
+    assert.doesNotMatch(
+      document,
+      /(?:href|src)="\/assets\//u,
+      `${routePath} uses the shared asset namespace`,
+    );
   }),
 );
 

--- a/apps/docs/vite.config.ts
+++ b/apps/docs/vite.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from "vite";
 import { docsPaths } from "./lib/docs-chapters.ts";
 
 export default defineConfig({
+  build: {
+    assetsDir: "docs-assets",
+  },
   server: {
     host: "0.0.0.0",
     port: 3005,

--- a/apps/landing/PRODUCT.md
+++ b/apps/landing/PRODUCT.md
@@ -31,6 +31,8 @@ resources.
 ## Constraints
 
 - The app is prerendered by TanStack Start and deploys only `dist/client`.
+- Generated assets use `/landing-assets` so the shared development hostname can
+  route them without colliding with Web assets.
 - It is an adoption surface, not the user documentation or authenticated app.
 - Follow the Persuade mode in `DESIGN.md`.
 - Polish is the supported product language and all copy remains behind i18n.

--- a/apps/landing/scripts/verify-static-build.mjs
+++ b/apps/landing/scripts/verify-static-build.mjs
@@ -35,6 +35,16 @@ for (const [documentName, document, canonicalUrl] of [
     document,
     /<link rel="apple-touch-icon" href="\/apple-icon\.png"/u,
   );
+  assert.match(
+    document,
+    /(?:href|src)="\/landing-assets\/[^"]+\.(?:css|js)"/u,
+    `${documentName} does not use the landing asset namespace`,
+  );
+  assert.doesNotMatch(
+    document,
+    /(?:href|src)="\/assets\//u,
+    `${documentName} uses the shared asset namespace`,
+  );
 }
 
 assert.match(homeDocument, /<script type="application\/ld\+json">/u);

--- a/apps/landing/scripts/verify-static-build.mjs
+++ b/apps/landing/scripts/verify-static-build.mjs
@@ -35,16 +35,21 @@ for (const [documentName, document, canonicalUrl] of [
     document,
     /<link rel="apple-touch-icon" href="\/apple-icon\.png"/u,
   );
-  assert.match(
-    document,
-    /(?:href|src)="\/landing-assets\/[^"]+\.(?:css|js)"/u,
-    `${documentName} does not use the landing asset namespace`,
+  const generatedAssetReferences = Array.from(
+    document.matchAll(/(?:href|src)="([^"]+\.(?:css|js)(?:[?#][^"]*)?)"/gu),
+    ([, reference]) => reference,
   );
-  assert.doesNotMatch(
-    document,
-    /(?:href|src)="\/assets\//u,
-    `${documentName} uses the shared asset namespace`,
+  assert.ok(
+    generatedAssetReferences.length > 0,
+    `${documentName} does not reference generated CSS or JavaScript`,
   );
+  for (const reference of generatedAssetReferences) {
+    assert.match(
+      reference,
+      /^\/landing-assets\//u,
+      `${documentName} references a generated asset outside the Landing namespace: ${reference}`,
+    );
+  }
 }
 
 assert.match(homeDocument, /<script type="application\/ld\+json">/u);

--- a/apps/landing/scripts/verify-static-build.mjs
+++ b/apps/landing/scripts/verify-static-build.mjs
@@ -3,6 +3,11 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 
 const clientDirectory = path.resolve("dist/client");
+const artifactBaseUrl = new URL("https://static-artifact.invalid");
+
+function isLocalAssetReference(reference) {
+  return new URL(reference, artifactBaseUrl).origin === artifactBaseUrl.origin;
+}
 
 function readDocument(relativePath) {
   return readFile(path.join(clientDirectory, relativePath), "utf8");
@@ -38,7 +43,7 @@ for (const [documentName, document, canonicalUrl] of [
   const generatedAssetReferences = Array.from(
     document.matchAll(/(?:href|src)="([^"]+\.(?:css|js)(?:[?#][^"]*)?)"/gu),
     ([, reference]) => reference,
-  );
+  ).filter(isLocalAssetReference);
   assert.ok(
     generatedAssetReferences.length > 0,
     `${documentName} does not reference generated CSS or JavaScript`,

--- a/apps/landing/vite.config.ts
+++ b/apps/landing/vite.config.ts
@@ -5,6 +5,9 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  build: {
+    assetsDir: "landing-assets",
+  },
   server: {
     host: "0.0.0.0",
     port: 3003,

--- a/apps/traffic-splitter/PRODUCT.md
+++ b/apps/traffic-splitter/PRODUCT.md
@@ -1,13 +1,14 @@
-# Development traffic splitter context
+# Traffic splitter context
 
 Read the canonical [`PRODUCT.md`](../../PRODUCT.md) first.
 
-The traffic splitter is development infrastructure, not a product surface. It
-owns the `dev.lootlog.pl` custom domain and forwards public requests to the
-development Landing, Docs, or Web origin. It stores no user data and must not
-forward cookies or authorization headers to those static origins.
+The traffic splitter is edge infrastructure, not a product surface. One route
+table serves two independently deployed Workers: `dev.lootlog.pl` forwards to
+development Landing, Docs, and Web origins, while `lootlog.pl` forwards to
+their production origins. It stores no user data and must not forward cookies
+or authorization headers to those static origins.
 
-The Worker exists as an independent deployable because its custom-domain and
-cross-origin routing lifecycle is separate from all three frontend artifacts.
-Its route table and Wrangler configuration in this workspace are the source of
-truth; do not edit the deployed Worker in the Cloudflare dashboard.
+The Workers remain separate deployables because development changes must not
+change production and production approval and rollback remain independent.
+The route table and Wrangler configuration in this workspace are the source of
+truth; do not edit either deployed Worker in the Cloudflare dashboard.

--- a/apps/traffic-splitter/PRODUCT.md
+++ b/apps/traffic-splitter/PRODUCT.md
@@ -1,0 +1,13 @@
+# Development traffic splitter context
+
+Read the canonical [`PRODUCT.md`](../../PRODUCT.md) first.
+
+The traffic splitter is development infrastructure, not a product surface. It
+owns the `dev.lootlog.pl` custom domain and forwards public requests to the
+development Landing, Docs, or Web origin. It stores no user data and must not
+forward cookies or authorization headers to those static origins.
+
+The Worker exists as an independent deployable because its custom-domain and
+cross-origin routing lifecycle is separate from all three frontend artifacts.
+Its route table and Wrangler configuration in this workspace are the source of
+truth; do not edit the deployed Worker in the Cloudflare dashboard.

--- a/apps/traffic-splitter/README.md
+++ b/apps/traffic-splitter/README.md
@@ -1,15 +1,21 @@
-# Development traffic splitter
+# Traffic splitter
 
-This Cloudflare Worker owns `dev.lootlog.pl` and routes requests to the
-development Landing, Docs, and Web origins. Generated asset namespaces are
+This package is the source of truth for two independently deployed Cloudflare
+Workers:
+
+- `lootlog-traffic-splitter-dev` owns `dev.lootlog.pl` and uses development
+  origins;
+- `lootlog-route-splitter` owns `lootlog.pl` and uses production origins.
+
+Both Workers use the same route table. Their generated asset namespaces are
 explicit:
 
-| Paths                                                         | Origin                         |
-| ------------------------------------------------------------- | ------------------------------ |
-| `/`, legal pages, `/landing-assets`, `/brand`, `/screenshots` | Landing Pages preview          |
-| `/docs`, `/docs-assets`, `/__tsr`, `/api/search`              | Docs development Assets Worker |
-| `/__legacy-assets/{landing,docs}/assets`                      | Tagged legacy asset origin     |
-| `/assets` and every remaining application route               | Web Pages preview              |
+| Paths                                                                   | Origin                     |
+| ----------------------------------------------------------------------- | -------------------------- |
+| `/`, legal pages, `/_next`, `/landing-assets`, `/brand`, `/screenshots` | Landing                    |
+| `/docs`, `/docs-assets`, `/__tsr`, `/api/search`                        | Docs                       |
+| `/__legacy-assets/{landing,docs}/assets`                                | Tagged legacy asset origin |
+| `/assets` and every remaining application route                         | Web                        |
 
 Legacy `/assets` requests selected from a Landing or Docs document are
 temporarily redirected into an origin-tagged, non-cacheable namespace. When a
@@ -28,7 +34,15 @@ pnpm --filter @lootlog/traffic-splitter lint
 pnpm --filter @lootlog/traffic-splitter build
 ```
 
-Merges to `main` deploy the Worker through the GitHub `dev` environment. Set
-`CLOUDFLARE_WORKERS_API_TOKEN` there from Cloudflare's **Edit Cloudflare
-Workers** token template, scoped to the Lootlog account and `lootlog.pl` zone.
-The existing Pages-only `CLOUDFLARE_API_TOKEN` is intentionally not reused.
+The `dev` command and merges to `main` target only the Wrangler `develop`
+environment and therefore cannot overwrite the production Worker. The GitHub
+`dev` environment uses `CLOUDFLARE_WORKERS_API_TOKEN`, scoped to the Lootlog
+account and `lootlog.pl` zone. The existing Pages-only
+`CLOUDFLARE_API_TOKEN` is intentionally not reused.
+
+Production is the top-level Wrangler environment. It is deployed only by the
+approved release workflow from its checksummed artifact. During a coordinated
+release, the compatible splitter is promoted before Landing and Docs. Public
+smoke checks then fetch the generated CSS and JavaScript through their real
+domains. A failed deployment or smoke check rolls applications back first and
+the splitter last.

--- a/apps/traffic-splitter/README.md
+++ b/apps/traffic-splitter/README.md
@@ -8,11 +8,16 @@ explicit:
 | ------------------------------------------------------------- | ------------------------------ |
 | `/`, legal pages, `/landing-assets`, `/brand`, `/screenshots` | Landing Pages preview          |
 | `/docs`, `/docs-assets`, `/__tsr`, `/api/search`              | Docs development Assets Worker |
+| `/__legacy-assets/{landing,docs}/assets`                      | Tagged legacy asset origin     |
 | `/assets` and every remaining application route               | Web Pages preview              |
 
-Legacy `/assets` requests are selected from a same-origin `Referer` so cached
-HTML from before the namespace migration remains usable during a deployment.
-Cookies and authorization headers are removed before forwarding.
+Legacy `/assets` requests selected from a Landing or Docs document are
+temporarily redirected into an origin-tagged, non-cacheable namespace. When a
+cached untagged parent asset requests a child, the Worker identifies the parent
+with HEAD requests to the three fixed origins before applying the same tag.
+This keeps pre-migration HTML and nested assets usable during a deployment
+without sharing mutable browser state. Cookies and authorization headers are
+removed before forwarding or probing.
 
 ## Commands
 

--- a/apps/traffic-splitter/README.md
+++ b/apps/traffic-splitter/README.md
@@ -1,0 +1,29 @@
+# Development traffic splitter
+
+This Cloudflare Worker owns `dev.lootlog.pl` and routes requests to the
+development Landing, Docs, and Web origins. Generated asset namespaces are
+explicit:
+
+| Paths                                                         | Origin                         |
+| ------------------------------------------------------------- | ------------------------------ |
+| `/`, legal pages, `/landing-assets`, `/brand`, `/screenshots` | Landing Pages preview          |
+| `/docs`, `/docs-assets`, `/__tsr`, `/api/search`              | Docs development Assets Worker |
+| `/assets` and every remaining application route               | Web Pages preview              |
+
+Legacy `/assets` requests are selected from a same-origin `Referer` so cached
+HTML from before the namespace migration remains usable during a deployment.
+Cookies and authorization headers are removed before forwarding.
+
+## Commands
+
+```bash
+pnpm --filter @lootlog/traffic-splitter test
+pnpm --filter @lootlog/traffic-splitter typecheck
+pnpm --filter @lootlog/traffic-splitter lint
+pnpm --filter @lootlog/traffic-splitter build
+```
+
+Merges to `main` deploy the Worker through the GitHub `dev` environment. Set
+`CLOUDFLARE_WORKERS_API_TOKEN` there from Cloudflare's **Edit Cloudflare
+Workers** token template, scoped to the Lootlog account and `lootlog.pl` zone.
+The existing Pages-only `CLOUDFLARE_API_TOKEN` is intentionally not reused.

--- a/apps/traffic-splitter/package.json
+++ b/apps/traffic-splitter/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
-    "build": "wrangler deploy --dry-run --outdir dist && tsc --noEmit",
+    "dev": "wrangler dev --env develop",
+    "build": "wrangler deploy --env=\"\" --dry-run --outdir dist && tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint .",
     "test": "vitest run"

--- a/apps/traffic-splitter/package.json
+++ b/apps/traffic-splitter/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@lootlog/traffic-splitter",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "wrangler deploy --dry-run --outdir dist && tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint .",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@lootlog/typescript-config": "workspace:*",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "wrangler": "^4.127.0"
+  }
+}

--- a/apps/traffic-splitter/src/index.test.ts
+++ b/apps/traffic-splitter/src/index.test.ts
@@ -11,7 +11,13 @@ const environment = {
   WEB_ORIGIN: "https://develop.lootlog-web-monorepo.pages.dev",
 } satisfies TrafficSplitterEnvironment;
 
-describe("development traffic splitter", () => {
+const productionEnvironment = {
+  DOCS_ORIGIN: "https://lootlog-docs.example.workers.dev",
+  LANDING_ORIGIN: "https://lootlog-landing.pages.dev",
+  WEB_ORIGIN: "https://lootlog-web-monorepo.pages.dev",
+} satisfies TrafficSplitterEnvironment;
+
+describe("traffic splitter", () => {
   it.each([
     ["/", environment.LANDING_ORIGIN],
     ["/privacy-policy/", environment.LANDING_ORIGIN],
@@ -20,6 +26,7 @@ describe("development traffic splitter", () => {
     ["/brand/lootlog-mark.svg", environment.LANDING_ORIGIN],
     ["/screenshots/dashboard-current.png", environment.LANDING_ORIGIN],
     ["/favicon.ico", environment.LANDING_ORIGIN],
+    ["/_next/static/legacy.css", environment.LANDING_ORIGIN],
     ["/docs", environment.DOCS_ORIGIN],
     ["/docs/getting-started/", environment.DOCS_ORIGIN],
     ["/docs-assets/docs.js", environment.DOCS_ORIGIN],
@@ -35,6 +42,26 @@ describe("development traffic splitter", () => {
     await routeRequest(
       new Request(`https://dev.lootlog.pl${path}`),
       environment,
+      upstreamFetch,
+    );
+
+    expect(upstreamFetch.mock.calls[0]?.[0].url).toBe(
+      new URL(path, expectedOrigin).href,
+    );
+  });
+
+  it.each([
+    ["/landing-assets/app.css", productionEnvironment.LANDING_ORIGIN],
+    ["/docs-assets/docs.js", productionEnvironment.DOCS_ORIGIN],
+    ["/@me", productionEnvironment.WEB_ORIGIN],
+  ])("routes production path %s to %s", async (path, expectedOrigin) => {
+    const upstreamFetch = vi.fn<UpstreamFetch>((request) =>
+      Promise.resolve(Response.json({ url: request.url })),
+    );
+
+    await routeRequest(
+      new Request(`https://lootlog.pl${path}`),
+      productionEnvironment,
       upstreamFetch,
     );
 

--- a/apps/traffic-splitter/src/index.test.ts
+++ b/apps/traffic-splitter/src/index.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  routeRequest,
+  type TrafficSplitterEnvironment,
+  type UpstreamFetch,
+} from "./index";
+
+const environment = {
+  DOCS_ORIGIN: "https://lootlog-docs-develop.example.workers.dev",
+  LANDING_ORIGIN: "https://develop.lootlog-landing.pages.dev",
+  WEB_ORIGIN: "https://develop.lootlog-web-monorepo.pages.dev",
+} satisfies TrafficSplitterEnvironment;
+
+describe("development traffic splitter", () => {
+  it.each([
+    ["/", environment.LANDING_ORIGIN],
+    ["/privacy-policy/", environment.LANDING_ORIGIN],
+    ["/terms-of-service", environment.LANDING_ORIGIN],
+    ["/landing-assets/app.css", environment.LANDING_ORIGIN],
+    ["/brand/lootlog-mark.svg", environment.LANDING_ORIGIN],
+    ["/screenshots/dashboard-current.png", environment.LANDING_ORIGIN],
+    ["/favicon.ico", environment.LANDING_ORIGIN],
+    ["/docs", environment.DOCS_ORIGIN],
+    ["/docs/getting-started/", environment.DOCS_ORIGIN],
+    ["/docs-assets/docs.js", environment.DOCS_ORIGIN],
+    ["/__tsr/staticServerFnCache/page.json", environment.DOCS_ORIGIN],
+    ["/api/search?query=loot", environment.DOCS_ORIGIN],
+    ["/@me", environment.WEB_ORIGIN],
+    ["/assets/web.js", environment.WEB_ORIGIN],
+  ])("routes %s to %s", async (path, expectedOrigin) => {
+    const upstreamFetch = vi.fn<UpstreamFetch>((request) =>
+      Promise.resolve(Response.json({ url: request.url })),
+    );
+
+    await routeRequest(
+      new Request(`https://dev.lootlog.pl${path}`),
+      environment,
+      upstreamFetch,
+    );
+
+    expect(upstreamFetch.mock.calls[0]?.[0].url).toBe(
+      new URL(path, expectedOrigin).href,
+    );
+  });
+
+  it.each([
+    ["https://dev.lootlog.pl/", environment.LANDING_ORIGIN],
+    ["https://dev.lootlog.pl/privacy-policy", environment.LANDING_ORIGIN],
+    ["https://dev.lootlog.pl/docs/features", environment.DOCS_ORIGIN],
+    ["https://dev.lootlog.pl/@me", environment.WEB_ORIGIN],
+    ["https://example.com/docs", environment.WEB_ORIGIN],
+  ])(
+    "routes a legacy asset referred by %s to %s",
+    async (referer, expectedOrigin) => {
+      const upstreamFetch = vi.fn<UpstreamFetch>((request) =>
+        Promise.resolve(Response.json({ url: request.url })),
+      );
+      const request = new Request("https://dev.lootlog.pl/assets/legacy.js", {
+        headers: { referer },
+      });
+
+      await routeRequest(request, environment, upstreamFetch);
+
+      expect(upstreamFetch.mock.calls[0]?.[0].url).toBe(
+        `${expectedOrigin}/assets/legacy.js`,
+      );
+    },
+  );
+
+  it("preserves request semantics without forwarding credentials", async () => {
+    const upstreamResponse = new Response("upstream", {
+      headers: { "x-upstream": "web" },
+      status: 202,
+    });
+    const upstreamFetch = vi.fn<UpstreamFetch>(() =>
+      Promise.resolve(upstreamResponse),
+    );
+    const request = new Request(
+      "https://dev.lootlog.pl/@me?returnTo=%2Fsettings",
+      {
+        body: "payload",
+        headers: {
+          authorization: "Bearer secret",
+          cookie: "session=secret",
+          "x-request-id": "request-1",
+        },
+        method: "POST",
+      },
+    );
+
+    const response = await routeRequest(request, environment, upstreamFetch);
+    const upstreamRequest = upstreamFetch.mock.calls[0]?.[0];
+
+    expect(response).toBe(upstreamResponse);
+    expect(upstreamRequest?.url).toBe(
+      `${environment.WEB_ORIGIN}/@me?returnTo=%2Fsettings`,
+    );
+    expect(upstreamRequest?.method).toBe("POST");
+    expect(await upstreamRequest?.text()).toBe("payload");
+    expect(upstreamRequest?.headers.get("x-request-id")).toBe("request-1");
+    expect(upstreamRequest?.headers.has("authorization")).toBe(false);
+    expect(upstreamRequest?.headers.has("cookie")).toBe(false);
+  });
+});

--- a/apps/traffic-splitter/src/index.test.ts
+++ b/apps/traffic-splitter/src/index.test.ts
@@ -44,13 +44,11 @@ describe("development traffic splitter", () => {
   });
 
   it.each([
-    ["https://dev.lootlog.pl/", environment.LANDING_ORIGIN],
-    ["https://dev.lootlog.pl/privacy-policy", environment.LANDING_ORIGIN],
-    ["https://dev.lootlog.pl/docs/features", environment.DOCS_ORIGIN],
     ["https://dev.lootlog.pl/@me", environment.WEB_ORIGIN],
     ["https://example.com/docs", environment.WEB_ORIGIN],
+    ["not a URL", environment.WEB_ORIGIN],
   ])(
-    "routes a legacy asset referred by %s to %s",
+    "routes a Web or untrusted legacy asset referred by %s to %s",
     async (referer, expectedOrigin) => {
       const upstreamFetch = vi.fn<UpstreamFetch>((request) =>
         Promise.resolve(Response.json({ url: request.url })),
@@ -66,6 +64,195 @@ describe("development traffic splitter", () => {
       );
     },
   );
+
+  it.each([
+    {
+      alias: "landing",
+      pagePath: "/",
+      upstreamOrigin: environment.LANDING_ORIGIN,
+    },
+    {
+      alias: "docs",
+      pagePath: "/docs/features",
+      upstreamOrigin: environment.DOCS_ORIGIN,
+    },
+  ])(
+    "preserves the $alias origin across nested legacy assets",
+    async ({ alias, pagePath, upstreamOrigin }) => {
+      const upstreamFetch = vi.fn<UpstreamFetch>((request) =>
+        Promise.resolve(Response.json({ url: request.url })),
+      );
+      const assetUrl = "https://dev.lootlog.pl/assets/entry.css?theme=dark";
+
+      const redirectResponse = await routeRequest(
+        new Request(assetUrl, {
+          headers: { referer: `https://dev.lootlog.pl${pagePath}` },
+        }),
+        environment,
+        upstreamFetch,
+      );
+      const taggedAssetUrl = `https://dev.lootlog.pl/__legacy-assets/${alias}/assets/entry.css?theme=dark`;
+
+      expect(redirectResponse.status).toBe(307);
+      expect(redirectResponse.headers.get("location")).toBe(taggedAssetUrl);
+      expect(redirectResponse.headers.get("cache-control")).toBe(
+        "private, no-store",
+      );
+      expect(redirectResponse.headers.get("vary")).toBe("Referer");
+      expect(upstreamFetch).not.toHaveBeenCalled();
+
+      await routeRequest(
+        new Request(taggedAssetUrl),
+        environment,
+        upstreamFetch,
+      );
+
+      expect(upstreamFetch.mock.calls[0]?.[0].url).toBe(
+        `${upstreamOrigin}/assets/entry.css?theme=dark`,
+      );
+
+      const nestedResponse = await routeRequest(
+        new Request("https://dev.lootlog.pl/assets/nested.woff2", {
+          headers: { referer: taggedAssetUrl },
+        }),
+        environment,
+        upstreamFetch,
+      );
+
+      expect(nestedResponse.status).toBe(307);
+      expect(nestedResponse.headers.get("location")).toBe(
+        `https://dev.lootlog.pl/__legacy-assets/${alias}/assets/nested.woff2`,
+      );
+    },
+  );
+
+  it.each([
+    {
+      alias: "landing",
+      upstreamOrigin: environment.LANDING_ORIGIN,
+    },
+    {
+      alias: "docs",
+      upstreamOrigin: environment.DOCS_ORIGIN,
+    },
+  ])(
+    "recovers the $alias origin from an untagged cached legacy parent",
+    async ({ alias, upstreamOrigin }) => {
+      const parentPath = "/assets/cached-parent.css?version=1";
+      const upstreamFetch = vi.fn<UpstreamFetch>((request) => {
+        const requestOrigin = new URL(request.url).origin;
+        const contentType =
+          request.method === "HEAD" && requestOrigin === upstreamOrigin
+            ? "text/css"
+            : "text/html";
+
+        return Promise.resolve(
+          new Response(null, {
+            headers: { "content-type": contentType },
+            status: 200,
+          }),
+        );
+      });
+
+      const response = await routeRequest(
+        new Request("https://dev.lootlog.pl/assets/nested.woff2", {
+          headers: {
+            authorization: "Bearer secret",
+            cookie: "session=secret",
+            referer: `https://dev.lootlog.pl${parentPath}`,
+          },
+        }),
+        environment,
+        upstreamFetch,
+      );
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe(
+        `https://dev.lootlog.pl/__legacy-assets/${alias}/assets/nested.woff2`,
+      );
+      expect(
+        upstreamFetch.mock.calls.map(([request]) => ({
+          method: request.method,
+          url: request.url,
+        })),
+      ).toContainEqual({
+        method: "HEAD",
+        url: `${upstreamOrigin}${parentPath}`,
+      });
+      expect(
+        upstreamFetch.mock.calls.every(
+          ([request]) =>
+            !request.headers.has("authorization") &&
+            !request.headers.has("cookie"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("keeps an untagged cached Web parent on the Web origin", async () => {
+    const parentPath = "/assets/cached-web.js";
+    const childPath = "/assets/web-chunk.js";
+    const upstreamFetch = vi.fn<UpstreamFetch>((request) => {
+      if (request.method === "HEAD") {
+        if (new URL(request.url).origin === environment.DOCS_ORIGIN) {
+          return Promise.reject(new Error("Docs origin unavailable"));
+        }
+
+        return Promise.resolve(
+          new Response(null, {
+            headers: { "content-type": "application/javascript" },
+          }),
+        );
+      }
+
+      return Promise.resolve(Response.json({ url: request.url }));
+    });
+
+    const response = await routeRequest(
+      new Request(`https://dev.lootlog.pl${childPath}`, {
+        headers: { referer: `https://dev.lootlog.pl${parentPath}` },
+      }),
+      environment,
+      upstreamFetch,
+    );
+
+    expect(response.status).toBe(200);
+    const forwardedRequests = upstreamFetch.mock.calls.map(([request]) => ({
+      method: request.method,
+      url: request.url,
+    }));
+
+    expect(
+      forwardedRequests.filter(({ method }) => method === "HEAD"),
+    ).toHaveLength(3);
+    expect(forwardedRequests.at(-1)).toEqual({
+      method: "GET",
+      url: `${environment.WEB_ORIGIN}${childPath}`,
+    });
+  });
+
+  it.each([
+    "//attacker.example/collect",
+    "///attacker.example/collect",
+    String.raw`/\\attacker.example/collect`,
+    "/%2F%2Fattacker.example/collect",
+  ])("keeps the selected upstream origin for %s", async (pathname) => {
+    const upstreamFetch = vi.fn<UpstreamFetch>((request) =>
+      Promise.resolve(Response.json({ url: request.url })),
+    );
+    const incomingRequest = new Request(
+      `https://dev.lootlog.pl${pathname}?source=dev`,
+    );
+
+    await routeRequest(incomingRequest, environment, upstreamFetch);
+
+    const upstreamRequest = upstreamFetch.mock.calls[0]?.[0];
+    const upstreamUrl = new URL(upstreamRequest?.url ?? "");
+
+    expect(upstreamUrl.origin).toBe(environment.WEB_ORIGIN);
+    expect(upstreamUrl.pathname).toBe(new URL(incomingRequest.url).pathname);
+    expect(upstreamUrl.search).toBe("?source=dev");
+  });
 
   it("preserves request semantics without forwarding credentials", async () => {
     const upstreamResponse = new Response("upstream", {

--- a/apps/traffic-splitter/src/index.ts
+++ b/apps/traffic-splitter/src/index.ts
@@ -11,6 +11,9 @@ type Upstream = "docs" | "landing" | "web";
 const landingDocuments = new Set(["/", "/privacy-policy", "/terms-of-service"]);
 const landingFiles = new Set(["/apple-icon.png", "/favicon.ico", "/icon.svg"]);
 const credentialHeaders = ["authorization", "cookie", "proxy-authorization"];
+const legacyDocsAssetRoot = "/__legacy-assets/docs";
+const legacyLandingAssetRoot = "/__legacy-assets/landing";
+const legacyAssetProbeOrder: Upstream[] = ["web", "landing", "docs"];
 
 function normalizeDocumentPath(pathname: string): string {
   if (pathname === "/") {
@@ -31,6 +34,7 @@ function selectPageUpstream(pathname: string): Upstream {
     landingDocuments.has(documentPath) ||
     landingFiles.has(pathname) ||
     isPathWithin(pathname, "/brand") ||
+    isPathWithin(pathname, legacyLandingAssetRoot) ||
     isPathWithin(pathname, "/landing-assets") ||
     isPathWithin(pathname, "/screenshots")
   ) {
@@ -40,6 +44,7 @@ function selectPageUpstream(pathname: string): Upstream {
   if (
     isPathWithin(pathname, "/docs") ||
     isPathWithin(pathname, "/docs-assets") ||
+    isPathWithin(pathname, legacyDocsAssetRoot) ||
     isPathWithin(pathname, "/__tsr") ||
     documentPath === "/api/search"
   ) {
@@ -53,20 +58,46 @@ function selectLegacyAssetUpstream(
   requestUrl: URL,
   referer: string | null,
 ): Upstream {
-  if (!referer) {
+  const refererUrl = getSameOriginReferer(requestUrl, referer);
+  if (!refererUrl) {
     return "web";
+  }
+
+  return selectPageUpstream(refererUrl.pathname);
+}
+
+function getSameOriginReferer(
+  requestUrl: URL,
+  referer: string | null,
+): URL | null {
+  if (!referer) {
+    return null;
   }
 
   try {
     const refererUrl = new URL(referer);
-    if (refererUrl.origin !== requestUrl.origin) {
-      return "web";
-    }
-
-    return selectPageUpstream(refererUrl.pathname);
+    return refererUrl.origin === requestUrl.origin ? refererUrl : null;
   } catch {
-    return "web";
+    return null;
   }
+}
+
+function getAmbiguousLegacyAssetReferer(
+  request: Request,
+  requestUrl: URL,
+): URL | null {
+  if (!isPathWithin(requestUrl.pathname, "/assets")) {
+    return null;
+  }
+
+  const refererUrl = getSameOriginReferer(
+    requestUrl,
+    request.headers.get("referer"),
+  );
+
+  return refererUrl && isPathWithin(refererUrl.pathname, "/assets")
+    ? refererUrl
+    : null;
 }
 
 function selectUpstream(request: Request, requestUrl: URL): Upstream {
@@ -94,12 +125,121 @@ function getUpstreamOrigin(
   }
 }
 
+function getLegacyAssetRoot(upstream: Upstream): string | null {
+  switch (upstream) {
+    case "docs":
+      return legacyDocsAssetRoot;
+    case "landing":
+      return legacyLandingAssetRoot;
+    case "web":
+      return null;
+  }
+}
+
+function createLegacyAssetRedirect(
+  requestUrl: URL,
+  upstream: Upstream,
+): Response | null {
+  if (!isPathWithin(requestUrl.pathname, "/assets")) {
+    return null;
+  }
+
+  const legacyAssetRoot = getLegacyAssetRoot(upstream);
+  if (!legacyAssetRoot) {
+    return null;
+  }
+
+  const redirectUrl = new URL(requestUrl);
+  redirectUrl.pathname = `${legacyAssetRoot}${requestUrl.pathname}`;
+
+  return new Response(null, {
+    headers: {
+      "cache-control": "private, no-store",
+      location: redirectUrl.href,
+      vary: "Referer",
+    },
+    status: 307,
+  });
+}
+
+function getUpstreamPathname(pathname: string): string {
+  for (const legacyAssetRoot of [legacyDocsAssetRoot, legacyLandingAssetRoot]) {
+    if (isPathWithin(pathname, legacyAssetRoot)) {
+      return pathname.slice(legacyAssetRoot.length);
+    }
+  }
+
+  return pathname;
+}
+
+function createLegacyAssetProbeRequest(
+  request: Request,
+  refererUrl: URL,
+  origin: string,
+): Request {
+  const upstreamUrl = new URL(origin);
+  upstreamUrl.pathname = refererUrl.pathname;
+  upstreamUrl.search = refererUrl.search;
+  upstreamUrl.hash = "";
+  const headers = new Headers(request.headers);
+
+  for (const header of credentialHeaders) {
+    headers.delete(header);
+  }
+  headers.delete("content-length");
+
+  return new Request(upstreamUrl, {
+    headers,
+    method: "HEAD",
+  });
+}
+
+function isStaticAssetResponse(response: Response): boolean {
+  if (!response.ok) {
+    return false;
+  }
+
+  const contentType = response.headers.get("content-type")?.toLowerCase();
+  return !contentType?.startsWith("text/html");
+}
+
+async function resolveAmbiguousLegacyAssetUpstream(
+  request: Request,
+  refererUrl: URL,
+  environment: TrafficSplitterEnvironment,
+  upstreamFetch: UpstreamFetch,
+): Promise<Upstream> {
+  const probes = await Promise.all(
+    legacyAssetProbeOrder.map(async (upstream) => {
+      try {
+        return {
+          response: await upstreamFetch(
+            createLegacyAssetProbeRequest(
+              request,
+              refererUrl,
+              getUpstreamOrigin(upstream, environment),
+            ),
+          ),
+          upstream,
+        };
+      } catch {
+        return { response: null, upstream };
+      }
+    }),
+  );
+
+  return (
+    probes.find(({ response }) => response && isStaticAssetResponse(response))
+      ?.upstream ?? "web"
+  );
+}
+
 function createUpstreamRequest(request: Request, origin: string): Request {
   const requestUrl = new URL(request.url);
-  const upstreamUrl = new URL(
-    `${requestUrl.pathname}${requestUrl.search}`,
-    origin,
-  );
+  const upstreamUrl = new URL(origin);
+  upstreamUrl.pathname = getUpstreamPathname(requestUrl.pathname);
+  upstreamUrl.search = requestUrl.search;
+  upstreamUrl.hash = "";
   const upstreamRequest = new Request(upstreamUrl, request);
 
   for (const header of credentialHeaders) {
@@ -109,13 +249,32 @@ function createUpstreamRequest(request: Request, origin: string): Request {
   return upstreamRequest;
 }
 
-export function routeRequest(
+export async function routeRequest(
   request: Request,
   environment: TrafficSplitterEnvironment,
   upstreamFetch: UpstreamFetch = fetch,
 ): Promise<Response> {
   const requestUrl = new URL(request.url);
-  const upstream = selectUpstream(request, requestUrl);
+  const ambiguousLegacyAssetReferer = getAmbiguousLegacyAssetReferer(
+    request,
+    requestUrl,
+  );
+  const canProbeLegacyAsset =
+    request.method === "GET" || request.method === "HEAD";
+  const upstream =
+    ambiguousLegacyAssetReferer && canProbeLegacyAsset
+      ? await resolveAmbiguousLegacyAssetUpstream(
+          request,
+          ambiguousLegacyAssetReferer,
+          environment,
+          upstreamFetch,
+        )
+      : selectUpstream(request, requestUrl);
+  const legacyAssetRedirect = createLegacyAssetRedirect(requestUrl, upstream);
+  if (legacyAssetRedirect) {
+    return legacyAssetRedirect;
+  }
+
   const upstreamOrigin = getUpstreamOrigin(upstream, environment);
 
   return upstreamFetch(createUpstreamRequest(request, upstreamOrigin));

--- a/apps/traffic-splitter/src/index.ts
+++ b/apps/traffic-splitter/src/index.ts
@@ -33,6 +33,7 @@ function selectPageUpstream(pathname: string): Upstream {
   if (
     landingDocuments.has(documentPath) ||
     landingFiles.has(pathname) ||
+    isPathWithin(pathname, "/_next") ||
     isPathWithin(pathname, "/brand") ||
     isPathWithin(pathname, legacyLandingAssetRoot) ||
     isPathWithin(pathname, "/landing-assets") ||

--- a/apps/traffic-splitter/src/index.ts
+++ b/apps/traffic-splitter/src/index.ts
@@ -1,0 +1,128 @@
+export interface TrafficSplitterEnvironment {
+  DOCS_ORIGIN: string;
+  LANDING_ORIGIN: string;
+  WEB_ORIGIN: string;
+}
+
+export type UpstreamFetch = (request: Request) => Promise<Response>;
+
+type Upstream = "docs" | "landing" | "web";
+
+const landingDocuments = new Set(["/", "/privacy-policy", "/terms-of-service"]);
+const landingFiles = new Set(["/apple-icon.png", "/favicon.ico", "/icon.svg"]);
+const credentialHeaders = ["authorization", "cookie", "proxy-authorization"];
+
+function normalizeDocumentPath(pathname: string): string {
+  if (pathname === "/") {
+    return pathname;
+  }
+
+  return pathname.replace(/\/+$/u, "");
+}
+
+function isPathWithin(pathname: string, root: string): boolean {
+  return pathname === root || pathname.startsWith(`${root}/`);
+}
+
+function selectPageUpstream(pathname: string): Upstream {
+  const documentPath = normalizeDocumentPath(pathname);
+
+  if (
+    landingDocuments.has(documentPath) ||
+    landingFiles.has(pathname) ||
+    isPathWithin(pathname, "/brand") ||
+    isPathWithin(pathname, "/landing-assets") ||
+    isPathWithin(pathname, "/screenshots")
+  ) {
+    return "landing";
+  }
+
+  if (
+    isPathWithin(pathname, "/docs") ||
+    isPathWithin(pathname, "/docs-assets") ||
+    isPathWithin(pathname, "/__tsr") ||
+    documentPath === "/api/search"
+  ) {
+    return "docs";
+  }
+
+  return "web";
+}
+
+function selectLegacyAssetUpstream(
+  requestUrl: URL,
+  referer: string | null,
+): Upstream {
+  if (!referer) {
+    return "web";
+  }
+
+  try {
+    const refererUrl = new URL(referer);
+    if (refererUrl.origin !== requestUrl.origin) {
+      return "web";
+    }
+
+    return selectPageUpstream(refererUrl.pathname);
+  } catch {
+    return "web";
+  }
+}
+
+function selectUpstream(request: Request, requestUrl: URL): Upstream {
+  if (isPathWithin(requestUrl.pathname, "/assets")) {
+    return selectLegacyAssetUpstream(
+      requestUrl,
+      request.headers.get("referer"),
+    );
+  }
+
+  return selectPageUpstream(requestUrl.pathname);
+}
+
+function getUpstreamOrigin(
+  upstream: Upstream,
+  environment: TrafficSplitterEnvironment,
+): string {
+  switch (upstream) {
+    case "docs":
+      return environment.DOCS_ORIGIN;
+    case "landing":
+      return environment.LANDING_ORIGIN;
+    case "web":
+      return environment.WEB_ORIGIN;
+  }
+}
+
+function createUpstreamRequest(request: Request, origin: string): Request {
+  const requestUrl = new URL(request.url);
+  const upstreamUrl = new URL(
+    `${requestUrl.pathname}${requestUrl.search}`,
+    origin,
+  );
+  const upstreamRequest = new Request(upstreamUrl, request);
+
+  for (const header of credentialHeaders) {
+    upstreamRequest.headers.delete(header);
+  }
+
+  return upstreamRequest;
+}
+
+export function routeRequest(
+  request: Request,
+  environment: TrafficSplitterEnvironment,
+  upstreamFetch: UpstreamFetch = fetch,
+): Promise<Response> {
+  const requestUrl = new URL(request.url);
+  const upstream = selectUpstream(request, requestUrl);
+  const upstreamOrigin = getUpstreamOrigin(upstream, environment);
+
+  return upstreamFetch(createUpstreamRequest(request, upstreamOrigin));
+}
+
+export default {
+  fetch(request: Request, environment: TrafficSplitterEnvironment) {
+    return routeRequest(request, environment);
+  },
+};

--- a/apps/traffic-splitter/tsconfig.json
+++ b/apps/traffic-splitter/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@lootlog/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/traffic-splitter/wrangler.jsonc
+++ b/apps/traffic-splitter/wrangler.jsonc
@@ -1,19 +1,36 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "lootlog-traffic-splitter-dev",
+  "name": "lootlog-route-splitter",
   "main": "src/index.ts",
   "compatibility_date": "2026-08-28",
   "workers_dev": true,
   "routes": [
     {
-      "pattern": "dev.lootlog.pl",
+      "pattern": "lootlog.pl",
       "custom_domain": true,
     },
   ],
   "vars": {
-    "DOCS_ORIGIN": "https://lootlog-docs-develop.communicator-dev.workers.dev",
-    "LANDING_ORIGIN": "https://develop.lootlog-landing.pages.dev",
-    "WEB_ORIGIN": "https://develop.lootlog-web-monorepo.pages.dev",
+    "DOCS_ORIGIN": "https://lootlog-docs.communicator-dev.workers.dev",
+    "LANDING_ORIGIN": "https://lootlog-landing.pages.dev",
+    "WEB_ORIGIN": "https://lootlog-web-monorepo.pages.dev",
+  },
+  "env": {
+    "develop": {
+      "name": "lootlog-traffic-splitter-dev",
+      "workers_dev": true,
+      "routes": [
+        {
+          "pattern": "dev.lootlog.pl",
+          "custom_domain": true,
+        },
+      ],
+      "vars": {
+        "DOCS_ORIGIN": "https://lootlog-docs-develop.communicator-dev.workers.dev",
+        "LANDING_ORIGIN": "https://develop.lootlog-landing.pages.dev",
+        "WEB_ORIGIN": "https://develop.lootlog-web-monorepo.pages.dev",
+      },
+    },
   },
   "observability": {
     "enabled": true,

--- a/apps/traffic-splitter/wrangler.jsonc
+++ b/apps/traffic-splitter/wrangler.jsonc
@@ -1,0 +1,21 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "lootlog-traffic-splitter-dev",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-28",
+  "workers_dev": true,
+  "routes": [
+    {
+      "pattern": "dev.lootlog.pl",
+      "custom_domain": true,
+    },
+  ],
+  "vars": {
+    "DOCS_ORIGIN": "https://lootlog-docs-develop.communicator-dev.workers.dev",
+    "LANDING_ORIGIN": "https://develop.lootlog-landing.pages.dev",
+    "WEB_ORIGIN": "https://develop.lootlog-web-monorepo.pages.dev",
+  },
+  "observability": {
+    "enabled": true,
+  },
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@lootlog/socket-parser": "workspace:*",
     "@lootlog/typescript-config": "workspace:*",
     "husky": "^9.1.7",
+    "jsonc-parser": "^3.3.1",
     "knip": "^6.32.3",
     "lint-staged": "^17.4.1",
     "oxfmt": "^0.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       knip:
         specifier: ^6.32.3
         version: 6.32.3
@@ -1303,6 +1306,21 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.11.12)(jsdom@29.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+
+  apps/traffic-splitter:
+    devDependencies:
+      '@lootlog/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.11.12)(jsdom@29.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+      wrangler:
+        specifier: ^4.127.0
+        version: 4.127.0
 
   apps/web:
     dependencies:

--- a/tools/ci/create-ci-plan.mjs
+++ b/tools/ci/create-ci-plan.mjs
@@ -41,6 +41,17 @@ const cloudflareDevelopmentTargets = new Map([
       project: "lootlog-docs-develop",
     },
   ],
+  [
+    "@lootlog/traffic-splitter",
+    {
+      artifactPath: "apps/traffic-splitter/dist",
+      configPath: "apps/traffic-splitter/wrangler.jsonc",
+      environment: "",
+      kind: "worker",
+      packageName: "@lootlog/traffic-splitter",
+      project: "lootlog-traffic-splitter-dev",
+    },
+  ],
 ]);
 
 const apiClientProducers = new Set([

--- a/tools/ci/create-ci-plan.mjs
+++ b/tools/ci/create-ci-plan.mjs
@@ -46,7 +46,7 @@ const cloudflareDevelopmentTargets = new Map([
     {
       artifactPath: "apps/traffic-splitter/dist",
       configPath: "apps/traffic-splitter/wrangler.jsonc",
-      environment: "",
+      environment: "develop",
       kind: "worker",
       packageName: "@lootlog/traffic-splitter",
       project: "lootlog-traffic-splitter-dev",

--- a/tools/release/create-deployment-matrix.mjs
+++ b/tools/release/create-deployment-matrix.mjs
@@ -13,6 +13,15 @@ const deployableServices = new Set([
 
 const cloudflareTargets = new Map([
   [
+    "@lootlog/traffic-splitter",
+    {
+      artifactPath: "apps/traffic-splitter/dist",
+      configPath: "apps/traffic-splitter/wrangler.jsonc",
+      kind: "worker",
+      project: "lootlog-route-splitter",
+    },
+  ],
+  [
     "@lootlog/landing",
     {
       artifactPath: "apps/landing/dist/client",
@@ -105,6 +114,15 @@ export function createReleasePlan(publishedPackages) {
       });
     }
   }
+
+  releasePlan.cloudflare.sort((left, right) => {
+    const leftPriority =
+      left.packageName === "@lootlog/traffic-splitter" ? 0 : 1;
+    const rightPriority =
+      right.packageName === "@lootlog/traffic-splitter" ? 0 : 1;
+
+    return leftPriority - rightPriority;
+  });
 
   return releasePlan;
 }

--- a/tools/release/create-deployment-matrix.test.mjs
+++ b/tools/release/create-deployment-matrix.test.mjs
@@ -62,25 +62,32 @@ test("supports all eight deployable applications", () => {
   );
 });
 
-test("supports all five Cloudflare applications", () => {
+test("supports all six Cloudflare applications", () => {
   const publishedPackages = [
     { name: "@lootlog/landing", version: "1.0.0" },
     { name: "@lootlog/web", version: "1.0.0" },
     { name: "@lootlog/game-client", version: "1.0.0" },
     { name: "@lootlog/docs", version: "1.0.0" },
     { name: "@lootlog/wiki", version: "1.0.0" },
+    { name: "@lootlog/traffic-splitter", version: "1.0.0" },
   ];
 
+  const cloudflarePlan = createReleasePlan(publishedPackages).cloudflare;
+
   assert.deepEqual(
-    createReleasePlan(publishedPackages).cloudflare.map(
-      ({ artifactPath, kind, packageName, project }) => ({
-        artifactPath,
-        kind,
-        packageName,
-        project,
-      }),
-    ),
+    cloudflarePlan.map(({ artifactPath, kind, packageName, project }) => ({
+      artifactPath,
+      kind,
+      packageName,
+      project,
+    })),
     [
+      {
+        artifactPath: "apps/traffic-splitter/dist",
+        kind: "worker",
+        packageName: "@lootlog/traffic-splitter",
+        project: "lootlog-route-splitter",
+      },
       {
         artifactPath: "apps/landing/dist/client",
         kind: "pages",
@@ -112,6 +119,10 @@ test("supports all five Cloudflare applications", () => {
         project: "lootlog-wiki",
       },
     ],
+  );
+  assert.equal(
+    cloudflarePlan[0].configPath,
+    "apps/traffic-splitter/wrangler.jsonc",
   );
 });
 

--- a/tools/release/development-workflow.test.mjs
+++ b/tools/release/development-workflow.test.mjs
@@ -95,4 +95,12 @@ test("deploys the development traffic splitter from the repository", () => {
     developmentWorkflow,
     /matrix\.kind == 'worker' && secrets\.CLOUDFLARE_WORKERS_API_TOKEN/u,
   );
+  assert.match(
+    developmentWorkflow,
+    /matrix\.kind == 'pages' && secrets\.CLOUDFLARE_API_TOKEN \|\| ''/u,
+  );
+  assert.match(
+    developmentWorkflow,
+    /if \[\[ -z "\$CLOUDFLARE_API_TOKEN" \]\]; then/u,
+  );
 });

--- a/tools/release/development-workflow.test.mjs
+++ b/tools/release/development-workflow.test.mjs
@@ -54,7 +54,11 @@ test("keeps Pages development targets and skips version pull requests", () => {
     affectedPackages: ["@lootlog/landing"],
   });
   const versionPlan = createCiPlan({
-    affectedPackages: ["@lootlog/docs", "@lootlog/landing"],
+    affectedPackages: [
+      "@lootlog/docs",
+      "@lootlog/landing",
+      "@lootlog/traffic-splitter",
+    ],
     associatedPullRequestHeads: ["changeset-release/main"],
   });
 
@@ -78,19 +82,38 @@ test("deploys the development traffic splitter from the repository", () => {
     {
       artifactPath: "apps/traffic-splitter/dist",
       configPath: "apps/traffic-splitter/wrangler.jsonc",
-      environment: "",
+      environment: "develop",
       kind: "worker",
       packageName: "@lootlog/traffic-splitter",
       project: "lootlog-traffic-splitter-dev",
     },
   ]);
+  assert.equal(trafficSplitterWranglerConfig.name, "lootlog-route-splitter");
+  assert.deepEqual(trafficSplitterWranglerConfig.routes, [
+    { custom_domain: true, pattern: "lootlog.pl" },
+  ]);
+  assert.deepEqual(trafficSplitterWranglerConfig.vars, {
+    DOCS_ORIGIN: "https://lootlog-docs.communicator-dev.workers.dev",
+    LANDING_ORIGIN: "https://lootlog-landing.pages.dev",
+    WEB_ORIGIN: "https://lootlog-web-monorepo.pages.dev",
+  });
   assert.equal(
-    trafficSplitterWranglerConfig.name,
+    trafficSplitterWranglerConfig.env.develop.name,
     "lootlog-traffic-splitter-dev",
   );
-  assert.deepEqual(trafficSplitterWranglerConfig.routes, [
+  assert.deepEqual(trafficSplitterWranglerConfig.env.develop.routes, [
     { custom_domain: true, pattern: "dev.lootlog.pl" },
   ]);
+  assert.deepEqual(trafficSplitterWranglerConfig.env.develop.vars, {
+    DOCS_ORIGIN: "https://lootlog-docs-develop.communicator-dev.workers.dev",
+    LANDING_ORIGIN: "https://develop.lootlog-landing.pages.dev",
+    WEB_ORIGIN: "https://develop.lootlog-web-monorepo.pages.dev",
+  });
+  assert.notEqual(
+    trafficSplitterWranglerConfig.env.develop.name,
+    trafficSplitterWranglerConfig.name,
+    "development must not overwrite the production Worker",
+  );
   assert.match(
     developmentWorkflow,
     /matrix\.kind == 'worker' && secrets\.CLOUDFLARE_WORKERS_API_TOKEN/u,

--- a/tools/release/development-workflow.test.mjs
+++ b/tools/release/development-workflow.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
+import { parse } from "jsonc-parser";
 import { createCiPlan } from "../ci/create-ci-plan.mjs";
 
 const developmentWorkflow = readFileSync(
@@ -10,6 +11,12 @@ const developmentWorkflow = readFileSync(
 const docsWranglerConfig = JSON.parse(
   readFileSync(
     new URL("../../apps/docs/wrangler.jsonc", import.meta.url),
+    "utf8",
+  ),
+);
+const trafficSplitterWranglerConfig = parse(
+  readFileSync(
+    new URL("../../apps/traffic-splitter/wrangler.jsonc", import.meta.url),
     "utf8",
   ),
 );
@@ -60,4 +67,32 @@ test("keeps Pages development targets and skips version pull requests", () => {
     },
   ]);
   assert.deepEqual(versionPlan.cloudflareTargets, []);
+});
+
+test("deploys the development traffic splitter from the repository", () => {
+  const plan = createCiPlan({
+    affectedPackages: ["@lootlog/traffic-splitter"],
+  });
+
+  assert.deepEqual(plan.cloudflareTargets, [
+    {
+      artifactPath: "apps/traffic-splitter/dist",
+      configPath: "apps/traffic-splitter/wrangler.jsonc",
+      environment: "",
+      kind: "worker",
+      packageName: "@lootlog/traffic-splitter",
+      project: "lootlog-traffic-splitter-dev",
+    },
+  ]);
+  assert.equal(
+    trafficSplitterWranglerConfig.name,
+    "lootlog-traffic-splitter-dev",
+  );
+  assert.deepEqual(trafficSplitterWranglerConfig.routes, [
+    { custom_domain: true, pattern: "dev.lootlog.pl" },
+  ]);
+  assert.match(
+    developmentWorkflow,
+    /matrix\.kind == 'worker' && secrets\.CLOUDFLARE_WORKERS_API_TOKEN/u,
+  );
 });

--- a/tools/release/release-workflow.test.mjs
+++ b/tools/release/release-workflow.test.mjs
@@ -81,8 +81,29 @@ test("smoke-checks Landing and Docs before the rollback boundary closes", () => 
 
   assert.match(smokeStep, /https:\/\/lootlog\.pl\/privacy-policy/u);
   assert.match(smokeStep, /https:\/\/docs\.lootlog\.pl\/api\/search/u);
+  assert.match(
+    smokeStep,
+    /verify-public-static-assets\.mjs \\\n+\s+https:\/\/lootlog\.pl \\\n+\s+\/landing-assets/u,
+  );
+  assert.match(
+    smokeStep,
+    /verify-public-static-assets\.mjs \\\n+\s+https:\/\/docs\.lootlog\.pl \\\n+\s+\/docs-assets/u,
+  );
   assert.ok(
     smokeStepPosition < rollbackStepPosition,
     "public smoke checks must run before the rollback step",
+  );
+});
+
+test("deploys the immutable production splitter before frontend artifacts", () => {
+  const deployStep = getNamedStep("Deploy Cloudflare release artifacts");
+
+  assert.match(
+    deployStep,
+    /sort_by\(if \.packageName == "@lootlog\/traffic-splitter" then 0 else 1 end\)/u,
+  );
+  assert.match(
+    deployStep,
+    /@lootlog\/traffic-splitter\)[\s\S]*wrangler deploy "\$artifact_path\/index\.js"/u,
   );
 });

--- a/tools/release/verify-public-static-assets.mjs
+++ b/tools/release/verify-public-static-assets.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+
+const generatedAssetPattern =
+  /(?:href|src)="([^"]+\.(?:css|js)(?:[?#][^"]*)?)"/gu;
+
+function isPathWithin(pathname, root) {
+  return pathname === root || pathname.startsWith(`${root}/`);
+}
+
+async function fetchWithRetry(
+  url,
+  { fetchImplementation, retryAttempts, retryDelayMilliseconds },
+) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= retryAttempts; attempt += 1) {
+    try {
+      const response = await fetchImplementation(url, { redirect: "follow" });
+      if (response.ok) {
+        return response;
+      }
+
+      lastError = new Error(`${url} returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt < retryAttempts) {
+      await delay(retryDelayMilliseconds);
+    }
+  }
+
+  throw new Error(`Failed to fetch ${url}`, { cause: lastError });
+}
+
+function hasExpectedContentType(assetUrl, response) {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+
+  if (assetUrl.pathname.endsWith(".css")) {
+    return contentType.startsWith("text/css");
+  }
+
+  return /^(?:application|text)\/(?:javascript|x-javascript)/u.test(
+    contentType,
+  );
+}
+
+export async function verifyPublicStaticAssets({
+  baseUrl,
+  documentPaths,
+  expectedNamespace,
+  fetchImplementation = fetch,
+  retryAttempts = 10,
+  retryDelayMilliseconds = 3000,
+}) {
+  assert.ok(documentPaths.length > 0, "At least one document path is required");
+  assert.match(expectedNamespace, /^\/[A-Za-z0-9-]+$/u);
+
+  const publicOrigin = new URL(baseUrl).origin;
+  const assets = new Map();
+
+  for (const documentPath of documentPaths) {
+    const documentUrl = new URL(documentPath, publicOrigin);
+    const response = await fetchWithRetry(documentUrl, {
+      fetchImplementation,
+      retryAttempts,
+      retryDelayMilliseconds,
+    });
+    const document = await response.text();
+    const localAssetUrls = Array.from(
+      document.matchAll(generatedAssetPattern),
+      ([, reference]) => new URL(reference, documentUrl),
+    ).filter((assetUrl) => assetUrl.origin === publicOrigin);
+
+    assert.ok(
+      localAssetUrls.length > 0,
+      `${documentUrl.href} does not reference local CSS or JavaScript`,
+    );
+
+    for (const assetUrl of localAssetUrls) {
+      assert.ok(
+        isPathWithin(assetUrl.pathname, expectedNamespace),
+        `${documentUrl.href} references ${assetUrl.href} outside the ${expectedNamespace} namespace`,
+      );
+      assets.set(assetUrl.href, assetUrl);
+    }
+  }
+
+  await Promise.all(
+    Array.from(assets.values(), async (assetUrl) => {
+      const response = await fetchWithRetry(assetUrl, {
+        fetchImplementation,
+        retryAttempts,
+        retryDelayMilliseconds,
+      });
+
+      assert.ok(
+        hasExpectedContentType(assetUrl, response),
+        `${assetUrl.href} expected CSS or JavaScript content type, received ${response.headers.get("content-type") ?? "none"}`,
+      );
+    }),
+  );
+}
+
+const isCommandLineInvocation =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCommandLineInvocation) {
+  const [baseUrl, expectedNamespace, ...documentPaths] = process.argv.slice(2);
+
+  if (!baseUrl || !expectedNamespace || documentPaths.length === 0) {
+    throw new Error(
+      "Usage: verify-public-static-assets.mjs <base-url> <asset-namespace> <document-path>...",
+    );
+  }
+
+  await verifyPublicStaticAssets({
+    baseUrl,
+    documentPaths,
+    expectedNamespace,
+  });
+  process.stdout.write(
+    `Verified public assets for ${baseUrl} in ${expectedNamespace}.\n`,
+  );
+}

--- a/tools/release/verify-public-static-assets.test.mjs
+++ b/tools/release/verify-public-static-assets.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { verifyPublicStaticAssets } from "./verify-public-static-assets.mjs";
+
+function createFetch(responses, requests) {
+  return async (input) => {
+    const url = input.toString();
+    requests.push(url);
+    const response = responses.get(url);
+
+    if (!response) {
+      return new Response("missing", { status: 404 });
+    }
+
+    return response.clone();
+  };
+}
+
+test("checks every local generated asset and ignores external links", async () => {
+  const requests = [];
+  const responses = new Map([
+    [
+      "https://lootlog.pl/",
+      new Response(
+        '<link href="/landing-assets/app.css"><script src="/landing-assets/app.js"></script><a href="https://addon.lootlog.pl/entrypoint.user.js">Install</a>',
+        { headers: { "content-type": "text/html" } },
+      ),
+    ],
+    [
+      "https://lootlog.pl/landing-assets/app.css",
+      new Response("body {}", { headers: { "content-type": "text/css" } }),
+    ],
+    [
+      "https://lootlog.pl/landing-assets/app.js",
+      new Response("export {}", {
+        headers: { "content-type": "application/javascript" },
+      }),
+    ],
+  ]);
+
+  await verifyPublicStaticAssets({
+    baseUrl: "https://lootlog.pl",
+    documentPaths: ["/"],
+    expectedNamespace: "/landing-assets",
+    fetchImplementation: createFetch(responses, requests),
+    retryAttempts: 1,
+  });
+
+  assert.deepEqual(requests, [
+    "https://lootlog.pl/",
+    "https://lootlog.pl/landing-assets/app.css",
+    "https://lootlog.pl/landing-assets/app.js",
+  ]);
+});
+
+test("rejects a local generated asset outside the expected namespace", async () => {
+  const responses = new Map([
+    [
+      "https://lootlog.pl/",
+      new Response(
+        '<link href="/landing-assets/app.css"><script src="/assets/wrong.js"></script>',
+        { headers: { "content-type": "text/html" } },
+      ),
+    ],
+  ]);
+
+  await assert.rejects(
+    verifyPublicStaticAssets({
+      baseUrl: "https://lootlog.pl",
+      documentPaths: ["/"],
+      expectedNamespace: "/landing-assets",
+      fetchImplementation: createFetch(responses, []),
+      retryAttempts: 1,
+    }),
+    /outside the \/landing-assets namespace/u,
+  );
+});
+
+test("rejects an asset served as HTML", async () => {
+  const responses = new Map([
+    [
+      "https://lootlog.pl/",
+      new Response('<script src="/landing-assets/app.js"></script>', {
+        headers: { "content-type": "text/html" },
+      }),
+    ],
+    [
+      "https://lootlog.pl/landing-assets/app.js",
+      new Response("<html>SPA fallback</html>", {
+        headers: { "content-type": "text/html" },
+      }),
+    ],
+  ]);
+
+  await assert.rejects(
+    verifyPublicStaticAssets({
+      baseUrl: "https://lootlog.pl",
+      documentPaths: ["/"],
+      expectedNamespace: "/landing-assets",
+      fetchImplementation: createFetch(responses, []),
+      retryAttempts: 1,
+    }),
+    /expected CSS or JavaScript content type/u,
+  );
+});


### PR DESCRIPTION
## Summary

- namespace Landing and Docs build assets as `/landing-assets` and `/docs-assets`
- keep one tested `@lootlog/traffic-splitter` implementation for two independently deployed Workers
- deploy `lootlog-traffic-splitter-dev` only from merges to `main`
- include `lootlog-route-splitter` only in an approved production release
- preserve cached pre-migration HTML through legacy `/assets` routing and `/_next` compatibility
- deploy the production splitter before frontend artifacts and roll it back after them
- smoke-check public Landing and Docs CSS and JavaScript, not only HTML

## Root cause

The manually managed development splitter only routed Next.js `/_next` assets. After the TanStack Start migration, Landing and Web both emitted files under `/assets`. Landing CSS and JavaScript therefore reached the Web Pages origin and were returned as HTML.

## Environment isolation

The Wrangler top-level environment owns the existing production Worker `lootlog-route-splitter` on `lootlog.pl`. The `develop` environment owns `lootlog-traffic-splitter-dev` on `dev.lootlog.pl` and has separate origins. The affected-package workflow always supplies `--env develop`; Changesets version pull requests skip development deployment entirely.

Merging this PR cannot deploy the production Worker. Production remains unchanged until the Changesets release is merged and the GitHub `prod` environment is approved.

## Production rollout safety

The release builds a checksummed splitter artifact alongside the frontend artifacts. Promotion installs the backward-compatible splitter first, then Landing and Docs. Public smoke checks fetch generated CSS and JavaScript through `lootlog.pl` and `docs.lootlog.pl`. Any failed deployment or smoke check invokes the existing rollback in reverse order, restoring frontend applications before the splitter.

## Verification

- Landing, Docs, and traffic splitter lint, typecheck, test, and build
- 31 traffic routing tests
- 41 CI and release-tooling tests
- frozen lockfile and repository formatting
- exact Wrangler dry-runs for both production and `develop` splitter environments
- read-only checks of all configured production origins
- live development smoke checks for Landing CSS/JS, legal pages, Docs HTML/CSS/search, and Web fallback
- browser verification of rendered Landing and Docs content

The development Docs Worker and splitter currently running on `dev.lootlog.pl` were deployed earlier from this branch. No production deployment was performed.
