### PR TITLE
refactor(reservations): share reservation time policy

### DIFF
--- a/.changeset/deep-reservation-policy.md
+++ b/.changeset/deep-reservation-policy.md
@@ -1,0 +1,11 @@
+---
+"@lootlog/api": patch
+"@lootlog/reservations": patch
+"@lootlog/web": patch
+---
+
+Centralize Reservation settings defaults and time validation in a shared domain
+module. Keep Organization settings in the API database while making the Web
+form match the authoritative 60-second past-start grace and preserving existing
+Reservation mutation error contracts. Replace localized Reservation settings
+errors in the API with stable translation keys.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -31,6 +31,7 @@
     "@lootlog/datetime": "workspace:*",
     "@lootlog/instrumentation": "workspace:*",
     "@lootlog/nest-shared": "workspace:*",
+    "@lootlog/reservations": "workspace:*",
     "@lootlog/scoring": "workspace:*",
     "@lootlog/types": "workspace:*",
     "@nestjs/axios": "catalog:",

--- a/apps/api/src/guilds/dto/update-guild-config.dto.spec.ts
+++ b/apps/api/src/guilds/dto/update-guild-config.dto.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { ErrorKey } from "src/guilds/enum/error-key.enum";
+import { UpdateGuildConfigDto } from "./update-guild-config.dto";
+
+describe("UpdateGuildConfigDto", () => {
+  it("returns a translation key instead of localized backend copy", () => {
+    const result = UpdateGuildConfigDto.schema.safeParse({
+      reservationTimeGranularityMinutes: 7,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    expect(result.error.issues[0]?.message).toBe(
+      ErrorKey.GUILDS_RESERVATION_TIME_GRANULARITY_INVALID,
+    );
+  });
+});

--- a/apps/api/src/guilds/dto/update-guild-config.dto.ts
+++ b/apps/api/src/guilds/dto/update-guild-config.dto.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import { createZodDto } from "nestjs-zod";
+import { RESERVATION_TIME_GRANULARITY_OPTIONS } from "@lootlog/reservations";
+import { ErrorKey } from "src/guilds/enum/error-key.enum";
 
 const UpdateGuildConfigSchema = z.object({
   vanityUrl: z.string().min(1).nullable().optional(),
@@ -9,9 +11,15 @@ const UpdateGuildConfigSchema = z.object({
   reservationTimeGranularityMinutes: z
     .number()
     .int()
-    .refine((value) => [5, 10, 15, 30, 60].includes(value), {
-      message: "Nieprawidłowy krok siatki rezerwacji.",
-    })
+    .refine(
+      (value) =>
+        RESERVATION_TIME_GRANULARITY_OPTIONS.some(
+          (granularity) => granularity === value,
+        ),
+      {
+        message: ErrorKey.GUILDS_RESERVATION_TIME_GRANULARITY_INVALID,
+      },
+    )
     .optional(),
   reservationMaxAdvanceDays: z.number().int().min(1).max(30).optional(),
   reservationActiveLimitPerSpot: z.number().int().min(1).max(10).optional(),

--- a/apps/api/src/guilds/enum/error-key.enum.ts
+++ b/apps/api/src/guilds/enum/error-key.enum.ts
@@ -3,5 +3,7 @@ export enum ErrorKey {
   GUILD_ALREADY_INITIALIZED = "errors.guilds.alreadyInitialized",
   GUILDS_INITIALIZE_BOT_INVALID_ROLES = "errors.guilds.initializeBot.invalidRoles",
   GUILDS_INITIALIZE_BOT_SAME_ROLES = "errors.guilds.initializeBot.sameRoles",
+  GUILDS_RESERVATION_DURATION_RANGE_INVALID = "errors.guilds.reservations.durationRangeInvalid",
+  GUILDS_RESERVATION_TIME_GRANULARITY_INVALID = "errors.guilds.reservations.timeGranularityInvalid",
   GUILDS_VANITY_URL_RESTRICTED = "errors.guilds.vanityUrlRestricted",
 }

--- a/apps/api/src/guilds/guilds.service.spec.ts
+++ b/apps/api/src/guilds/guilds.service.spec.ts
@@ -1222,9 +1222,12 @@ describe("GuildsService", () => {
           reservationMinDurationMinutes: 90,
           reservationMaxDurationMinutes: 60,
         }),
-      ).rejects.toThrow(
-        "Minimalna długość rezerwacji nie może być większa niż maksymalna.",
-      );
+      ).rejects.toMatchObject({
+        response: {
+          message: "errors.guilds.reservations.durationRangeInvalid",
+        },
+        status: 400,
+      });
 
       expect(mockPrismaService.guild.update).not.toHaveBeenCalled();
     });

--- a/apps/api/src/guilds/guilds.service.ts
+++ b/apps/api/src/guilds/guilds.service.ts
@@ -7,6 +7,10 @@ import {
   HttpStatus,
 } from "@nestjs/common";
 import { DiscordGuildSyncStatus } from "@lootlog/types";
+import {
+  resolveReservationSettings,
+  type ReservationSettings,
+} from "@lootlog/reservations";
 
 import { WINSTON_MODULE_PROVIDER } from "nest-winston";
 import type { Logger } from "winston";
@@ -74,14 +78,6 @@ type GuildPermissionMember = {
 
 const USER_GUILD_PERMISSIONS_CACHE_TTL_SECONDS = 60;
 const CURRENT_USER_ACCESSIBLE_GUILDS_CACHE_TTL_SECONDS = 30;
-const DEFAULT_RESERVATION_SETTINGS = {
-  reservationMaxDurationMinutes: 180,
-  reservationMinDurationMinutes: 30,
-  reservationTimeGranularityMinutes: 15,
-  reservationMaxAdvanceDays: 7,
-  reservationActiveLimitPerSpot: 3,
-} as const;
-
 @Injectable()
 export class GuildsService {
   private readonly staleAfterMs: number;
@@ -379,26 +375,12 @@ export class GuildsService {
     return guild;
   }
 
-  private withReservationSettingsDefaults<T extends Record<string, unknown>>(
-    guild: T,
-  ) {
+  private withReservationSettingsDefaults<
+    T extends Record<string, unknown> & Partial<ReservationSettings>,
+  >(guild: T) {
     return {
       ...guild,
-      reservationMaxDurationMinutes:
-        guild.reservationMaxDurationMinutes ??
-        DEFAULT_RESERVATION_SETTINGS.reservationMaxDurationMinutes,
-      reservationMinDurationMinutes:
-        guild.reservationMinDurationMinutes ??
-        DEFAULT_RESERVATION_SETTINGS.reservationMinDurationMinutes,
-      reservationTimeGranularityMinutes:
-        guild.reservationTimeGranularityMinutes ??
-        DEFAULT_RESERVATION_SETTINGS.reservationTimeGranularityMinutes,
-      reservationMaxAdvanceDays:
-        guild.reservationMaxAdvanceDays ??
-        DEFAULT_RESERVATION_SETTINGS.reservationMaxAdvanceDays,
-      reservationActiveLimitPerSpot:
-        guild.reservationActiveLimitPerSpot ??
-        DEFAULT_RESERVATION_SETTINGS.reservationActiveLimitPerSpot,
+      ...resolveReservationSettings(guild),
     };
   }
 
@@ -1029,9 +1011,9 @@ export class GuildsService {
       nextMaxDuration !== undefined &&
       nextMinDuration > nextMaxDuration
     ) {
-      throw new BadRequestException(
-        "Minimalna długość rezerwacji nie może być większa niż maksymalna.",
-      );
+      throw new BadRequestException({
+        message: ErrorKey.GUILDS_RESERVATION_DURATION_RANGE_INVALID,
+      });
     }
 
     const oldGuild = await this.prisma.guild.findUnique({
@@ -1049,9 +1031,9 @@ export class GuildsService {
       nextMaxDuration === undefined &&
       nextMinDuration > oldGuild.reservationMaxDurationMinutes
     ) {
-      throw new BadRequestException(
-        "Minimalna długość rezerwacji nie może być większa niż maksymalna.",
-      );
+      throw new BadRequestException({
+        message: ErrorKey.GUILDS_RESERVATION_DURATION_RANGE_INVALID,
+      });
     }
 
     if (
@@ -1060,9 +1042,9 @@ export class GuildsService {
       nextMinDuration === undefined &&
       oldGuild.reservationMinDurationMinutes > nextMaxDuration
     ) {
-      throw new BadRequestException(
-        "Maksymalna długość rezerwacji nie może być mniejsza niż minimalna.",
-      );
+      throw new BadRequestException({
+        message: ErrorKey.GUILDS_RESERVATION_DURATION_RANGE_INVALID,
+      });
     }
 
     const guild = await this.prisma.guild.update({

--- a/apps/api/src/reservations/reservation-policy.spec.ts
+++ b/apps/api/src/reservations/reservation-policy.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
+import type { ReservationSettings } from "@lootlog/reservations";
 import {
   parseReservationWindow,
   validateReservationTime,
-  type ReservationSettings,
 } from "./reservation-policy";
 
 const settings: ReservationSettings = {
@@ -34,6 +34,41 @@ describe("reservation policy", () => {
         settings,
       }),
     ).toThrowError(expect.objectContaining({ status: 422 }));
+  });
+
+  it("preserves the HTTP error contract for a past start", () => {
+    expect(() =>
+      validateReservationTime({
+        startsAt: new Date("2026-08-26T11:45:00.000Z"),
+        endsAt: new Date("2026-08-26T12:30:00.000Z"),
+        now: new Date("2026-08-26T12:00:00.000Z"),
+        settings,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        response: { code: "RESERVATION_START_IN_PAST" },
+        status: 422,
+      }),
+    );
+  });
+
+  it("preserves Organization settings in HTTP error details", () => {
+    expect(() =>
+      validateReservationTime({
+        startsAt: new Date("2026-08-26T12:15:00.000Z"),
+        endsAt: new Date("2026-08-26T12:20:00.000Z"),
+        now: new Date("2026-08-26T12:00:00.000Z"),
+        settings: { ...settings, reservationMinDurationMinutes: 15 },
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        response: {
+          code: "RESERVATION_TOO_SHORT",
+          minimumMinutes: 15,
+        },
+        status: 422,
+      }),
+    );
   });
 
   it("limits a calendar query to 31 days", () => {

--- a/apps/api/src/reservations/reservation-policy.ts
+++ b/apps/api/src/reservations/reservation-policy.ts
@@ -2,18 +2,12 @@ import {
   BadRequestException,
   UnprocessableEntityException,
 } from "@nestjs/common";
-
-export type ReservationSettings = {
-  reservationMaxDurationMinutes: number;
-  reservationMinDurationMinutes: number;
-  reservationTimeGranularityMinutes: number;
-  reservationMaxAdvanceDays: number;
-  reservationActiveLimitPerSpot: number;
-};
+import {
+  validateReservationTime as getReservationTimeValidationIssue,
+  type ReservationSettings,
+} from "@lootlog/reservations";
 
 const MAX_WINDOW_MS = 31 * 24 * 60 * 60 * 1000;
-const START_GRACE_MS = 60 * 1000;
-
 export function parseReservationWindow(fromValue: string, toValue: string) {
   const from = new Date(fromValue);
   const to = new Date(toValue);
@@ -40,64 +34,8 @@ export function validateReservationTime(options: {
   now?: Date;
   allowPastStart?: boolean;
 }): void {
-  const now = options.now ?? new Date();
-  const durationMinutes =
-    (options.endsAt.getTime() - options.startsAt.getTime()) / 60_000;
-
-  if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
-    throw new UnprocessableEntityException({ code: "INVALID_TIME_RANGE" });
+  const issue = getReservationTimeValidationIssue(options);
+  if (issue) {
+    throw new UnprocessableEntityException(issue);
   }
-  if (
-    !options.allowPastStart &&
-    options.startsAt.getTime() < now.getTime() - START_GRACE_MS
-  ) {
-    throw new UnprocessableEntityException({
-      code: "RESERVATION_START_IN_PAST",
-    });
-  }
-  if (durationMinutes < options.settings.reservationMinDurationMinutes) {
-    throw new UnprocessableEntityException({
-      code: "RESERVATION_TOO_SHORT",
-      minimumMinutes: options.settings.reservationMinDurationMinutes,
-    });
-  }
-  if (durationMinutes > options.settings.reservationMaxDurationMinutes) {
-    throw new UnprocessableEntityException({
-      code: "RESERVATION_TOO_LONG",
-      maximumMinutes: options.settings.reservationMaxDurationMinutes,
-    });
-  }
-  if (
-    options.startsAt.getTime() >
-    now.getTime() +
-      options.settings.reservationMaxAdvanceDays * 24 * 60 * 60 * 1000
-  ) {
-    throw new UnprocessableEntityException({
-      code: "RESERVATION_TOO_FAR_IN_ADVANCE",
-      maximumDays: options.settings.reservationMaxAdvanceDays,
-    });
-  }
-  if (
-    !isAlignedToGrid(
-      options.startsAt,
-      options.settings.reservationTimeGranularityMinutes,
-    ) ||
-    !isAlignedToGrid(
-      options.endsAt,
-      options.settings.reservationTimeGranularityMinutes,
-    )
-  ) {
-    throw new UnprocessableEntityException({
-      code: "INVALID_TIME_GRID",
-      granularityMinutes: options.settings.reservationTimeGranularityMinutes,
-    });
-  }
-}
-
-function isAlignedToGrid(date: Date, granularityMinutes: number): boolean {
-  return (
-    date.getUTCSeconds() === 0 &&
-    date.getUTCMilliseconds() === 0 &&
-    date.getUTCMinutes() % granularityMinutes === 0
-  );
 }

--- a/apps/api/src/reservations/reservation-settings-defaults.spec.ts
+++ b/apps/api/src/reservations/reservation-settings-defaults.spec.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_RESERVATION_SETTINGS } from "@lootlog/reservations";
+
+describe("Reservation settings defaults", () => {
+  it("keeps TypeScript fallbacks aligned with persisted Guild defaults", () => {
+    const prismaSchema = readFileSync(
+      new URL("../../prisma/schema.prisma", import.meta.url),
+      "utf8",
+    );
+
+    for (const [field, value] of Object.entries(DEFAULT_RESERVATION_SETTINGS)) {
+      expect(prismaSchema).toMatch(
+        new RegExp(`${field}\\s+Int\\s+@default\\(${value}\\)`),
+      );
+    }
+  });
+});

--- a/apps/api/src/reservations/reservations.service.ts
+++ b/apps/api/src/reservations/reservations.service.ts
@@ -5,6 +5,10 @@ import {
   NotFoundException,
   UnprocessableEntityException,
 } from "@nestjs/common";
+import {
+  resolveReservationSettings,
+  type ReservationSettings,
+} from "@lootlog/reservations";
 import { PrismaService } from "src/db/prisma.service";
 import { Permission, Prisma } from "src/generated/prisma/client";
 import { GuildsService } from "src/guilds/guilds.service";
@@ -21,18 +25,9 @@ import {
 import {
   parseReservationWindow,
   validateReservationTime,
-  type ReservationSettings,
 } from "./reservation-policy";
 import { ReservationReminderService } from "./reservation-reminder.service";
 import { ReservationSharingService } from "./reservation-sharing.service";
-
-const DEFAULT_RESERVATION_SETTINGS: ReservationSettings = {
-  reservationMaxDurationMinutes: 180,
-  reservationMinDurationMinutes: 30,
-  reservationTimeGranularityMinutes: 15,
-  reservationMaxAdvanceDays: 7,
-  reservationActiveLimitPerSpot: 3,
-};
 
 type ViewerContext = {
   guildId: string;
@@ -596,7 +591,7 @@ export class ReservationsService {
       },
     });
 
-    return guild ?? DEFAULT_RESERVATION_SETTINGS;
+    return resolveReservationSettings(guild);
   }
 
   private toPresentationViewer(context: ViewerContext) {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@lexical/table": "0.48.0",
     "@lootlog/api-client": "workspace:*",
     "@lootlog/datetime": "workspace:*",
+    "@lootlog/reservations": "workspace:*",
     "@lootlog/scoring": "workspace:*",
     "@lootlog/socket-parser": "workspace:*",
     "@lootlog/types": "workspace:*",

--- a/apps/web/src/features/guild/reservations/schedule/find-nearest-free-reservation-range.spec.ts
+++ b/apps/web/src/features/guild/reservations/schedule/find-nearest-free-reservation-range.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { ReservationSettings } from "@lootlog/reservations";
 import {
   findNearestFreeReservationRange,
   getNearestFreeReservationSearchWindow,
 } from "./find-nearest-free-reservation-range";
-import type { ReservationSettings } from "./reservation-settings";
 
 const settings = {
   reservationMaxDurationMinutes: 180,

--- a/apps/web/src/features/guild/reservations/schedule/find-nearest-free-reservation-range.ts
+++ b/apps/web/src/features/guild/reservations/schedule/find-nearest-free-reservation-range.ts
@@ -1,8 +1,8 @@
+import type { ReservationSettings } from "@lootlog/reservations";
 import {
   ceilDateToReservationStep,
   floorDateToReservationStep,
   getReservationLatestStartDate,
-  type ReservationSettings,
 } from "./reservation-settings";
 import type { ReservationRange } from "./types";
 

--- a/apps/web/src/features/guild/reservations/schedule/reservation-form-dialog.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-form-dialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@lootlog/ui/components/drawer";
 import { ScrollArea } from "@lootlog/ui/components/scroll-area";
 import { useTranslation } from "react-i18next";
-import type { ReservationSettings } from "./reservation-settings";
+import type { ReservationSettings } from "@lootlog/reservations";
 import { ReservationForm } from "./reservation-form";
 
 type ReservationFormDialogProps = {

--- a/apps/web/src/features/guild/reservations/schedule/reservation-form.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-form.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
+import type { ReservationSettings } from "@lootlog/reservations";
 import { toast } from "sonner";
 import {
   getListReservationSpotsQueryKey,
@@ -25,7 +26,6 @@ import { getReservationErrorMessage } from "../get-reservation-error-message";
 import {
   getReservationEarliestStartDate,
   getReservationLatestStartDate,
-  type ReservationSettings,
   validateReservationDateRange,
 } from "./reservation-settings";
 import { getReservationValidationMessage } from "./reservation-validation-message";

--- a/apps/web/src/features/guild/reservations/schedule/reservation-settings-info-dialog.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-settings-info-dialog.tsx
@@ -7,6 +7,7 @@ import {
   ShieldAlert,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { ReservationSettings } from "@lootlog/reservations";
 import {
   Dialog,
   DialogContent,
@@ -14,8 +15,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@lootlog/ui/components/dialog";
-
-import type { ReservationSettings } from "./reservation-settings";
 
 type ReservationSettingsInfoDialogProps = {
   open: boolean;

--- a/apps/web/src/features/guild/reservations/schedule/reservation-settings.spec.ts
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-settings.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   clampReservationEndDate,
   getDurationMinutes,
-  getReservationSettings,
   isReservationStartSelectable,
   snapMinutesToStep,
   validateReservationDateRange,
@@ -17,16 +16,6 @@ describe("reservation settings helpers", () => {
     reservationActiveLimitPerSpot: 3,
   };
   const now = new Date(2026, 0, 1, 12, 0, 0, 0);
-
-  it("falls back to default settings when guild config is missing", () => {
-    expect(getReservationSettings(undefined)).toEqual({
-      reservationMaxDurationMinutes: 180,
-      reservationMinDurationMinutes: 30,
-      reservationTimeGranularityMinutes: 15,
-      reservationMaxAdvanceDays: 7,
-      reservationActiveLimitPerSpot: 3,
-    });
-  });
 
   it("snaps minutes down to the configured step", () => {
     expect(snapMinutesToStep(37, 15)).toBe(30);
@@ -102,6 +91,17 @@ describe("reservation settings helpers", () => {
       validateReservationDateRange({
         fromDate: new Date(2026, 0, 1, 10, 45),
         toDate: new Date(2026, 0, 1, 11, 30),
+        settings,
+        now,
+      }),
+    ).toBe("startTooOld");
+  });
+
+  it("matches the authoritative 60-second grace for a past start", () => {
+    expect(
+      validateReservationDateRange({
+        fromDate: new Date(2026, 0, 1, 11, 45),
+        toDate: new Date(2026, 0, 1, 12, 30),
         settings,
         now,
       }),

--- a/apps/web/src/features/guild/reservations/schedule/reservation-settings.ts
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-settings.ts
@@ -1,20 +1,9 @@
-export const DEFAULT_RESERVATION_SETTINGS = {
-  reservationMaxDurationMinutes: 180,
-  reservationMinDurationMinutes: 30,
-  reservationTimeGranularityMinutes: 15,
-  reservationMaxAdvanceDays: 7,
-  reservationActiveLimitPerSpot: 3,
-} as const;
-
-export const RESERVATION_GRANULARITY_OPTIONS = [5, 10, 15, 30, 60] as const;
-
-export type ReservationSettings = {
-  reservationMaxDurationMinutes: number;
-  reservationMinDurationMinutes: number;
-  reservationTimeGranularityMinutes: number;
-  reservationMaxAdvanceDays: number;
-  reservationActiveLimitPerSpot: number;
-};
+import {
+  RESERVATION_START_GRACE_MS,
+  validateReservationTime,
+  type ReservationSettings,
+  type ReservationTimeValidationIssue,
+} from "@lootlog/reservations";
 
 export type ReservationRangeValidationError =
   | "timeRangeRequired"
@@ -40,8 +29,6 @@ type ClampReservationEndDateOptions = {
   now?: Date;
 };
 
-const START_PAST_TOLERANCE_MS = 60 * 60 * 1000;
-
 const alignDateToStep = (
   date: Date,
   stepMinutes: number,
@@ -63,26 +50,6 @@ const alignDateToStep = (
   return alignedDate;
 };
 
-export const getReservationSettings = (
-  guild: Partial<ReservationSettings> | null | undefined,
-): ReservationSettings => ({
-  reservationMaxDurationMinutes:
-    guild?.reservationMaxDurationMinutes ??
-    DEFAULT_RESERVATION_SETTINGS.reservationMaxDurationMinutes,
-  reservationMinDurationMinutes:
-    guild?.reservationMinDurationMinutes ??
-    DEFAULT_RESERVATION_SETTINGS.reservationMinDurationMinutes,
-  reservationTimeGranularityMinutes:
-    guild?.reservationTimeGranularityMinutes ??
-    DEFAULT_RESERVATION_SETTINGS.reservationTimeGranularityMinutes,
-  reservationMaxAdvanceDays:
-    guild?.reservationMaxAdvanceDays ??
-    DEFAULT_RESERVATION_SETTINGS.reservationMaxAdvanceDays,
-  reservationActiveLimitPerSpot:
-    guild?.reservationActiveLimitPerSpot ??
-    DEFAULT_RESERVATION_SETTINGS.reservationActiveLimitPerSpot,
-});
-
 export const snapMinutesToStep = (minutes: number, stepMinutes: number) =>
   Math.floor(minutes / stepMinutes) * stepMinutes;
 
@@ -90,7 +57,7 @@ export const getDurationMinutes = (fromDate: Date, toDate: Date) =>
   Math.round((toDate.getTime() - fromDate.getTime()) / 60_000);
 
 export const getReservationEarliestStartDate = (now = new Date()) =>
-  new Date(now.getTime() - START_PAST_TOLERANCE_MS);
+  new Date(now.getTime() - RESERVATION_START_GRACE_MS);
 
 export const isReservationStartSelectable = (
   startsAt: Date,
@@ -126,37 +93,34 @@ export const validateReservationDateRange = ({
     return "timeRangeRequired";
   }
 
-  if (fromDate >= toDate) {
-    return "endAfterStart";
+  const issue = validateReservationTime({
+    startsAt: fromDate,
+    endsAt: toDate,
+    settings,
+    now,
+    allowPastStart,
+  });
+
+  return issue ? toReservationRangeValidationError(issue) : null;
+};
+
+const toReservationRangeValidationError = (
+  issue: ReservationTimeValidationIssue,
+): ReservationRangeValidationError => {
+  switch (issue.code) {
+    case "INVALID_TIME_RANGE":
+      return "endAfterStart";
+    case "INVALID_TIME_GRID":
+      return "invalidTimeGrid";
+    case "RESERVATION_START_IN_PAST":
+      return "startTooOld";
+    case "RESERVATION_TOO_SHORT":
+      return "minimumDuration";
+    case "RESERVATION_TOO_LONG":
+      return "maximumDuration";
+    case "RESERVATION_TOO_FAR_IN_ADVANCE":
+      return "maxAdvance";
   }
-
-  const isOnGrid = (date: Date) =>
-    date.getMinutes() % settings.reservationTimeGranularityMinutes === 0 &&
-    date.getSeconds() === 0 &&
-    date.getMilliseconds() === 0;
-  if (!isOnGrid(fromDate) || !isOnGrid(toDate)) {
-    return "invalidTimeGrid";
-  }
-
-  if (!allowPastStart && fromDate < getReservationEarliestStartDate(now)) {
-    return "startTooOld";
-  }
-
-  const durationMinutes = getDurationMinutes(fromDate, toDate);
-
-  if (durationMinutes < settings.reservationMinDurationMinutes) {
-    return "minimumDuration";
-  }
-
-  if (durationMinutes > settings.reservationMaxDurationMinutes) {
-    return "maximumDuration";
-  }
-
-  if (fromDate > getReservationLatestStartDate(settings, now)) {
-    return "maxAdvance";
-  }
-
-  return null;
 };
 
 export const clampReservationEndDate = ({

--- a/apps/web/src/features/guild/reservations/schedule/reservation-validation-message.ts
+++ b/apps/web/src/features/guild/reservations/schedule/reservation-validation-message.ts
@@ -1,9 +1,7 @@
 import type { TFunction } from "i18next";
+import type { ReservationSettings } from "@lootlog/reservations";
 
-import type {
-  ReservationRangeValidationError,
-  ReservationSettings,
-} from "./reservation-settings";
+import type { ReservationRangeValidationError } from "./reservation-settings";
 
 export const getReservationValidationMessage = (
   error: ReservationRangeValidationError,

--- a/apps/web/src/features/guild/reservations/schedule/reservations-schedule.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservations-schedule.tsx
@@ -5,6 +5,7 @@ import { useParams } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Permission } from "@lootlog/types";
+import { resolveReservationSettings } from "@lootlog/reservations";
 import {
   getListReservationSpotsQueryKey,
   getListSpotReservationsQueryKey,
@@ -41,7 +42,6 @@ import { ReservationDetails } from "./reservation-details";
 import { ReservationFormDialog } from "./reservation-form-dialog";
 import {
   ceilDateToReservationStep,
-  getReservationSettings,
   isReservationStartSelectable,
 } from "./reservation-settings";
 import { ScheduleHeader } from "./schedule-header";
@@ -77,7 +77,7 @@ export function ReservationsSchedule() {
   const swipePreviewEnd = addDays(weekEnd, 1);
   const dayIndex = differenceInCalendarDays(date, weekStart);
   const guildQuery = useGuildsControllerGetGuildById({ guildId });
-  const settings = getReservationSettings(guildQuery.data);
+  const settings = resolveReservationSettings(guildQuery.data);
   const reservationsQuery = useListSpotReservations(
     { guildId, spotId },
     {

--- a/apps/web/src/features/guild/reservations/schedule/schedule-header.spec.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/schedule-header.spec.tsx
@@ -8,7 +8,7 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_RESERVATION_SETTINGS } from "./reservation-settings";
+import { DEFAULT_RESERVATION_SETTINGS } from "@lootlog/reservations";
 import { ScheduleHeader } from "./schedule-header";
 
 const navigate = vi.fn<(options: { to: string }) => void>();

--- a/apps/web/src/features/guild/reservations/schedule/schedule-header.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/schedule-header.tsx
@@ -13,10 +13,10 @@ import {
   WandSparkles,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import type { ReservationSettings } from "@lootlog/reservations";
 import { Button } from "@lootlog/ui/components/button";
 import { cn } from "@lootlog/ui/lib/utils";
 import { ReservationSettingsInfoDialog } from "./reservation-settings-info-dialog";
-import type { ReservationSettings } from "./reservation-settings";
 
 type ScheduleHeaderProps = {
   date: Date;

--- a/apps/web/src/features/guild/settings/reservations/reservations-form.schema.ts
+++ b/apps/web/src/features/guild/settings/reservations/reservations-form.schema.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import { RESERVATION_TIME_GRANULARITY_OPTIONS } from "@lootlog/reservations";
 
 export const reservationsSettingsFormSchema = z
   .object({
@@ -7,7 +8,11 @@ export const reservationsSettingsFormSchema = z
     reservationTimeGranularityMinutes: z
       .number()
       .int()
-      .refine((value) => [5, 10, 15, 30, 60].includes(value)),
+      .refine((value) =>
+        RESERVATION_TIME_GRANULARITY_OPTIONS.some(
+          (granularity) => granularity === value,
+        ),
+      ),
     reservationMaxAdvanceDays: z.number().int().min(1).max(30),
     reservationActiveLimitPerSpot: z.number().int().min(1).max(10),
   })

--- a/apps/web/src/features/guild/settings/reservations/reservations-settings-form.tsx
+++ b/apps/web/src/features/guild/settings/reservations/reservations-settings-form.tsx
@@ -23,6 +23,10 @@ import {
 } from "@lootlog/ui/components/select";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
+import {
+  RESERVATION_TIME_GRANULARITY_OPTIONS,
+  resolveReservationSettings,
+} from "@lootlog/reservations";
 import { UnsavedChangesBar } from "@/components/ui/unsaved-changes-bar";
 import { useGuildId } from "@/hooks/context/use-guild-id";
 import {
@@ -34,10 +38,6 @@ import {
   reservationsSettingsFormSchema,
   type ReservationsSettingsFormValues,
 } from "./reservations-form.schema";
-import {
-  getReservationSettings,
-  RESERVATION_GRANULARITY_OPTIONS,
-} from "@/features/guild/reservations/schedule/reservation-settings";
 import type { GuildResponseDtoOutput } from "@lootlog/api-client/models/main/guild-response-dto-output";
 
 type ReservationsSettingsFormProps = {
@@ -51,7 +51,7 @@ export const ReservationsSettingsForm = ({
   const guildId = useGuildId();
   const queryClient = useQueryClient();
   const { mutate: updateGuildConfig } = useGuildsControllerUpdateGuildConfig();
-  const settings = getReservationSettings(guild);
+  const settings = resolveReservationSettings(guild);
 
   const form = useForm<ReservationsSettingsFormValues>({
     resolver: zodResolver(reservationsSettingsFormSchema),
@@ -59,7 +59,7 @@ export const ReservationsSettingsForm = ({
   });
 
   useEffect(() => {
-    form.reset(getReservationSettings(guild));
+    form.reset(resolveReservationSettings(guild));
   }, [
     form,
     guild.reservationActiveLimitPerSpot,
@@ -209,13 +209,15 @@ export const ReservationsSettingsForm = ({
                     <Select
                       value={String(field.value)}
                       onValueChange={(value) => field.onChange(Number(value))}
-                      items={RESERVATION_GRANULARITY_OPTIONS.map((value) => ({
-                        value: String(value),
-                        label: t(
-                          "settings.reservations.fields.granularity.option",
-                          { minutes: value },
-                        ),
-                      }))}
+                      items={RESERVATION_TIME_GRANULARITY_OPTIONS.map(
+                        (value) => ({
+                          value: String(value),
+                          label: t(
+                            "settings.reservations.fields.granularity.option",
+                            { minutes: value },
+                          ),
+                        }),
+                      )}
                     >
                       <FormControl
                         render={
@@ -225,7 +227,7 @@ export const ReservationsSettingsForm = ({
                         }
                       />
                       <SelectContent>
-                        {RESERVATION_GRANULARITY_OPTIONS.map((value) => (
+                        {RESERVATION_TIME_GRANULARITY_OPTIONS.map((value) => (
                           <SelectItem key={value} value={String(value)}>
                             {t(
                               "settings.reservations.fields.granularity.option",

--- a/apps/web/src/features/user/reservations/edit-my-reservation-form.tsx
+++ b/apps/web/src/features/user/reservations/edit-my-reservation-form.tsx
@@ -2,6 +2,7 @@ import { useId, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
+import { resolveReservationSettings } from "@lootlog/reservations";
 import { toast } from "sonner";
 import type { MyReservationsResponseDtoItemsItem } from "@lootlog/api-client/models/main/my-reservations-response-dto-items-item";
 import {
@@ -25,7 +26,6 @@ import { getReservationErrorMessage } from "@/features/guild/reservations/get-re
 import {
   getReservationEarliestStartDate,
   getReservationLatestStartDate,
-  getReservationSettings,
   validateReservationDateRange,
 } from "@/features/guild/reservations/schedule/reservation-settings";
 import { getReservationValidationMessage } from "@/features/guild/reservations/schedule/reservation-validation-message";
@@ -64,7 +64,7 @@ export function EditMyReservationForm({
   const [reminder, setReminder] = useState<ReminderValue>(
     toReminderValue(reservation.reminderMinutesBefore),
   );
-  const settings = getReservationSettings(reservation.editingConstraints);
+  const settings = resolveReservationSettings(reservation.editingConstraints);
   const targetsQuery = useNotificationsUserControllerGetUserTargets();
   const hasActiveDm = Boolean(
     targetsQuery.data?.some(

--- a/packages/reservations/package.json
+++ b/packages/reservations/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@lootlog/reservations",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "lint": "oxlint src",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@lootlog/typescript-config": "workspace:*",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/reservations/src/index.spec.ts
+++ b/packages/reservations/src/index.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_RESERVATION_SETTINGS,
+  resolveReservationSettings,
+  validateReservationTime,
+} from "./index";
+
+describe("Reservation time policy", () => {
+  it("resolves missing settings without replacing Organization values", () => {
+    expect(
+      resolveReservationSettings({
+        reservationMinDurationMinutes: 15,
+        reservationTimeGranularityMinutes: 5,
+      }),
+    ).toEqual({
+      ...DEFAULT_RESERVATION_SETTINGS,
+      reservationMinDurationMinutes: 15,
+      reservationTimeGranularityMinutes: 5,
+    });
+  });
+
+  it("accepts a range aligned to the Organization settings", () => {
+    expect(
+      validateReservationTime({
+        startsAt: new Date("2026-08-26T12:15:00.000Z"),
+        endsAt: new Date("2026-08-26T13:15:00.000Z"),
+        now: new Date("2026-08-26T12:00:00.000Z"),
+        settings: DEFAULT_RESERVATION_SETTINGS,
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects a start outside the authoritative 60-second grace", () => {
+    expect(
+      validateReservationTime({
+        startsAt: new Date("2026-08-26T11:45:00.000Z"),
+        endsAt: new Date("2026-08-26T12:30:00.000Z"),
+        now: new Date("2026-08-26T12:00:00.000Z"),
+        settings: DEFAULT_RESERVATION_SETTINGS,
+      }),
+    ).toEqual({ code: "RESERVATION_START_IN_PAST" });
+  });
+
+  it("allows an unchanged past start while editing", () => {
+    expect(
+      validateReservationTime({
+        startsAt: new Date("2026-08-26T11:45:00.000Z"),
+        endsAt: new Date("2026-08-26T12:30:00.000Z"),
+        now: new Date("2026-08-26T12:00:00.000Z"),
+        settings: DEFAULT_RESERVATION_SETTINGS,
+        allowPastStart: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns details from the supplied Organization settings", () => {
+    expect(
+      validateReservationTime({
+        startsAt: new Date("2026-08-26T12:15:00.000Z"),
+        endsAt: new Date("2026-08-26T12:20:00.000Z"),
+        now: new Date("2026-08-26T12:00:00.000Z"),
+        settings: {
+          ...DEFAULT_RESERVATION_SETTINGS,
+          reservationMinDurationMinutes: 15,
+        },
+      }),
+    ).toEqual({
+      code: "RESERVATION_TOO_SHORT",
+      minimumMinutes: 15,
+    });
+  });
+});

--- a/packages/reservations/src/index.ts
+++ b/packages/reservations/src/index.ts
@@ -1,0 +1,119 @@
+export type ReservationSettings = {
+  reservationMaxDurationMinutes: number;
+  reservationMinDurationMinutes: number;
+  reservationTimeGranularityMinutes: number;
+  reservationMaxAdvanceDays: number;
+  reservationActiveLimitPerSpot: number;
+};
+
+export const DEFAULT_RESERVATION_SETTINGS = {
+  reservationMaxDurationMinutes: 180,
+  reservationMinDurationMinutes: 30,
+  reservationTimeGranularityMinutes: 15,
+  reservationMaxAdvanceDays: 7,
+  reservationActiveLimitPerSpot: 3,
+} as const satisfies ReservationSettings;
+
+export const RESERVATION_TIME_GRANULARITY_OPTIONS = [
+  5, 10, 15, 30, 60,
+] as const;
+
+export const RESERVATION_START_GRACE_MS = 60_000;
+
+export type ReservationTimeValidationIssue =
+  | { code: "INVALID_TIME_RANGE" }
+  | { code: "RESERVATION_START_IN_PAST" }
+  | { code: "RESERVATION_TOO_SHORT"; minimumMinutes: number }
+  | { code: "RESERVATION_TOO_LONG"; maximumMinutes: number }
+  | { code: "RESERVATION_TOO_FAR_IN_ADVANCE"; maximumDays: number }
+  | { code: "INVALID_TIME_GRID"; granularityMinutes: number };
+
+type ValidateReservationTimeOptions = {
+  startsAt: Date;
+  endsAt: Date;
+  settings: ReservationSettings;
+  now?: Date;
+  allowPastStart?: boolean;
+};
+
+export function resolveReservationSettings(
+  settings: Partial<ReservationSettings> | null | undefined,
+): ReservationSettings {
+  return {
+    reservationMaxDurationMinutes:
+      settings?.reservationMaxDurationMinutes ??
+      DEFAULT_RESERVATION_SETTINGS.reservationMaxDurationMinutes,
+    reservationMinDurationMinutes:
+      settings?.reservationMinDurationMinutes ??
+      DEFAULT_RESERVATION_SETTINGS.reservationMinDurationMinutes,
+    reservationTimeGranularityMinutes:
+      settings?.reservationTimeGranularityMinutes ??
+      DEFAULT_RESERVATION_SETTINGS.reservationTimeGranularityMinutes,
+    reservationMaxAdvanceDays:
+      settings?.reservationMaxAdvanceDays ??
+      DEFAULT_RESERVATION_SETTINGS.reservationMaxAdvanceDays,
+    reservationActiveLimitPerSpot:
+      settings?.reservationActiveLimitPerSpot ??
+      DEFAULT_RESERVATION_SETTINGS.reservationActiveLimitPerSpot,
+  };
+}
+
+export function validateReservationTime({
+  startsAt,
+  endsAt,
+  settings,
+  now = new Date(),
+  allowPastStart = false,
+}: ValidateReservationTimeOptions): ReservationTimeValidationIssue | null {
+  const durationMinutes = (endsAt.getTime() - startsAt.getTime()) / 60_000;
+
+  if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+    return { code: "INVALID_TIME_RANGE" };
+  }
+  if (
+    !allowPastStart &&
+    startsAt.getTime() < now.getTime() - RESERVATION_START_GRACE_MS
+  ) {
+    return { code: "RESERVATION_START_IN_PAST" };
+  }
+  if (durationMinutes < settings.reservationMinDurationMinutes) {
+    return {
+      code: "RESERVATION_TOO_SHORT",
+      minimumMinutes: settings.reservationMinDurationMinutes,
+    };
+  }
+  if (durationMinutes > settings.reservationMaxDurationMinutes) {
+    return {
+      code: "RESERVATION_TOO_LONG",
+      maximumMinutes: settings.reservationMaxDurationMinutes,
+    };
+  }
+  if (
+    startsAt.getTime() >
+    now.getTime() + settings.reservationMaxAdvanceDays * 24 * 60 * 60 * 1000
+  ) {
+    return {
+      code: "RESERVATION_TOO_FAR_IN_ADVANCE",
+      maximumDays: settings.reservationMaxAdvanceDays,
+    };
+  }
+  if (
+    !isAlignedToGrid(startsAt, settings.reservationTimeGranularityMinutes) ||
+    !isAlignedToGrid(endsAt, settings.reservationTimeGranularityMinutes)
+  ) {
+    return {
+      code: "INVALID_TIME_GRID",
+      granularityMinutes: settings.reservationTimeGranularityMinutes,
+    };
+  }
+
+  return null;
+}
+
+function isAlignedToGrid(date: Date, granularityMinutes: number): boolean {
+  return (
+    date.getUTCSeconds() === 0 &&
+    date.getUTCMilliseconds() === 0 &&
+    date.getUTCMinutes() % granularityMinutes === 0
+  );
+}

--- a/packages/reservations/tsconfig.json
+++ b/packages/reservations/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@lootlog/typescript-config/base.json",
+  "include": ["src"]
+}

--- a/packages/reservations/tsdown.config.ts
+++ b/packages/reservations/tsdown.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm", "cjs"],
+  outExtensions: ({ format }) => ({
+    js: format === "cjs" ? ".js" : ".mjs",
+  }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@lootlog/nest-shared':
         specifier: workspace:*
         version: link:../../packages/nest-shared
+      '@lootlog/reservations':
+        specifier: workspace:*
+        version: link:../../packages/reservations
       '@lootlog/scoring':
         specifier: workspace:*
         version: link:../../packages/scoring
@@ -1357,6 +1360,9 @@ importers:
       '@lootlog/datetime':
         specifier: workspace:*
         version: link:../../packages/datetime
+      '@lootlog/reservations':
+        specifier: workspace:*
+        version: link:../../packages/reservations
       '@lootlog/scoring':
         specifier: workspace:*
         version: link:../../packages/scoring
@@ -1783,6 +1789,21 @@ importers:
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.11.12)(jsdom@29.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(tsx@4.23.12)(yaml@2.9.0))
+
+  packages/reservations:
+    devDependencies:
+      '@lootlog/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.14(oxc-resolver@11.24.2)(tsx@4.23.12)(typescript@7.0.2)(unrun@0.2.36)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2


### PR DESCRIPTION
## Summary

- Add the non-deployable `@lootlog/reservations` package for shared reservation settings and time validation.
- Use the same 60-second past-start grace period in API and Web while keeping per-Organization database settings as the source of truth.
- Replace Polish backend validation messages with stable error keys and add regression tests for HTTP contracts and Prisma default drift.

## Related issue

None.

## Testing

- Pre-commit checks for all changed packages: formatting, lint, typecheck, build, and tests.
- API: 107 test files, 1048 tests passed.
- Focused Web reservation tests: 25 tests passed.
- Shared reservations package: 5 tests passed.

## Screenshots or recordings

Not applicable; there are no visual changes.

## Risks and rollout

The Web client now rejects new reservation starts more than 60 seconds in the past instead of allowing 60 minutes. The database schema, stored values, generated API clients, and deployment topology are unchanged. No migration or environment variable is required.

## Checklist

- [x] A changeset is included, or this change does not require one
- [x] Relevant tests were added or run, or testing is not applicable
- [x] Migrations, environment variables, documentation, and breaking changes are covered when applicable