### PR TITLE
fix(gateway): authenticate sockets before connection

### DIFF
--- a/.changeset/gateway-websocket-auth-ordering.md
+++ b/.changeset/gateway-websocket-auth-ordering.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/gateway": patch
+---
+
+Authenticate Socket.IO connections before exposing websocket message handlers and reject incomplete socket identities.

--- a/apps/gateway/src/gateway/gateway-auth-race.spec.ts
+++ b/apps/gateway/src/gateway/gateway-auth-race.spec.ts
@@ -1,0 +1,244 @@
+import { HttpService } from "@nestjs/axios";
+import { type INestApplication, Module } from "@nestjs/common";
+import { IoAdapter } from "@nestjs/platform-socket.io";
+import { Test } from "@nestjs/testing";
+import { io, type Socket as ClientSocket } from "socket.io-client";
+import type { ServerOptions } from "socket.io";
+import { Gateway } from "./gateway";
+import { GatewayEvent } from "./enums/gateway-event.enum";
+import { ConnectionService } from "./services/connection.service";
+import { GatewayAuthService } from "./services/gateway-auth.service";
+import { PresenceService } from "./services/presence.service";
+import { SubscriptionService } from "./services/subscription.service";
+import { MapPingService } from "./services/map-ping.service";
+import { AirTagService } from "./services/air-tag.service";
+import { RedisIoAdapter } from "src/lib/redis/redis-io.adapter";
+
+class TestRedisIoAdapter extends RedisIoAdapter {
+  override createIOServer(port: number, options?: ServerOptions) {
+    return IoAdapter.prototype.createIOServer.call(this, port, options);
+  }
+}
+
+@Module({
+  providers: [
+    Gateway,
+    GatewayAuthService,
+    ConnectionService,
+    { provide: HttpService, useValue: { get: vi.fn() } },
+    {
+      provide: PresenceService,
+      useValue: {
+        emitDisconnectPresence: vi.fn(),
+        emitMemberWebPresenceUpdate: vi.fn(),
+      },
+    },
+    {
+      provide: SubscriptionService,
+      useValue: {
+        handleJoin: vi.fn().mockResolvedValue({ status: "success" }),
+        handleDisconnect: vi.fn(),
+      },
+    },
+    { provide: MapPingService, useValue: {} },
+    { provide: AirTagService, useValue: {} },
+  ],
+})
+class TestGatewayModule {}
+
+describe("Gateway authentication ordering", () => {
+  let app: INestApplication;
+  let client: ClientSocket | undefined;
+
+  afterEach(async () => {
+    client?.disconnect();
+    await app?.close();
+  });
+
+  it("does not expose JOIN until delayed connection authentication completes", async () => {
+    let resolveIdentity!: (identity: {
+      discordId: string;
+      userId: string;
+    }) => void;
+    let markAuthenticationStarted!: () => void;
+    const authenticationStarted = new Promise<void>((resolve) => {
+      markAuthenticationStarted = resolve;
+    });
+    const identity = new Promise<{ discordId: string; userId: string }>(
+      (resolve) => {
+        resolveIdentity = resolve;
+      },
+    );
+
+    const testingModule = await Test.createTestingModule({
+      imports: [TestGatewayModule],
+    }).compile();
+    app = testingModule.createNestApplication();
+    app.useWebSocketAdapter(new TestRedisIoAdapter(app));
+
+    const gatewayAuthService = app.get(GatewayAuthService);
+    vi.spyOn(gatewayAuthService, "verifyConnectionIdentity").mockImplementation(
+      () => {
+        markAuthenticationStarted();
+        return identity;
+      },
+    );
+
+    await app.listen(0);
+    const address = app.getHttpServer().address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the test gateway to listen on a TCP port");
+    }
+
+    const subscriptionService = app.get(SubscriptionService);
+    const connected = new Promise<void>((resolve, reject) => {
+      client = io(`http://127.0.0.1:${address.port}`, {
+        transports: ["websocket"],
+        extraHeaders: {
+          cookie: "session=real",
+          origin: "https://lootlog.com",
+        },
+      });
+      client.on("connect", () => {
+        client?.emit(GatewayEvent.JOIN, {});
+        resolve();
+      });
+      client.on("connect_error", reject);
+    });
+
+    await authenticationStarted;
+    const connectedBeforeAuthentication = await Promise.race([
+      connected.then(() => true),
+      new Promise<false>((resolve) => {
+        setTimeout(() => resolve(false), 100);
+      }),
+    ]);
+    if (connectedBeforeAuthentication) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20);
+      });
+    }
+
+    expect(vi.mocked(subscriptionService.handleJoin).mock.calls[0]).toBe(
+      undefined,
+    );
+    expect(connectedBeforeAuthentication).toBe(false);
+
+    resolveIdentity({ discordId: "discord-1", userId: "user-1" });
+    await connected;
+    await vi.waitFor(() => {
+      expect(subscriptionService.handleJoin).toHaveBeenCalledTimes(1);
+    });
+    expect(subscriptionService.handleJoin).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "discord-1",
+      "user-1",
+      undefined,
+      undefined,
+    );
+  });
+
+  it.each([
+    {
+      description: "auth verification fails",
+      headers: {
+        cookie: "session=expired",
+        origin: "https://lootlog.com",
+      },
+      stubVerification: true,
+    },
+    {
+      description: "credentials are missing",
+      headers: { origin: "https://lootlog.com" },
+      stubVerification: false,
+    },
+  ])(
+    "refuses the connection when $description",
+    async ({ headers, stubVerification }) => {
+      const testingModule = await Test.createTestingModule({
+        imports: [TestGatewayModule],
+      }).compile();
+      app = testingModule.createNestApplication();
+      app.useWebSocketAdapter(new TestRedisIoAdapter(app));
+
+      if (stubVerification) {
+        vi.spyOn(
+          app.get(GatewayAuthService),
+          "verifyConnectionIdentity",
+        ).mockResolvedValue(null);
+      }
+
+      await app.listen(0);
+      const address = app.getHttpServer().address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected the test gateway to listen on a TCP port");
+      }
+
+      const connectionError = new Promise<Error>((resolve) => {
+        client = io(`http://127.0.0.1:${address.port}`, {
+          transports: ["websocket"],
+          reconnection: false,
+          extraHeaders: headers,
+        });
+        client.on("connect_error", resolve);
+      });
+
+      await expect(connectionError).resolves.toMatchObject({
+        message: "Unauthorized",
+      });
+      expect(client.connected).toBe(false);
+      expect(app.get(SubscriptionService).handleJoin).not.toHaveBeenCalled();
+    },
+  );
+
+  it("reauthenticates an automatic reconnect before handling JOIN again", async () => {
+    const testingModule = await Test.createTestingModule({
+      imports: [TestGatewayModule],
+    }).compile();
+    app = testingModule.createNestApplication();
+    app.useWebSocketAdapter(new TestRedisIoAdapter(app));
+
+    const gatewayAuthService = app.get(GatewayAuthService);
+    const verifyConnectionIdentity = vi
+      .spyOn(gatewayAuthService, "verifyConnectionIdentity")
+      .mockResolvedValue({ discordId: "discord-1", userId: "user-1" });
+
+    await app.listen(0);
+    const address = app.getHttpServer().address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected the test gateway to listen on a TCP port");
+    }
+
+    const subscriptionService = app.get(SubscriptionService);
+    client = io(`http://127.0.0.1:${address.port}`, {
+      autoConnect: false,
+      transports: ["websocket"],
+      extraHeaders: {
+        cookie: "session=real",
+        origin: "https://lootlog.com",
+      },
+    });
+    client.on("connect", () => client?.emit(GatewayEvent.JOIN, {}));
+
+    client.connect();
+    await vi.waitFor(() => {
+      expect(subscriptionService.handleJoin).toHaveBeenCalledTimes(1);
+    });
+
+    client.io.engine?.close();
+    await vi.waitFor(
+      () => {
+        expect(subscriptionService.handleJoin).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 2_000 },
+    );
+
+    expect(verifyConnectionIdentity).toHaveBeenCalledTimes(2);
+    for (const joinCall of vi.mocked(subscriptionService.handleJoin).mock
+      .calls) {
+      expect(joinCall[2]).toBe("discord-1");
+      expect(joinCall[3]).toBe("user-1");
+    }
+  });
+});

