### PR TITLE
fix(web): restore reservation selection across midnight

### DIFF
--- a/.changeset/bright-reservations-midnight.md
+++ b/.changeset/bright-reservations-midnight.md
@@ -1,0 +1,6 @@
+---
+"@lootlog/web": patch
+---
+
+Restore desktop Reservation range selection across midnight while respecting
+the Organization's maximum duration and time granularity.

--- a/apps/web/src/features/guild/reservations/schedule/desktop-week-schedule.spec.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/desktop-week-schedule.spec.tsx
@@ -3,6 +3,7 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReservationSettings } from "@lootlog/reservations";
 import { HEADER_HEIGHT, LABEL_COLUMN_WIDTH, MIN_ROW_HEIGHT } from "./constants";
 import { DesktopWeekSchedule } from "./desktop-week-schedule";
 import type { ReservationSegment } from "./types";
@@ -15,6 +16,14 @@ afterEach(() => {
   cleanup();
   vi.useRealTimers();
 });
+
+const settings = {
+  reservationMaxDurationMinutes: 180,
+  reservationMinDurationMinutes: 30,
+  reservationTimeGranularityMinutes: 15,
+  reservationMaxAdvanceDays: 7,
+  reservationActiveLimitPerSpot: 3,
+} satisfies ReservationSettings;
 
 const createSegment = (dayIdx = 3): ReservationSegment => {
   const startsAt = new Date(2026, 0, 8, 10, 0);
@@ -58,13 +67,62 @@ const createSegment = (dayIdx = 3): ReservationSegment => {
   };
 };
 
+const renderEmptySchedule = () => {
+  const onRangeSelect = vi.fn();
+  const { container } = render(
+    <DesktopWeekSchedule
+      weekStart={new Date(2026, 0, 5)}
+      segments={[]}
+      settings={settings}
+      onRangeSelect={onRangeSelect}
+      onReservationSelect={vi.fn()}
+    />,
+  );
+  const grid = container.querySelector(".grid");
+  expect(grid).toBeInstanceOf(HTMLDivElement);
+  if (!(grid instanceof HTMLDivElement)) {
+    throw new TypeError("Expected the desktop schedule grid to render");
+  }
+  vi.spyOn(grid, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(
+      0,
+      0,
+      LABEL_COLUMN_WIDTH + 700,
+      HEADER_HEIGHT + 24 * MIN_ROW_HEIGHT,
+    ),
+  );
+  return { container, grid, onRangeSelect };
+};
+
+const moveSelection = (
+  grid: HTMLDivElement,
+  start: { day: number; minutes: number },
+  end: { day: number; minutes: number },
+) => {
+  const toPointerCoordinates = (point: { day: number; minutes: number }) => ({
+    clientX: LABEL_COLUMN_WIDTH + point.day * 100 + 10,
+    clientY: HEADER_HEIGHT + (point.minutes / 60) * MIN_ROW_HEIGHT + 1,
+  });
+  fireEvent.pointerDown(grid, {
+    button: 0,
+    ...toPointerCoordinates(start),
+    pointerId: 1,
+    pointerType: "mouse",
+  });
+  fireEvent.pointerMove(grid, {
+    ...toPointerCoordinates(end),
+    pointerId: 1,
+    pointerType: "mouse",
+  });
+};
+
 describe("DesktopWeekSchedule", () => {
   it("renders only segments from the visible week", () => {
     const { container } = render(
       <DesktopWeekSchedule
         weekStart={new Date(2026, 0, 5)}
         segments={[createSegment(-1), createSegment(3), createSegment(7)]}
-        minuteStep={15}
+        settings={settings}
         onRangeSelect={vi.fn()}
         onReservationSelect={vi.fn()}
       />,
@@ -81,7 +139,7 @@ describe("DesktopWeekSchedule", () => {
       <DesktopWeekSchedule
         weekStart={new Date(2026, 0, 5)}
         segments={[]}
-        minuteStep={15}
+        settings={settings}
         onRangeSelect={vi.fn()}
         onReservationSelect={vi.fn()}
       />,
@@ -120,7 +178,7 @@ describe("DesktopWeekSchedule", () => {
       <DesktopWeekSchedule
         weekStart={new Date(2026, 0, 5)}
         segments={[createSegment()]}
-        minuteStep={15}
+        settings={settings}
         onRangeSelect={onRangeSelect}
         onReservationSelect={vi.fn()}
       />,
@@ -165,5 +223,73 @@ describe("DesktopWeekSchedule", () => {
     });
 
     expect(onRangeSelect).not.toHaveBeenCalled();
+  });
+
+  it("selects the maximum allowed range across midnight", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 4, 12, 0));
+    const { container, grid, onRangeSelect } = renderEmptySchedule();
+    moveSelection(
+      grid,
+      { day: 0, minutes: 23 * 60 },
+      { day: 1, minutes: 23 * 60 },
+    );
+
+    expect(
+      container.querySelectorAll(
+        ".pointer-events-none.absolute.z-20.rounded-md",
+      ),
+    ).toHaveLength(2);
+
+    fireEvent.pointerUp(grid, { pointerId: 1, pointerType: "mouse" });
+
+    expect(onRangeSelect).toHaveBeenCalledWith({
+      startsAt: new Date(2026, 0, 5, 23, 0),
+      endsAt: new Date(2026, 0, 6, 2, 0),
+    });
+  });
+
+  it("selects a range across midnight when dragging backwards", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 4, 12, 0));
+    const { container, grid, onRangeSelect } = renderEmptySchedule();
+    moveSelection(grid, { day: 1, minutes: 60 }, { day: 0, minutes: 23 * 60 });
+
+    expect(
+      container.querySelectorAll(
+        ".pointer-events-none.absolute.z-20.rounded-md",
+      ),
+    ).toHaveLength(2);
+
+    fireEvent.pointerUp(grid, { pointerId: 1, pointerType: "mouse" });
+
+    expect(onRangeSelect).toHaveBeenCalledWith({
+      startsAt: new Date(2026, 0, 5, 23, 0),
+      endsAt: new Date(2026, 0, 6, 1, 15),
+    });
+  });
+
+  it("keeps same-day range selection unchanged", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 0, 4, 12, 0));
+    const { container, grid, onRangeSelect } = renderEmptySchedule();
+    moveSelection(
+      grid,
+      { day: 0, minutes: 10 * 60 },
+      { day: 0, minutes: 10 * 60 + 45 },
+    );
+
+    expect(
+      container.querySelectorAll(
+        ".pointer-events-none.absolute.z-20.rounded-md",
+      ),
+    ).toHaveLength(1);
+
+    fireEvent.pointerUp(grid, { pointerId: 1, pointerType: "mouse" });
+
+    expect(onRangeSelect).toHaveBeenCalledWith({
+      startsAt: new Date(2026, 0, 5, 10, 0),
+      endsAt: new Date(2026, 0, 5, 11, 0),
+    });
   });
 });

