### PR TITLE
perf(api): paginate loot from organization records

### DIFF
--- a/.changeset/quick-loot-record-pagination.md
+++ b/.changeset/quick-loot-record-pagination.md
@@ -1,0 +1,5 @@
+---
+"@lootlog/api": patch
+---
+
+Query Organization Loot records directly when paginating loot lists so PostgreSQL can use the tenant-scoped ordering index before loading global loot facts.

--- a/apps/api/src/loots/loots.service.spec.ts
+++ b/apps/api/src/loots/loots.service.spec.ts
@@ -37,6 +37,7 @@ import {
   Permission,
   type Guild,
   LootSource,
+  type Prisma,
   type Role,
 } from "#src/generated/prisma/client";
 import { ErrorKey } from "./enum/error-key.enum.js";
@@ -2021,6 +2022,15 @@ describe("Loot modules", () => {
       world: "testworld",
     };
 
+    const getLastOrganizationLootWhere = () => {
+      const lastCall =
+        prismaService.organizationLootRecord.findMany.mock.calls.at(-1) as
+          | [Prisma.OrganizationLootRecordFindManyArgs]
+          | undefined;
+
+      return lastCall?.[0].where?.loot;
+    };
+
     it("should return loots with submissions", async () => {
       const mockSubmissions = [
         {
@@ -2033,26 +2043,30 @@ describe("Loot modules", () => {
         },
       ];
 
-      const mockLootsWithRelations = [
+      const mockOrganizationRecords = [
         {
-          id: 1,
-          uniqueId: "unique1",
-          world: "testworld",
-          source: LootSource.FIGHT,
-          location: "Test Location",
-          lootShare: {},
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          organizationLootRecords: [
-            { submissions: mockSubmissions, _count: { comments: 0 } },
-          ],
-          lootItems: [],
-          lootPlayers: [],
-          lootNpcs: [],
+          lootId: 1,
+          submissions: mockSubmissions,
+          _count: { comments: 0 },
+          loot: {
+            id: 1,
+            uniqueId: "unique1",
+            world: "testworld",
+            source: LootSource.FIGHT,
+            location: "Test Location",
+            lootShare: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            lootItems: [],
+            lootPlayers: [],
+            lootNpcs: [],
+          },
         },
       ];
 
-      prismaService.loot.findMany.mockResolvedValue(mockLootsWithRelations);
+      prismaService.organizationLootRecord.findMany.mockResolvedValue(
+        mockOrganizationRecords,
+      );
 
       const result = await service.fetchLootsByGuildId(
         mockGuild,
@@ -2067,6 +2081,81 @@ describe("Loot modules", () => {
         uniqueId: "unique1",
         submissions: mockSubmissions,
       });
+      expect(
+        prismaService.organizationLootRecord.findMany,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            guildId: mockGuild.id,
+            archivedAt: null,
+            loot: expect.objectContaining({ world: "testworld" }),
+          }),
+          orderBy: { lootId: "desc" },
+          take: params.limit,
+        }),
+      );
+      expect(prismaService.loot.findMany).not.toHaveBeenCalled();
+    });
+
+    it("should keep cursor and role visibility within the Organization Loot query", async () => {
+      const role: Role = {
+        id: "role1",
+        name: "Loot Reader",
+        color: 0,
+        position: 1,
+        permissions: [Permission.LOOTLOG_LOOTS_READ],
+        lvlRangeFrom: 10,
+        lvlRangeTo: 60,
+        guildId: mockGuild.id,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      prismaService.organizationLootRecord.findMany.mockResolvedValue([]);
+
+      await service.fetchLootsByGuildId(
+        mockGuild,
+        [Permission.LOOTLOG_LOOTS_READ],
+        [role],
+        { ...params, cursor: 123 },
+      );
+
+      expect(getLastOrganizationLootWhere()).toEqual(
+        expect.objectContaining({
+          AND: expect.arrayContaining([
+            { id: { lt: 123 } },
+            {
+              AND: [
+                { lootNpcs: { some: {} } },
+                {
+                  lootNpcs: {
+                    every: {
+                      npcSnapshot: {
+                        OR: [
+                          {
+                            AND: [
+                              { lvl: { not: null, gte: 10, lte: 60 } },
+                              {
+                                type: {
+                                  not: null,
+                                  notIn: [
+                                    NpcType.TITAN,
+                                    NpcType.HERO,
+                                    NpcType.EVENT_HERO,
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          ]),
+        }),
+      );
     });
 
     it("should revive cached loot dates before returning first page results", async () => {
@@ -2103,7 +2192,7 @@ describe("Loot modules", () => {
     });
 
     it("should return empty array when no loots found", async () => {
-      prismaService.loot.findMany.mockResolvedValue([]);
+      prismaService.organizationLootRecord.findMany.mockResolvedValue([]);
 
       const result = await service.fetchLootsByGuildId(
         mockGuild,
@@ -2117,7 +2206,7 @@ describe("Loot modules", () => {
     });
 
     it("should apply ranged loot filters to the Prisma query", async () => {
-      prismaService.loot.findMany.mockResolvedValue([]);
+      prismaService.organizationLootRecord.findMany.mockResolvedValue([]);
 
       await service.fetchLootsByGuildId(mockGuild, [], [], {
         ...params,
@@ -2131,126 +2220,120 @@ describe("Loot modules", () => {
         createdAtMax: "2024-01-31T23:59:59.999Z",
       });
 
-      expect(prismaService.loot.findMany).toHaveBeenCalledWith(
+      expect(getLastOrganizationLootWhere()).toEqual(
         expect.objectContaining({
-          where: expect.objectContaining({
-            AND: expect.arrayContaining([
-              {
-                lootNpcs: {
-                  some: {
-                    npcSnapshot: {
-                      lvl: {
-                        gte: 10,
-                        lte: 20,
-                      },
-                    },
-                  },
-                },
-              },
-              {
-                lootItems: {
-                  some: {
-                    itemSnapshot: {
-                      lvl: {
-                        gte: 30,
-                        lte: 40,
-                      },
-                    },
-                  },
-                },
-              },
-              {
-                lootPlayers: {
-                  some: {
+          AND: expect.arrayContaining([
+            {
+              lootNpcs: {
+                some: {
+                  npcSnapshot: {
                     lvl: {
-                      gte: 50,
-                      lte: 60,
+                      gte: 10,
+                      lte: 20,
                     },
                   },
                 },
               },
-              {
-                createdAt: {
-                  gte: new Date("2024-01-01T00:00:00.000Z"),
-                  lte: new Date("2024-01-31T23:59:59.999Z"),
+            },
+            {
+              lootItems: {
+                some: {
+                  itemSnapshot: {
+                    lvl: {
+                      gte: 30,
+                      lte: 40,
+                    },
+                  },
                 },
               },
-            ]),
-          }),
+            },
+            {
+              lootPlayers: {
+                some: {
+                  lvl: {
+                    gte: 50,
+                    lte: 60,
+                  },
+                },
+              },
+            },
+            {
+              createdAt: {
+                gte: new Date("2024-01-01T00:00:00.000Z"),
+                lte: new Date("2024-01-31T23:59:59.999Z"),
+              },
+            },
+          ]),
         }),
       );
     });
 
     it("should apply item profession filters to the Prisma query", async () => {
-      prismaService.loot.findMany.mockResolvedValue([]);
+      prismaService.organizationLootRecord.findMany.mockResolvedValue([]);
 
       await service.fetchLootsByGuildId(mockGuild, [], [], {
         ...params,
         professions: [Profession.HUNTER, Profession.TRACKER, "INVALID"],
       });
 
-      expect(prismaService.loot.findMany).toHaveBeenCalledWith(
+      expect(getLastOrganizationLootWhere()).toEqual(
         expect.objectContaining({
-          where: expect.objectContaining({
-            AND: expect.arrayContaining([
-              {
-                lootItems: {
-                  some: {
-                    itemSnapshot: {
-                      OR: [
-                        {
-                          statRaw: {
-                            not: {
-                              contains: "reqp=",
-                            },
+          AND: expect.arrayContaining([
+            {
+              lootItems: {
+                some: {
+                  itemSnapshot: {
+                    OR: [
+                      {
+                        statRaw: {
+                          not: {
+                            contains: "reqp=",
                           },
                         },
-                        {
-                          statsSnapshot: {
-                            path: ["reqp"],
-                            string_contains: "h",
-                          },
+                      },
+                      {
+                        statsSnapshot: {
+                          path: ["reqp"],
+                          string_contains: "h",
                         },
-                        {
-                          statsSnapshot: {
-                            path: ["reqp"],
-                            string_contains: "t",
-                          },
+                      },
+                      {
+                        statsSnapshot: {
+                          path: ["reqp"],
+                          string_contains: "t",
                         },
-                      ],
-                    },
+                      },
+                    ],
                   },
                 },
               },
-            ]),
-          }),
+            },
+          ]),
         }),
       );
     });
 
     it("should ignore invalid item profession filters", async () => {
-      prismaService.loot.findMany.mockResolvedValue([]);
+      prismaService.organizationLootRecord.findMany.mockResolvedValue([]);
 
       await service.fetchLootsByGuildId(mockGuild, [], [], {
         ...params,
         professions: ["INVALID"],
       });
 
-      expect(prismaService.loot.findMany).toHaveBeenCalledWith(
+      expect(getLastOrganizationLootWhere()).not.toEqual(
         expect.objectContaining({
-          where: expect.not.objectContaining({
-            AND: expect.arrayContaining([
-              expect.objectContaining({
-                lootItems: expect.objectContaining({
-                  some: expect.objectContaining({
-                    itemSnapshot: expect.objectContaining({
-                      OR: expect.any(Array),
-                    }),
+          AND: expect.arrayContaining([
+            expect.objectContaining({
+              lootItems: expect.objectContaining({
+                some: expect.objectContaining({
+                  itemSnapshot: expect.objectContaining({
+                    OR: expect.any(Array),
                   }),
                 }),
               }),
-            ]),
-          }),
+            }),
+          ]),
         }),
       );
     });

--- a/apps/api/src/loots/services/loot-query.service.ts
+++ b/apps/api/src/loots/services/loot-query.service.ts
@@ -48,6 +48,27 @@ type LootNpcWithSnapshot = Prisma.LootNpcGetPayload<{
   include: { npcSnapshot: true };
 }>;
 
+type LootWhereOptions = {
+  npcTypes?: string[];
+  npcs?: string[];
+  players?: string[];
+  rarities?: string[];
+  professions?: string[];
+  npcLevelMin?: number;
+  npcLevelMax?: number;
+  itemLevelMin?: number;
+  itemLevelMax?: number;
+  playerLevelMin?: number;
+  playerLevelMax?: number;
+  search?: string;
+  world?: string;
+  hid?: string;
+  itemSnapshotIds?: number[];
+  cursor?: number | null;
+  createdAtMin?: string;
+  createdAtMax?: string;
+};
+
 @Injectable()
 export class LootQueryService {
   constructor(private readonly prisma: PrismaService) {}
@@ -84,7 +105,7 @@ export class LootQueryService {
       return [];
     }
 
-    const baseWhere = this.buildBaseWhereCondition(guild, permissions, roles, {
+    const lootWhere = this.buildLootWhereCondition(permissions, roles, {
       npcTypes,
       npcs,
       players,
@@ -105,89 +126,85 @@ export class LootQueryService {
       createdAtMax,
     });
 
-    const lootsWithRelations = await this.prisma.loot.findMany({
-      where: baseWhere,
-      orderBy: { id: "desc" },
-      take: limit,
-      select: {
-        id: true,
-        uniqueId: true,
-        world: true,
-        source: true,
-        location: true,
-        lootShare: true,
-        createdAt: true,
-        updatedAt: true,
-        organizationLootRecords: {
-          where: { guildId: guild.id, archivedAt: null },
-          take: 1,
-          select: {
-            submissions: {
-              include: {
-                member: {
-                  select: {
-                    name: true,
-                    avatar: true,
-                    userId: true,
-                  },
+    const organizationRecords =
+      await this.prisma.organizationLootRecord.findMany({
+        where: {
+          guildId: guild.id,
+          archivedAt: null,
+          loot: lootWhere,
+        },
+        orderBy: { lootId: "desc" },
+        take: limit,
+        select: {
+          submissions: {
+            include: {
+              member: {
+                select: {
+                  name: true,
+                  avatar: true,
+                  userId: true,
                 },
               },
             },
-            _count: { select: { comments: true } },
+          },
+          _count: { select: { comments: true } },
+          loot: {
+            select: {
+              id: true,
+              uniqueId: true,
+              world: true,
+              source: true,
+              location: true,
+              lootShare: true,
+              createdAt: true,
+              updatedAt: true,
+              lootItems: {
+                select: lootItemSelect,
+                orderBy: { id: "asc" },
+              },
+              lootPlayers: {
+                include: { playerSnapshot: true },
+                orderBy: { id: "asc" },
+              },
+              lootNpcs: {
+                include: { npcSnapshot: true },
+                orderBy: { id: "asc" },
+              },
+            },
           },
         },
-        lootItems: {
-          select: lootItemSelect,
-          orderBy: { id: "asc" },
-        },
-        lootPlayers: {
-          include: { playerSnapshot: true },
-          orderBy: { id: "asc" },
-        },
-        lootNpcs: {
-          include: { npcSnapshot: true },
-          orderBy: { id: "asc" },
-        },
-      },
+      });
+
+    if (organizationRecords.length === 0) return [];
+
+    return organizationRecords.map((organizationRecord): LootQueryResult => {
+      const { loot } = organizationRecord;
+
+      return {
+        id: loot.id,
+        uniqueId: loot.uniqueId,
+        world: loot.world,
+        source: loot.source,
+        location: loot.location,
+        lootShare: this.parseLootShare(loot.lootShare),
+        createdAt: loot.createdAt,
+        updatedAt: loot.updatedAt,
+        items: this.mapItems(
+          loot.lootItems as unknown as LootItemWithSnapshot[],
+        ),
+        players: (loot.lootPlayers as unknown as LootPlayerWithSnapshot[]).map(
+          (entry) => this.mapPlayerFromSnapshot(entry),
+        ),
+        npcs: this.mapNpcs(loot.lootNpcs as unknown as LootNpcWithSnapshot[]),
+        submissions: organizationRecord.submissions.map((submission) => ({
+          guildId: guild.id,
+          lootId: loot.id,
+          memberId: submission.memberId,
+          member: submission.member,
+        })),
+        commentsCount: organizationRecord._count.comments,
+      };
     });
-
-    if (!lootsWithRelations.length) return [];
-
-    const results: LootQueryResult[] = lootsWithRelations.flatMap((loot) => {
-      const organizationRecord = loot.organizationLootRecords[0];
-      if (!organizationRecord) {
-        return [];
-      }
-
-      return [
-        {
-          id: loot.id,
-          uniqueId: loot.uniqueId,
-          world: loot.world,
-          source: loot.source,
-          location: loot.location,
-          lootShare: this.parseLootShare(loot.lootShare),
-          createdAt: loot.createdAt,
-          updatedAt: loot.updatedAt,
-          items: this.mapItems(
-            loot.lootItems as unknown as LootItemWithSnapshot[],
-          ),
-          players: (
-            loot.lootPlayers as unknown as LootPlayerWithSnapshot[]
-          ).map((entry) => this.mapPlayerFromSnapshot(entry)),
-          npcs: this.mapNpcs(loot.lootNpcs as unknown as LootNpcWithSnapshot[]),
-          submissions: organizationRecord.submissions.map((submission) => ({
-            guildId: guild.id,
-            lootId: loot.id,
-            memberId: submission.memberId,
-            member: submission.member,
-          })),
-          commentsCount: organizationRecord._count.comments,
-        },
-      ];
-    });
-
-    return results;
   }
 
   async countLootsByGuildId(
@@ -397,6 +414,22 @@ export class LootQueryService {
     guild: Guild,
     permissions: Permission[],
     roles: Role[],
+    options: LootWhereOptions,
+  ): Prisma.LootWhereInput {
+    return {
+      ...this.buildLootWhereCondition(permissions, roles, options),
+      organizationLootRecords: {
+        some: {
+          guildId: guild.id,
+          archivedAt: null,
+        },
+      },
+    };
+  }
+
+  private buildLootWhereCondition(
+    permissions: Permission[],
+    roles: Role[],
     {
       npcTypes = [],
       npcs = [],
@@ -416,26 +449,7 @@ export class LootQueryService {
       cursor,
       createdAtMin,
       createdAtMax,
-    }: {
-      npcTypes?: string[];
-      npcs?: string[];
-      players?: string[];
-      rarities?: string[];
-      professions?: string[];
-      npcLevelMin?: number;
-      npcLevelMax?: number;
-      itemLevelMin?: number;
-      itemLevelMax?: number;
-      playerLevelMin?: number;
-      playerLevelMax?: number;
-      search?: string;
-      world?: string;
-      hid?: string;
-      itemSnapshotIds?: number[];
-      cursor?: number | null;
-      createdAtMin?: string;
-      createdAtMax?: string;
-    },
+    }: LootWhereOptions,
   ): Prisma.LootWhereInput {
     const visibilityCondition = buildLootNpcVisibilityWhere(permissions, roles);
     const playersCondition = this.buildPlayersCondition(players);
@@ -466,17 +480,10 @@ export class LootQueryService {
       createdAtMax,
     );
 
-    const baseWhere: Prisma.LootWhereInput = {
-      organizationLootRecords: {
-        some: {
-          guildId: guild.id,
-          archivedAt: null,
-        },
-      },
-    };
+    const lootWhere: Prisma.LootWhereInput = {};
 
     if (world) {
-      baseWhere.world = world;
+      lootWhere.world = world;
     }
 
     const andConditions = [
@@ -497,10 +504,10 @@ export class LootQueryService {
     ].filter(Boolean) as Prisma.LootWhereInput[];
 
     if (andConditions.length > 0) {
-      baseWhere.AND = andConditions;
+      lootWhere.AND = andConditions;
     }
 
-    return baseWhere;
+    return lootWhere;
   }
 
   private parseLootShare(lootShare: Prisma.JsonValue) {


### PR DESCRIPTION
## Summary

- anchor loot-list pagination on active `OrganizationLootRecord` rows so PostgreSQL can use the tenant-scoped `(guildId, archivedAt, lootId)` index
- keep the existing global loot filters, cursor, and complete NPC visibility policy on the related `Loot`
- hydrate the same global loot facts together with Organization-owned submissions and comment counts
- add regression coverage and an API patch changeset

## Motivation

After the Organization Loot migration, starting from `Loot` and checking the Organization record through `EXISTS` caused PostgreSQL to choose a full tenant scan for members with restricted NPC visibility. Production diagnostics measured roughly 190-215 ms in the primary query and about 30,000 Organization records examined before `LIMIT 20`. Starting from the Organization record preserves the domain boundary and lets pagination follow the existing index.

A production-shape prototype reduced the warm end-to-end Prisma call from roughly 198 ms to 61-63 ms while preserving the result and visibility predicate.

## Verification

- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/loots/loots.service.spec.ts` (50 tests)
- `pnpm --filter @lootlog/api exec vitest run --config ./vitest.config.ts src/events/services/event-wrapped.service.spec.ts`
- `pnpm --filter @lootlog/api lint`
- `pnpm --filter @lootlog/api build`
- pre-commit full API suite: 110 files, 1050 tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved loot list pagination by querying guild-specific loot records directly.
  * Pagination now better leverages database ordering, improving efficiency for larger loot lists.

* **Bug Fixes**
  * Improved consistency for cursor-based pagination, role visibility, and ranged loot filters.
  * Excluded archived loot records from paginated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->