--- a/apps/gateway/src/gateway/gateway.spec.ts
+++ b/apps/gateway/src/gateway/gateway.spec.ts
@@ -4,12 +4,6 @@ import { Platform } from "./enums/platform.enum";
 import { UserPresenceStatus } from "./enums/user-presence-status.enum";
 
 describe("Gateway", () => {
-  const mockConnectionService = {
-    getConnectionMetadata: vi.fn(),
-    validateConnection: vi.fn(),
-    initializeSocketData: vi.fn(),
-  };
-
   const mockPresenceService = {
     emitDisconnectPresence: vi.fn(),
     broadcastPlayerDisconnect: vi.fn(),
@@ -24,10 +18,6 @@ describe("Gateway", () => {
   const mockSubscriptionService = {
     handleJoin: vi.fn(),
     handleDisconnect: vi.fn(),
-  };
-
-  const mockGatewayAuthService = {
-    verifyConnectionIdentity: vi.fn(),
   };
 
   const mockMapPingService = {
@@ -45,83 +35,17 @@ describe("Gateway", () => {
 
   beforeEach(() => {
     gateway = new Gateway(
-      mockConnectionService as never,
       mockPresenceService as never,
       mockSubscriptionService as never,
-      mockGatewayAuthService as never,
       mockMapPingService as never,
       mockAirTagService as never,
     );
     gateway.server = mockServer as never;
   });
 
-  it("disconnects invalid websocket connections", async () => {
-    const client = {
-      request: { headers: {} },
-      disconnect: vi.fn(),
-      on: vi.fn(),
-    };
-
-    mockConnectionService.getConnectionMetadata.mockReturnValue({
-      platform: Platform.UNKNOWN,
-    });
-    mockGatewayAuthService.verifyConnectionIdentity.mockResolvedValue(null);
-    mockConnectionService.validateConnection.mockReturnValue({
-      valid: false,
-    });
-
-    await gateway.handleConnection(client as never);
-
-    expect(client.disconnect).toHaveBeenCalled();
-    expect(client.on).not.toHaveBeenCalled();
-  });
-
-  it("disconnects spoofed websocket connections without a verified session", async () => {
-    const client = {
-      request: {
-        headers: {
-          "x-auth-discord-id": "spoofed-discord",
-          "x-auth-user-id": "spoofed-user",
-          origin: "https://lootlog.com",
-        },
-      },
-      handshake: {},
-      disconnect: vi.fn(),
-      on: vi.fn(),
-    };
-
-    mockGatewayAuthService.verifyConnectionIdentity.mockResolvedValue(null);
-    mockConnectionService.getConnectionMetadata.mockReturnValue({
-      platform: Platform.WEB_APP,
-    });
-    mockConnectionService.validateConnection.mockReturnValue({
-      valid: false,
-    });
-
-    await gateway.handleConnection(client as never);
-
-    expect(mockConnectionService.validateConnection).toHaveBeenCalledWith(
-      null,
-      Platform.WEB_APP,
-    );
-    expect(client.disconnect).toHaveBeenCalled();
-    expect(mockConnectionService.initializeSocketData).not.toHaveBeenCalled();
-  });
-
-  it("initializes socket data and handles disconnecting callbacks", async () => {
+  it("handles disconnecting callbacks for authenticated sockets", async () => {
     let disconnectingHandler!: () => Promise<void>;
 
-    const client = {
-      id: "socket-1",
-      request: { headers: {} },
-      disconnect: vi.fn(),
-      on: vi.fn((event: string, handler: () => Promise<void>) => {
-        if (event === GatewayEvent.DISCONNECTING) {
-          disconnectingHandler = handler;
-        }
-      }),
-      data: undefined,
-    };
     const socketData = {
       discordId: "discord-1",
       userId: "user-1",
@@ -134,16 +58,18 @@ describe("Gateway", () => {
         },
       ],
     };
+    const client = {
+      id: "socket-1",
+      request: { headers: {} },
+      disconnect: vi.fn(),
+      on: vi.fn((event: string, handler: () => Promise<void>) => {
+        if (event === GatewayEvent.DISCONNECTING) {
+          disconnectingHandler = handler;
+        }
+      }),
+      data: socketData,
+    };
 
-    mockConnectionService.getConnectionMetadata.mockReturnValue({
-      platform: Platform.GAME,
-    });
-    mockGatewayAuthService.verifyConnectionIdentity.mockResolvedValue({
-      discordId: "discord-1",
-      userId: "user-1",
-    });
-    mockConnectionService.validateConnection.mockReturnValue({ valid: true });
-    mockConnectionService.initializeSocketData.mockReturnValue(socketData);
     mockSubscriptionService.handleDisconnect.mockResolvedValue(undefined);
     mockPresenceService.broadcastPlayerDisconnect.mockResolvedValue(undefined);
 
@@ -168,17 +94,6 @@ describe("Gateway", () => {
   it("emits web presence offline when a web socket disconnects", async () => {
     let disconnectingHandler!: () => Promise<void>;
 
-    const client = {
-      id: "socket-1",
-      request: { headers: {} },
-      disconnect: vi.fn(),
-      on: vi.fn((event: string, handler: () => Promise<void>) => {
-        if (event === GatewayEvent.DISCONNECTING) {
-          disconnectingHandler = handler;
-        }
-      }),
-      data: undefined,
-    };
     const socketData = {
       discordId: "discord-1",
       userId: "user-1",
@@ -191,16 +106,18 @@ describe("Gateway", () => {
         },
       ],
     };
+    const client = {
+      id: "socket-1",
+      request: { headers: {} },
+      disconnect: vi.fn(),
+      on: vi.fn((event: string, handler: () => Promise<void>) => {
+        if (event === GatewayEvent.DISCONNECTING) {
+          disconnectingHandler = handler;
+        }
+      }),
+      data: socketData,
+    };
 
-    mockConnectionService.getConnectionMetadata.mockReturnValue({
-      platform: Platform.WEB_APP,
-    });
-    mockGatewayAuthService.verifyConnectionIdentity.mockResolvedValue({
-      discordId: "discord-1",
-      userId: "user-1",
-    });
-    mockConnectionService.validateConnection.mockReturnValue({ valid: true });
-    mockConnectionService.initializeSocketData.mockReturnValue(socketData);
     mockSubscriptionService.handleDisconnect.mockResolvedValue(undefined);
     mockPresenceService.broadcastPlayerDisconnect.mockResolvedValue(undefined);
 

--- a/apps/gateway/src/gateway/gateway.ts
+++ b/apps/gateway/src/gateway/gateway.ts
@@ -1,4 +1,4 @@
-import { UseFilters, Logger } from "@nestjs/common";
+import { UseFilters } from "@nestjs/common";
 import {
   BaseWsExceptionFilter,
   ConnectedSocket,
@@ -30,14 +30,12 @@ import type {
   Socket,
   PlayerPresence,
 } from "src/gateway/types/socket-user.type";
-import { ConnectionService } from "./services/connection.service";
 import {
   type MemberWebPresenceFetchResponse,
   type PresenceFetchResponse,
   PresenceService,
 } from "./services/presence.service";
 import { SubscriptionService } from "./services/subscription.service";
-import { GatewayAuthService } from "./services/gateway-auth.service";
 import { MapPingService } from "./services/map-ping.service";
 import { AirTagService } from "./services/air-tag.service";
 
@@ -46,13 +44,9 @@ import { AirTagService } from "./services/air-tag.service";
   pingTimeout: GatewayConfig.SOCKET_PING_TIMEOUT_MS,
 })
 export class Gateway {
-  private readonly logger = new Logger(Gateway.name);
-
   constructor(
-    private connectionService: ConnectionService,
     private presenceService: PresenceService,
     private subscriptionService: SubscriptionService,
-    private gatewayAuthService: GatewayAuthService,
     private mapPingService: MapPingService,
     private airTagService: AirTagService,
   ) {}
@@ -60,29 +54,7 @@ export class Gateway {
   @WebSocketServer()
   server: Server;
 
-  async handleConnection(client: Socket) {
-    const identity = await this.gatewayAuthService.verifyConnectionIdentity(
-      client.request,
-    );
-    const { platform } = this.connectionService.getConnectionMetadata(
-      client.request,
-    );
-
-    const validation = this.connectionService.validateConnection(
-      identity?.discordId ?? null,
-      platform,
-    );
-    if (!validation.valid) {
-      return client.disconnect();
-    }
-
-    client.data = this.connectionService.initializeSocketData(
-      identity!.discordId,
-      identity!.userId,
-      client.id,
-      platform,
-    );
-
+  handleConnection(client: Socket) {
     client.on(GatewayEvent.DISCONNECTING, async () => {
       if (client.data) {
         this.presenceService.emitDisconnectPresence(this.server, client);

--- a/apps/gateway/src/gateway/services/connection.service.ts
+++ b/apps/gateway/src/gateway/services/connection.service.ts
@@ -28,13 +28,13 @@ export class ConnectionService {
 
   initializeSocketData(
     discordId: string,
-    userId: string | null,
+    userId: string,
     socketId: string,
     platform: Platform,
-  ): Partial<SocketUser> {
+  ): SocketUser {
     return {
       discordId,
-      userId: userId ?? undefined,
+      userId,
       sessionId: socketId,
       platform,
     };

--- a/apps/gateway/src/gateway/services/gateway-auth.service.spec.ts
+++ b/apps/gateway/src/gateway/services/gateway-auth.service.spec.ts
@@ -2,14 +2,20 @@ import { of, throwError } from "rxjs";
 import type { HttpService } from "@nestjs/axios";
 import { GatewayAuthService } from "./gateway-auth.service";
 import { env } from "src/config/env";
+import { ConnectionService } from "./connection.service";
+import { Platform } from "../enums/platform.enum";
 
 describe("GatewayAuthService", () => {
   const get = vi.fn();
   let service: GatewayAuthService;
 
   beforeEach(() => {
+    get.mockReset();
     env.AUTH_URL = "http://auth:4001";
-    service = new GatewayAuthService({ get } as unknown as HttpService);
+    service = new GatewayAuthService(
+      { get } as unknown as HttpService,
+      new ConnectionService(),
+    );
   });
 
   it("verifies websocket identity with only cookie and authorization headers", async () => {
@@ -45,6 +51,31 @@ describe("GatewayAuthService", () => {
     });
   });
 
+  it.each([
+    { credentials: { cookie: "session=real" }, method: "cookie" },
+    {
+      credentials: { authorization: "Bearer real-token" },
+      method: "bearer token",
+    },
+  ])("verifies websocket identity with a $method", async ({ credentials }) => {
+    get.mockReturnValue(
+      of({
+        headers: {
+          "x-auth-discord-id": "discord-1",
+          "x-auth-user-id": "user-1",
+        },
+      }),
+    );
+
+    await expect(
+      service.verifyConnectionIdentity({ headers: credentials } as never),
+    ).resolves.toEqual({ discordId: "discord-1", userId: "user-1" });
+    expect(get).toHaveBeenCalledWith("http://auth:4001/auth/verify", {
+      headers: credentials,
+      timeout: 10000,
+    });
+  });
+
   it("rejects direct sockets that only spoof trusted auth headers", async () => {
     await expect(
       service.verifyConnectionIdentity({
@@ -66,5 +97,138 @@ describe("GatewayAuthService", () => {
         headers: { cookie: "session=expired" },
       } as never),
     ).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      headers: { "x-auth-discord-id": "", "x-auth-user-id": "user-1" },
+      description: "empty discordId",
+    },
+    {
+      headers: {
+        "x-auth-discord-id": "discord-1",
+        "x-auth-user-id": "   ",
+      },
+      description: "blank userId",
+    },
+    {
+      headers: { "x-auth-discord-id": "discord-1" },
+      description: "missing userId",
+    },
+  ])("rejects auth identity with $description", async ({ headers }) => {
+    get.mockReturnValue(of({ headers }));
+
+    await expect(
+      service.verifyConnectionIdentity({
+        headers: { cookie: "session=real" },
+      } as never),
+    ).resolves.toBeNull();
+  });
+
+  it("initializes complete authenticated socket data", async () => {
+    get.mockReturnValue(
+      of({
+        headers: {
+          "x-auth-discord-id": "discord-1",
+          "x-auth-user-id": "user-1",
+        },
+      }),
+    );
+    const client = {
+      id: "socket-1",
+      request: {
+        headers: {
+          authorization: "Bearer real-token",
+          origin: "https://lootlog.com",
+        },
+      },
+      data: {},
+    };
+
+    await expect(service.authenticateConnection(client as never)).resolves.toBe(
+      true,
+    );
+    expect(client.data).toEqual({
+      discordId: "discord-1",
+      userId: "user-1",
+      sessionId: "socket-1",
+      platform: Platform.WEB_APP,
+    });
+  });
+
+  it("rejects a socket without credentials before calling auth", async () => {
+    const client = {
+      id: "socket-1",
+      request: { headers: { origin: "https://lootlog.com" } },
+      data: {},
+    };
+
+    await expect(service.authenticateConnection(client as never)).resolves.toBe(
+      false,
+    );
+    expect(get).not.toHaveBeenCalled();
+    expect(client.data).toEqual({});
+  });
+
+  it("rejects a socket when auth verification fails", async () => {
+    get.mockReturnValue(throwError(() => new Error("unauthorized")));
+    const client = {
+      id: "socket-1",
+      request: {
+        headers: {
+          cookie: "session=expired",
+          origin: "https://lootlog.com",
+        },
+      },
+      data: {},
+    };
+
+    await expect(service.authenticateConnection(client as never)).resolves.toBe(
+      false,
+    );
+    expect(client.data).toEqual({});
+  });
+
+  it("rejects incomplete identity even if the typed auth boundary is violated", async () => {
+    vi.spyOn(service, "verifyConnectionIdentity").mockResolvedValue({
+      discordId: "discord-1",
+      userId: "",
+    });
+    const client = {
+      id: "socket-1",
+      request: {
+        headers: {
+          cookie: "session=real",
+          origin: "https://lootlog.com",
+        },
+      },
+      data: {},
+    };
+
+    await expect(service.authenticateConnection(client as never)).resolves.toBe(
+      false,
+    );
+    expect(client.data).toEqual({});
+  });
+
+  it("rejects a socket from an unknown platform", async () => {
+    get.mockReturnValue(
+      of({
+        headers: {
+          "x-auth-discord-id": "discord-1",
+          "x-auth-user-id": "user-1",
+        },
+      }),
+    );
+    const client = {
+      id: "socket-1",
+      request: { headers: { cookie: "session=real" } },
+      data: {},
+    };
+
+    await expect(service.authenticateConnection(client as never)).resolves.toBe(
+      false,
+    );
+    expect(client.data).toEqual({});
   });
 });

--- a/apps/gateway/src/gateway/services/gateway-auth.service.ts
+++ b/apps/gateway/src/gateway/services/gateway-auth.service.ts
@@ -4,6 +4,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { firstValueFrom } from "rxjs";
 import { env } from "src/config/env";
 import type { Socket } from "src/gateway/types/socket-user.type";
+import { ConnectionService } from "./connection.service";
 
 const REQUEST_TIMEOUT_MS = 10000;
 
@@ -16,7 +17,39 @@ export interface GatewayConnectionIdentity {
 export class GatewayAuthService {
   private readonly logger = new Logger(GatewayAuthService.name);
 
-  constructor(private readonly httpService: HttpService) {}
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly connectionService: ConnectionService,
+  ) {}
+
+  async authenticateConnection(client: Socket): Promise<boolean> {
+    const identity = await this.verifyConnectionIdentity(client.request);
+    const { platform } = this.connectionService.getConnectionMetadata(
+      client.request,
+    );
+
+    if (!this.isIdentityComplete(identity)) {
+      this.logger.warn("Websocket authentication returned incomplete identity");
+      return false;
+    }
+
+    const validation = this.connectionService.validateConnection(
+      identity.discordId,
+      platform,
+    );
+    if (!validation.valid) {
+      return false;
+    }
+
+    client.data = this.connectionService.initializeSocketData(
+      identity.discordId,
+      identity.userId,
+      client.id,
+      platform,
+    );
+
+    return true;
+  }
 
   async verifyConnectionIdentity(
     request: Socket["request"],
@@ -40,7 +73,7 @@ export class GatewayAuthService {
       );
       const userId = this.getHeaderValue(response.headers["x-auth-user-id"]);
 
-      if (!discordId || !userId) {
+      if (!this.isNonEmptyString(discordId) || !this.isNonEmptyString(userId)) {
         this.logger.warn("Auth verify response did not include identity");
         return null;
       }
@@ -83,5 +116,19 @@ export class GatewayAuthService {
     }
 
     return value;
+  }
+
+  private isIdentityComplete(
+    identity: GatewayConnectionIdentity | null,
+  ): identity is GatewayConnectionIdentity {
+    return (
+      identity !== null &&
+      this.isNonEmptyString(identity.discordId) &&
+      this.isNonEmptyString(identity.userId)
+    );
+  }
+
+  private isNonEmptyString(value: unknown): value is string {
+    return typeof value === "string" && value.trim().length > 0;
   }
 }

--- a/apps/gateway/src/gateway/services/subscription.service.spec.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.spec.ts
@@ -145,6 +145,9 @@ describe("SubscriptionService", () => {
   });
 
   it("returns an error when the user has no guilds", async () => {
+    const warnSpy = vi
+      .spyOn(Logger.prototype, "warn")
+      .mockImplementation(() => undefined);
     const client = {
       data: {
         platform: Platform.WEB_APP,
@@ -170,6 +173,9 @@ describe("SubscriptionService", () => {
     expect(client.join).not.toHaveBeenCalled();
     expect(mockPresenceService.emitInitialPresence).not.toHaveBeenCalled();
     expect(mockMargonemAccountProofService.verifyProof).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "No guilds found for discordId=discord-1 userId=user-1. User may not have LOOTLOG_READ permission in any guild.",
+    );
   });
 
   it("allows game joins without a valid Margonem account proof during the grace period", async () => {

--- a/apps/gateway/src/gateway/services/subscription.service.ts
+++ b/apps/gateway/src/gateway/services/subscription.service.ts
@@ -78,7 +78,7 @@ export class SubscriptionService {
 
       if (guilds.length === 0) {
         this.logger.warn(
-          `No guilds found for user ${discordId}. User may not have LOOTLOG_READ permission in any guild.`,
+          `No guilds found for discordId=${discordId} userId=${userId}. User may not have LOOTLOG_READ permission in any guild.`,
         );
         return {
           status: ResponseStatus.ERROR,
@@ -135,7 +135,7 @@ export class SubscriptionService {
       };
     } catch (error) {
       this.logger.error(
-        `Failed to join gateway for user ${discordId}: ${error.message}`,
+        `Failed to join gateway for discordId=${discordId} userId=${userId}: ${error.message}`,
         error.stack,
       );
 

--- a/apps/gateway/src/lib/redis/redis-io.adapter.ts
+++ b/apps/gateway/src/lib/redis/redis-io.adapter.ts
@@ -2,17 +2,42 @@ import { IoAdapter } from "@nestjs/platform-socket.io";
 import { createAdapter } from "@socket.io/redis-adapter";
 import { Redis } from "ioredis";
 import type { INestApplication } from "@nestjs/common";
-import type { ServerOptions } from "socket.io";
+import type { Server, ServerOptions } from "socket.io";
 import { msgpackParser } from "@lootlog/socket-parser";
 import { redisConfig } from "src/config/redis.config";
+import { GatewayAuthService } from "src/gateway/services/gateway-auth.service";
+import type { Socket } from "src/gateway/types/socket-user.type";
 
 const SOCKET_IO_REDIS_REQUESTS_TIMEOUT = 30000;
 
 export class RedisIoAdapter extends IoAdapter {
   private adapterConstructor: ReturnType<typeof createAdapter>;
+  private readonly gatewayAuthService: GatewayAuthService;
 
   constructor(app: INestApplication) {
     super(app);
+    this.gatewayAuthService = app.get(GatewayAuthService);
+  }
+
+  override bindClientConnect(
+    server: Server,
+    callback: (client: Socket) => void,
+  ): void {
+    server.use((client, next) => {
+      void this.gatewayAuthService
+        .authenticateConnection(client as Socket)
+        .then((authenticated) => {
+          if (authenticated) {
+            next();
+            return;
+          }
+
+          next(new Error("Unauthorized"));
+        })
+        .catch(() => next(new Error("Unauthorized")));
+    });
+
+    super.bindClientConnect(server, callback);
   }
 
   async connectToRedis(): Promise<void> {

--- a/apps/gateway/src/shared/decorators/user-id.decorator.spec.ts
+++ b/apps/gateway/src/shared/decorators/user-id.decorator.spec.ts
@@ -1,0 +1,31 @@
+import { WsException } from "@nestjs/websockets";
+import { getRequiredSocketIdentity } from "./user-id.decorator";
+
+describe("websocket identity decorators", () => {
+  it.each([
+    { field: "discordId" as const, data: {} },
+    { field: "discordId" as const, data: { discordId: "" } },
+    { field: "userId" as const, data: { discordId: "discord-1" } },
+    { field: "userId" as const, data: { userId: "   " } },
+  ])("disconnects when $field is not a non-empty string", ({ field, data }) => {
+    const client = { data, disconnect: vi.fn() };
+
+    expect(() =>
+      getRequiredSocketIdentity(client as never, field),
+    ).toThrowError(WsException);
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { field: "discordId" as const, value: "discord-1" },
+    { field: "userId" as const, value: "user-1" },
+  ])("returns a valid $field", ({ field, value }) => {
+    const client = {
+      data: { [field]: value },
+      disconnect: vi.fn(),
+    };
+
+    expect(getRequiredSocketIdentity(client as never, field)).toBe(value);
+    expect(client.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gateway/src/shared/decorators/user-id.decorator.ts
+++ b/apps/gateway/src/shared/decorators/user-id.decorator.ts
@@ -2,17 +2,28 @@ import { createParamDecorator, type ExecutionContext } from "@nestjs/common";
 import { WsException } from "@nestjs/websockets";
 import type { Socket } from "src/gateway/types/socket-user.type";
 
+type IdentityField = "discordId" | "userId";
+
+export function getRequiredSocketIdentity(
+  client: Socket,
+  field: IdentityField,
+): string {
+  const value: unknown = client.data?.[field];
+
+  if (typeof value !== "string" || value.trim().length === 0) {
+    client.disconnect();
+    throw new WsException("Unauthorized");
+  }
+
+  return value;
+}
+
 export const WsDiscordId = createParamDecorator(
   (data: unknown, ctx: ExecutionContext): string => {
     const wsCtx = ctx.switchToWs();
     const client = wsCtx.getClient() as Socket;
 
-    if (!client.data) {
-      client.disconnect();
-      throw new WsException("Unauthorized");
-    }
-
-    return client.data.discordId;
+    return getRequiredSocketIdentity(client, "discordId");
   },
 );
 
@@ -21,11 +32,6 @@ export const WsUserId = createParamDecorator(
     const wsCtx = ctx.switchToWs();
     const client = wsCtx.getClient() as Socket;
 
-    if (!client.data) {
-      client.disconnect();
-      throw new WsException("Unauthorized");
-    }
-
-    return client.data.userId;
+    return getRequiredSocketIdentity(client, "userId");
   },
 );


### PR DESCRIPTION
## Summary

- authenticate each Socket.IO connection before Nest exposes websocket message handlers
- reject missing or blank discordId and userId values at runtime
- cover delayed authentication, rejected connections, missing credentials, and automatic reconnects
- distinguish Discord and internal user identifiers in subscription logs

## Root cause

Nest does not wait for an asynchronous handleConnection hook before binding message handlers. A client could receive connect and emit JOIN while Socket.IO data was still empty, which forwarded undefined identifiers to SubscriptionService.

The Redis Socket.IO adapter now runs authentication middleware before the connection event. This ordering applies to every inbound websocket event, not only JOIN.

## Verification

- node --test tools/release/*.test.mjs apps/developer/server-handler.test.js: 41 passed
- Changeset validation against origin/main: passed
- pnpm format:check: passed
- pnpm exec turbo run lint build --filter=@lootlog/gateway: passed
- pnpm exec turbo run test --filter=@lootlog/gateway: 21 files and 209 tests passed

## Blast radius

All eight inbound gateway handlers now wait for authentication. Cookie and bearer authentication, spoofed header rejection, origin and platform validation, Redis fan-out, web and game clients, Margonem account proof, websocket events, and payloads remain unchanged.