--- a/apps/web/src/features/guild/reservations/schedule/desktop-week-schedule.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/desktop-week-schedule.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
-import { format } from "date-fns";
+import { differenceInCalendarDays, format } from "date-fns";
 import { pl } from "date-fns/locale";
+import type { ReservationSettings } from "@lootlog/reservations";
 import { ScrollArea } from "@lootlog/ui/components/scroll-area";
 import { cn } from "@lootlog/ui/lib/utils";
 import {
@@ -12,13 +13,16 @@ import {
 } from "./constants";
 import { isEventInsideElement } from "./is-event-inside-element";
 import { ReservationBlock } from "./reservation-block";
-import { isReservationStartSelectable } from "./reservation-settings";
+import {
+  clampReservationEndDate,
+  isReservationStartSelectable,
+} from "./reservation-settings";
 import type { ReservationRange, ReservationSegment } from "./types";
 
 type DesktopWeekScheduleProps = {
   weekStart: Date;
   segments: ReservationSegment[];
-  minuteStep: number;
+  settings: ReservationSettings;
   onRangeSelect: (range: ReservationRange) => void;
   onReservationSelect: (reservationId: number) => void;
   onReservationCancel?: (reservationId: number) => void;
@@ -30,12 +34,13 @@ type SelectionPoint = { day: number; minutes: number };
 export function DesktopWeekSchedule({
   weekStart,
   segments,
-  minuteStep,
+  settings,
   onRangeSelect,
   onReservationSelect,
   onReservationCancel,
   cancellingReservationId,
 }: DesktopWeekScheduleProps) {
+  const minuteStep = settings.reservationTimeGranularityMinutes;
   const gridRef = useRef<HTMLDivElement>(null);
   const contextMenuOpenRef = useRef(false);
   const suppressSelectionRef = useRef(false);
@@ -75,35 +80,66 @@ export function DesktopWeekSchedule({
     return date;
   };
 
-  const selectionStyle = (() => {
-    if (!selection || selection.anchor.day !== selection.current.day)
-      return null;
-    const startMinutes = Math.min(
-      selection.anchor.minutes,
-      selection.current.minutes,
-    );
-    const endMinutes =
-      Math.max(selection.anchor.minutes, selection.current.minutes) +
-      minuteStep;
-    const dayFraction = selection.anchor.day / DAYS.length;
-    return {
-      left: `calc(${dayFraction * 100}% + ${LABEL_COLUMN_WIDTH * (1 - dayFraction)}px)`,
-      width: `calc(${100 / DAYS.length}% - ${LABEL_COLUMN_WIDTH / DAYS.length}px)`,
-      top: HEADER_HEIGHT + (startMinutes / 60) * MIN_ROW_HEIGHT,
-      height: ((endMinutes - startMinutes) / 60) * MIN_ROW_HEIGHT,
-    };
-  })();
+  const pointFromDate = (date: Date): SelectionPoint => ({
+    day: differenceInCalendarDays(date, weekStart),
+    minutes: date.getHours() * 60 + date.getMinutes(),
+  });
 
-  const finishSelection = () => {
-    if (!selection) return;
+  const getSelectionRange = (): ReservationRange | null => {
+    if (!selection) return null;
     const first = dateFromPoint(selection.anchor);
     const second = dateFromPoint(selection.current);
     const startsAt = first < second ? first : second;
     const lastStart = first < second ? second : first;
     const endsAt = new Date(lastStart.getTime() + minuteStep * 60_000);
+    return { startsAt, endsAt };
+  };
+
+  const selectionStyles = (() => {
+    const range = getSelectionRange();
+    if (!range) return [];
+    const styles: Array<React.CSSProperties & { day: number }> = [];
+    let dayStart = new Date(range.startsAt);
+    dayStart.setHours(0, 0, 0, 0);
+
+    while (dayStart < range.endsAt) {
+      const nextDayStart = new Date(dayStart);
+      nextDayStart.setDate(nextDayStart.getDate() + 1);
+      const segmentStart =
+        range.startsAt > dayStart ? range.startsAt : dayStart;
+      const segmentEnd =
+        range.endsAt < nextDayStart ? range.endsAt : nextDayStart;
+      const day = differenceInCalendarDays(dayStart, weekStart);
+
+      if (day >= 0 && day < DAYS.length && segmentStart < segmentEnd) {
+        const startMinutes =
+          segmentStart.getHours() * 60 + segmentStart.getMinutes();
+        const endMinutes =
+          segmentEnd >= nextDayStart
+            ? 24 * 60
+            : segmentEnd.getHours() * 60 + segmentEnd.getMinutes();
+        const dayFraction = day / DAYS.length;
+        styles.push({
+          day,
+          left: `calc(${dayFraction * 100}% + ${LABEL_COLUMN_WIDTH * (1 - dayFraction)}px)`,
+          width: `calc(${100 / DAYS.length}% - ${LABEL_COLUMN_WIDTH / DAYS.length}px)`,
+          top: HEADER_HEIGHT + (startMinutes / 60) * MIN_ROW_HEIGHT,
+          height: ((endMinutes - startMinutes) / 60) * MIN_ROW_HEIGHT,
+        });
+      }
+
+      dayStart = nextDayStart;
+    }
+
+    return styles;
+  })();
+
+  const finishSelection = () => {
+    const range = getSelectionRange();
+    if (!range) return;
     setSelection(null);
-    if (!isReservationStartSelectable(startsAt)) return;
-    onRangeSelect({ startsAt, endsAt });
+    if (!isReservationStartSelectable(range.startsAt)) return;
+    onRangeSelect(range);
   };
 
   const now = new Date();
@@ -161,9 +197,15 @@ export function DesktopWeekSchedule({
               !isReservationStartSelectable(dateFromPoint(point)),
           );
           if (!selection || !point) return;
+          const anchorDate = dateFromPoint(selection.anchor);
+          const targetDate = clampReservationEndDate({
+            anchorDate,
+            targetDate: dateFromPoint(point),
+            settings,
+          });
           setSelection({
             anchor: selection.anchor,
-            current: { ...point, day: selection.anchor.day },
+            current: pointFromDate(targetDate),
           });
         }}
         onPointerUp={() => {
@@ -237,12 +279,13 @@ export function DesktopWeekSchedule({
           />
         )}
 
-        {selectionStyle && (
+        {selectionStyles.map(({ day, ...style }) => (
           <div
+            key={day}
             className="pointer-events-none absolute z-20 rounded-md border border-primary bg-primary/20"
-            style={selectionStyle}
+            style={style}
           />
-        )}
+        ))}
 
         {segments
           .filter(

--- a/apps/web/src/features/guild/reservations/schedule/reservations-schedule.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservations-schedule.tsx
@@ -272,7 +272,7 @@ export function ReservationsSchedule() {
         <DesktopWeekSchedule
           weekStart={weekStart}
           segments={segments}
-          minuteStep={settings.reservationTimeGranularityMinutes}
+          settings={settings}
           onRangeSelect={openSelectedRange}
           onReservationSelect={setSelectedReservationId}
           onReservationCancel={(reservationId) =>


### PR DESCRIPTION
## Summary

- preserve the pointer's actual day while selecting a Reservation range in the desktop week schedule
- clamp cross-day selections to the Organization's maximum duration and time granularity
- render one selection preview segment per affected day and cover forward, backward, and same-day drags

## Related issue

None.

## Testing

- `pnpm --filter @lootlog/web test`
- `pnpm --filter @lootlog/web lint`
- `pnpm --filter @lootlog/web build`
- pre-commit checks: lint, format, and 604 web tests
- manual: dragged from Monday 23:00 into Tuesday with a 180-minute limit and confirmed the form opened with Tuesday 02:00 as the end time

## Screenshots or recordings

Not included; this restores interaction behavior without changing the visual design.

## Risks and rollout

None. The change uses the existing Reservation settings and range callback contract.

## Checklist

- [x] A changeset is included, or this change does not require one
- [x] Relevant tests were added or run, or testing is not applicable
- [x] Migrations, environment variables, documentation, and breaking changes are covered when applicable
