### PR TITLE
fix(web): unify guild and user breadcrumbs

### DIFF
--- a/.changeset/neat-breadcrumbs-align.md
+++ b/.changeset/neat-breadcrumbs-align.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/web": patch
+---
+
+Use the same breadcrumb layout and interactions in guild and user navigation.

--- a/apps/web/src/components/layout/app-breadcrumbs.spec.tsx
+++ b/apps/web/src/components/layout/app-breadcrumbs.spec.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppBreadcrumbs } from "./app-breadcrumbs";
+
+vi.mock("@/themes", () => ({
+  ThemeInteractiveFrame: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("AppBreadcrumbs", () => {
+  afterEach(cleanup);
+
+  it("renders accessible navigation with links, separators, and current page", () => {
+    const onNavigate = vi.fn();
+    const { container } = render(
+      <AppBreadcrumbs
+        breadcrumbs={[
+          { label: "Lootlog", path: "/guild" },
+          { label: "Settings", path: "/guild/settings" },
+          { label: "Members", path: null },
+        ]}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(
+      screen.getByRole("navigation", {
+        name: "common.breadcrumbs.navigationLabel",
+      }),
+    ).toBeDefined();
+    expect(
+      container.querySelectorAll('[data-slot="breadcrumb-separator"]'),
+    ).toHaveLength(2);
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe(
+      "Members",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(onNavigate).toHaveBeenCalledWith("/guild/settings");
+  });
+});

--- a/apps/web/src/components/layout/app-breadcrumbs.spec.tsx
+++ b/apps/web/src/components/layout/app-breadcrumbs.spec.tsx
@@ -22,8 +22,10 @@ describe("AppBreadcrumbs", () => {
       <AppBreadcrumbs
         breadcrumbs={[
           { label: "Lootlog", path: "/guild" },
-          { label: "Settings", path: "/guild/settings" },
-          { label: "Members", path: null },
+          { label: "Events", path: "/guild/events" },
+          { label: "Summer Event", path: "/guild/events/summer" },
+          { label: "Members", path: "/guild/events/summer/members" },
+          { label: "Very Long Member Name", path: null },
         ]}
         onNavigate={onNavigate}
       />,
@@ -36,14 +38,25 @@ describe("AppBreadcrumbs", () => {
     ).toBeDefined();
     expect(
       container.querySelectorAll('[data-slot="breadcrumb-separator"]'),
-    ).toHaveLength(2);
+    ).toHaveLength(4);
     expect(container.querySelector('[aria-current="page"]')?.textContent).toBe(
-      "Members",
+      "Very Long Member Name",
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+    const breadcrumbItems = container.querySelectorAll(
+      '[data-slot="breadcrumb-item"]',
+    );
+    expect(breadcrumbItems[0]?.className).toContain("2xl:inline-flex");
+    expect(breadcrumbItems[2]?.className).toContain("xl:inline-flex");
+    expect(breadcrumbItems[3]?.className).toContain("sm:inline-flex");
+    expect(breadcrumbItems[4]?.className).not.toContain("hidden");
+    expect(
+      screen.getByRole("button", { name: "Summer Event" }).className,
+    ).toContain("truncate");
+
+    fireEvent.click(screen.getByRole("button", { name: "Members" }));
 
     expect(onNavigate).toHaveBeenCalledOnce();
-    expect(onNavigate).toHaveBeenCalledWith("/guild/settings");
+    expect(onNavigate).toHaveBeenCalledWith("/guild/events/summer/members");
   });
 });

--- a/apps/web/src/components/layout/app-breadcrumbs.tsx
+++ b/apps/web/src/components/layout/app-breadcrumbs.tsx
@@ -9,12 +9,45 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@lootlog/ui/components/breadcrumb";
+import { cn } from "@lootlog/ui/lib/utils";
 import { Fragment, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 type AppBreadcrumbsProps = {
   breadcrumbs: NavigationInfo["breadcrumbs"];
   onNavigate: (path: string) => void;
+};
+
+type BreadcrumbVisibility = "always" | "sm" | "xl" | "2xl";
+
+const breadcrumbItemClassNames = {
+  always: "flex min-w-0",
+  sm: "hidden min-w-0 max-w-48 shrink-0 sm:inline-flex 2xl:max-w-56",
+  xl: "hidden min-w-0 max-w-48 shrink-0 xl:inline-flex 2xl:max-w-56",
+  "2xl": "hidden min-w-0 max-w-56 shrink-0 2xl:inline-flex",
+} satisfies Record<BreadcrumbVisibility, string>;
+
+const breadcrumbSeparatorClassNames = {
+  always: "",
+  sm: "hidden shrink-0 sm:block",
+  xl: "hidden shrink-0 xl:block",
+  "2xl": "hidden shrink-0 2xl:block",
+} satisfies Record<BreadcrumbVisibility, string>;
+
+const getBreadcrumbVisibility = (
+  index: number,
+  breadcrumbsCount: number,
+): BreadcrumbVisibility => {
+  if (index === breadcrumbsCount - 1) {
+    return "always";
+  }
+  if (index === breadcrumbsCount - 2) {
+    return "sm";
+  }
+  if (index === breadcrumbsCount - 3) {
+    return "xl";
+  }
+  return "2xl";
 };
 
 export const AppBreadcrumbs = ({
@@ -35,14 +68,16 @@ export const AppBreadcrumbs = ({
         {breadcrumbs.map((breadcrumb, index) => {
           const isLast = index === breadcrumbs.length - 1;
           const breadcrumbPath = breadcrumb.path;
+          const visibility = getBreadcrumbVisibility(index, breadcrumbs.length);
 
           return (
             <Fragment
               key={`${breadcrumb.label}-${breadcrumb.path ?? "current"}`}
             >
-              <BreadcrumbItem className="min-w-0 shrink-0 last:shrink">
+              <BreadcrumbItem className={breadcrumbItemClassNames[visibility]}>
                 {breadcrumbPath ? (
                   <div
+                    className="min-w-0 max-w-full"
                     onMouseEnter={() => setHoveredBreadcrumbIndex(index)}
                     onMouseLeave={() => setHoveredBreadcrumbIndex(null)}
                   >
@@ -59,7 +94,7 @@ export const AppBreadcrumbs = ({
                             onClick={() => onNavigate(breadcrumbPath)}
                           />
                         }
-                        className="min-h-8 cursor-pointer whitespace-nowrap rounded px-1 text-xs text-muted-foreground/70 transition-colors duration-200 hover:text-foreground"
+                        className="min-h-8 max-w-full cursor-pointer truncate rounded px-1 text-xs text-muted-foreground/70 transition-colors duration-200 hover:text-foreground"
                       >
                         {breadcrumb.label}
                       </BreadcrumbLink>
@@ -72,7 +107,12 @@ export const AppBreadcrumbs = ({
                 )}
               </BreadcrumbItem>
               {!isLast && (
-                <BreadcrumbSeparator className="text-muted-foreground/30" />
+                <BreadcrumbSeparator
+                  className={cn(
+                    "text-muted-foreground/30",
+                    breadcrumbSeparatorClassNames[visibility],
+                  )}
+                />
               )}
             </Fragment>
           );

--- a/apps/web/src/components/layout/app-breadcrumbs.tsx
+++ b/apps/web/src/components/layout/app-breadcrumbs.tsx
@@ -1,0 +1,83 @@
+import type { NavigationInfo } from "@/components/layout/get-navigation-info";
+import { ThemeInteractiveFrame } from "@/themes";
+import { Button } from "@lootlog/ui/components/button";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@lootlog/ui/components/breadcrumb";
+import { Fragment, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+type AppBreadcrumbsProps = {
+  breadcrumbs: NavigationInfo["breadcrumbs"];
+  onNavigate: (path: string) => void;
+};
+
+export const AppBreadcrumbs = ({
+  breadcrumbs,
+  onNavigate,
+}: AppBreadcrumbsProps) => {
+  const { t } = useTranslation();
+  const [hoveredBreadcrumbIndex, setHoveredBreadcrumbIndex] = useState<
+    number | null
+  >(null);
+
+  return (
+    <Breadcrumb
+      aria-label={t("common.breadcrumbs.navigationLabel")}
+      className="min-w-0 flex-1 overflow-hidden"
+    >
+      <BreadcrumbList className="flex-nowrap justify-center overflow-hidden">
+        {breadcrumbs.map((breadcrumb, index) => {
+          const isLast = index === breadcrumbs.length - 1;
+          const breadcrumbPath = breadcrumb.path;
+
+          return (
+            <Fragment
+              key={`${breadcrumb.label}-${breadcrumb.path ?? "current"}`}
+            >
+              <BreadcrumbItem className="min-w-0 shrink-0 last:shrink">
+                {breadcrumbPath ? (
+                  <div
+                    onMouseEnter={() => setHoveredBreadcrumbIndex(index)}
+                    onMouseLeave={() => setHoveredBreadcrumbIndex(null)}
+                  >
+                    <ThemeInteractiveFrame
+                      isHovered={hoveredBreadcrumbIndex === index}
+                      isActive={false}
+                    >
+                      <BreadcrumbLink
+                        render={
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onNavigate(breadcrumbPath)}
+                          />
+                        }
+                        className="min-h-8 cursor-pointer whitespace-nowrap rounded px-1 text-xs text-muted-foreground/70 transition-colors duration-200 hover:text-foreground"
+                      >
+                        {breadcrumb.label}
+                      </BreadcrumbLink>
+                    </ThemeInteractiveFrame>
+                  </div>
+                ) : (
+                  <BreadcrumbPage className="truncate text-sm font-bold">
+                    {breadcrumb.label}
+                  </BreadcrumbPage>
+                )}
+              </BreadcrumbItem>
+              {!isLast && (
+                <BreadcrumbSeparator className="text-muted-foreground/30" />
+              )}
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};

--- a/apps/web/src/components/layout/guild-breadcrumbs.tsx
+++ b/apps/web/src/components/layout/guild-breadcrumbs.tsx
@@ -8,15 +8,9 @@ import {
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Button } from "@lootlog/ui/components/button";
-import {
-  Breadcrumb,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-} from "@lootlog/ui/components/breadcrumb";
-import { ArrowLeft, Ellipsis } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import { SidebarTrigger } from "@lootlog/ui/components/sidebar";
-import { AnimatePresence, motion } from "framer-motion";
+import { AppBreadcrumbs } from "@/components/layout/app-breadcrumbs";
 import { AppTopBar } from "@/components/layout/app-top-bar";
 import { getNavigationInfo } from "./get-navigation-info";
 import {
@@ -149,22 +143,6 @@ const useBreadcrumbLookupData = ({
   };
 };
 
-const getBreadcrumbVisibilityClassName = (
-  index: number,
-  breadcrumbsCount: number,
-) => {
-  if (index === breadcrumbsCount - 1) {
-    return "flex min-w-0";
-  }
-  if (index === breadcrumbsCount - 2) {
-    return "hidden shrink-0 sm:flex";
-  }
-  if (index === breadcrumbsCount - 3) {
-    return "hidden shrink-0 xl:flex";
-  }
-  return "hidden shrink-0 2xl:flex";
-};
-
 export const GuildBreadcrumbs: FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
@@ -289,79 +267,10 @@ export const GuildBreadcrumbs: FC = () => {
           )}
         </div>
 
-        <Breadcrumb
-          aria-label={t("common.breadcrumbs.navigationLabel")}
-          className="min-w-0 max-w-full flex-1 overflow-hidden"
-        >
-          <BreadcrumbList className="flex-nowrap justify-center overflow-hidden px-1">
-            <AnimatePresence mode="popLayout">
-              {navInfo.breadcrumbs.length > 2 && (
-                <motion.li
-                  key="collapsed-breadcrumbs"
-                  className={`mr-1.5 hidden size-6 shrink-0 items-center justify-center text-muted-foreground/50 sm:flex 2xl:hidden ${navInfo.breadcrumbs.length === 3 ? "xl:hidden" : ""}`}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                  aria-hidden="true"
-                >
-                  <Ellipsis className="size-4" />
-                </motion.li>
-              )}
-              {navInfo.breadcrumbs.map((crumb, index) => {
-                const isLast = index === navInfo.breadcrumbs.length - 1;
-                const visibilityClassName = getBreadcrumbVisibilityClassName(
-                  index,
-                  navInfo.breadcrumbs.length,
-                );
-
-                return (
-                  <motion.li
-                    key={`${crumb.label}-${crumb.path ?? "current"}`}
-                    className={`${visibilityClassName} items-center`}
-                    initial={{ opacity: 0, x: -8 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: 8 }}
-                    transition={{ duration: 0.15 }}
-                  >
-                    {index > 0 && (
-                      <span
-                        className={`mx-1.5 select-none text-xs text-muted-foreground/30 ${isLast ? "hidden sm:inline" : ""}`}
-                      >
-                        /
-                      </span>
-                    )}
-                    {crumb.path ? (
-                      <BreadcrumbLink
-                        render={
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() =>
-                              navigate({ to: crumb.path as string })
-                            }
-                          />
-                        }
-                        className="min-h-8 max-w-48 cursor-pointer truncate whitespace-nowrap rounded px-1 text-xs text-muted-foreground/70 transition-colors duration-200 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background 2xl:max-w-56"
-                        title={crumb.label}
-                      >
-                        {crumb.label}
-                      </BreadcrumbLink>
-                    ) : (
-                      <BreadcrumbPage
-                        className="block min-w-0 truncate whitespace-nowrap text-sm font-bold text-foreground"
-                        title={crumb.label}
-                      >
-                        {crumb.label}
-                      </BreadcrumbPage>
-                    )}
-                  </motion.li>
-                );
-              })}
-            </AnimatePresence>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <AppBreadcrumbs
+          breadcrumbs={navInfo.breadcrumbs}
+          onNavigate={(breadcrumbPath) => navigate({ to: breadcrumbPath })}
+        />
         <div
           className={
             navInfo.showBack && navInfo.backPath ? "w-[4.5rem]" : "w-8"

--- a/apps/web/src/components/layout/user-shell.tsx
+++ b/apps/web/src/components/layout/user-shell.tsx
@@ -1,3 +1,4 @@
+import { AppBreadcrumbs } from "@/components/layout/app-breadcrumbs";
 import { AppTopBar } from "@/components/layout/app-top-bar";
 import { ROUTES } from "@/config/routes";
 import { UserHeaderActionsContext } from "@/contexts/user-header-actions-context";
@@ -6,19 +7,11 @@ import {
   type BattleRouteLabelMatch,
 } from "@/lib/battle/battle-route-label";
 import { Button } from "@lootlog/ui/components/button";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@lootlog/ui/components/breadcrumb";
 import { ScrollArea } from "@lootlog/ui/components/scroll-area";
 import { SidebarTrigger } from "@lootlog/ui/components/sidebar";
 import { useLocation, useMatches, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
-import { Fragment, useState, type FC, type ReactNode } from "react";
+import { useState, type FC, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { ThemeInteractiveFrame } from "@/themes";
 import { getUserNavigationInfo } from "./get-user-navigation-info";
@@ -84,61 +77,10 @@ export const UserShell: FC<UserShellProps> = ({ children }) => {
                 )}
               </div>
 
-              <Breadcrumb
-                aria-label={t("common.breadcrumbs.navigationLabel")}
-                className="min-w-0 flex-1 overflow-hidden"
-              >
-                <BreadcrumbList className="flex-nowrap justify-center overflow-hidden">
-                  {navigationInfo.breadcrumbs.map((crumb, index) => {
-                    const isLast =
-                      index === navigationInfo.breadcrumbs.length - 1;
-                    return (
-                      <Fragment
-                        key={`${crumb.label}-${crumb.path ?? "current"}`}
-                      >
-                        <BreadcrumbItem className="min-w-0 shrink-0 last:shrink">
-                          {crumb.path ? (
-                            <div
-                              onMouseEnter={() =>
-                                setHoveredButton(`crumb-${index}`)
-                              }
-                              onMouseLeave={() => setHoveredButton(null)}
-                            >
-                              <ThemeInteractiveFrame
-                                isHovered={hoveredButton === `crumb-${index}`}
-                                isActive={false}
-                              >
-                                <BreadcrumbLink
-                                  render={
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="sm"
-                                      onClick={() =>
-                                        navigate({ to: crumb.path as string })
-                                      }
-                                    />
-                                  }
-                                  className="min-h-8 cursor-pointer whitespace-nowrap rounded px-1 text-xs text-muted-foreground/70 transition-colors duration-200 hover:text-foreground"
-                                >
-                                  {crumb.label}
-                                </BreadcrumbLink>
-                              </ThemeInteractiveFrame>
-                            </div>
-                          ) : (
-                            <BreadcrumbPage className="truncate text-sm font-bold">
-                              {crumb.label}
-                            </BreadcrumbPage>
-                          )}
-                        </BreadcrumbItem>
-                        {!isLast && (
-                          <BreadcrumbSeparator className="text-muted-foreground/30" />
-                        )}
-                      </Fragment>
-                    );
-                  })}
-                </BreadcrumbList>
-              </Breadcrumb>
+              <AppBreadcrumbs
+                breadcrumbs={navigationInfo.breadcrumbs}
+                onNavigate={(path) => navigate({ to: path })}
+              />
 
               <div
                 ref={setHeaderActionsElement}


### PR DESCRIPTION
## Summary

- extract the battle panel breadcrumb presentation into a shared `AppBreadcrumbs` component
- reuse the shared shadcn composition in guild navigation
- remove guild-specific breadcrumb collapsing, separators, and motion
- cover accessible structure and navigation behavior with a component test

## Verification

- `pnpm --filter @lootlog/web test`
- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web build`