### PR TITLE
fix(reservations): correct sharing boundaries

### DIFF
--- a/.changeset/fresh-reservation-links.md
+++ b/.changeset/fresh-reservation-links.md
@@ -1,0 +1,10 @@
+---
+"@lootlog/api": patch
+"@lootlog/api-client": patch
+"@lootlog/web": patch
+---
+
+Return Reservation sharing invitation paths from the API and build complete
+links from the active Web origin so production invitations cannot inherit a
+local development hostname. Keep partner reservations visible without letting
+them affect local availability, nearest-free suggestions, or collision checks.

--- a/.changeset/fresh-reservation-links.md
+++ b/.changeset/fresh-reservation-links.md
@@ -6,5 +6,6 @@
 
 Return Reservation sharing invitation paths from the API and build complete
 links from the active Web origin so production invitations cannot inherit a
-local development hostname. Keep partner reservations visible without letting
-them affect local availability, nearest-free suggestions, or collision checks.
+local development hostname. Accept the previous absolute-URL response during
+the Web-first rollout. Keep partner reservations visible without letting them
+affect local availability, nearest-free suggestions, or collision checks.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -131,10 +131,11 @@ the Organization's time policy, and check collisions inside a serializable
 transaction. Reads are bounded by an explicit window; retention is handled by
 scheduled cleanup rather than a read-side mutation or full-calendar cache.
 
-An active calendar partnership extends visibility and collision checks to one
-direct partner while keeping source ownership and moderation unchanged. It is
-reciprocal and non-transitive. The detailed disclosure and revocation contract
-is recorded in [ADR 0001](docs/adr/0001-direct-reciprocal-reservation-sharing.md).
+An active calendar partnership extends visibility to one direct partner while
+keeping each Organization's availability, collision checks, source ownership,
+and moderation independent. It is reciprocal and non-transitive. The detailed
+disclosure and revocation contract is recorded in
+[ADR 0001](docs/adr/0001-direct-reciprocal-reservation-sharing.md).
 
 Reservation reminders reuse the notification domain. A reservation stores an
 offset, not a Discord identifier. The notification boundary resolves an active

--- a/apps/api/openapi.yaml
+++ b/apps/api/openapi.yaml
@@ -11106,14 +11106,14 @@ components:
           type: string
           format: date-time
           pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
-        inviteUrl:
+        invitePath:
           type: string
-          format: uri
+          pattern: ^\/reservation-sharing\/invitations\/[\w-]+$
       required:
         - id
         - expiresAt
         - createdAt
-        - inviteUrl
+        - invitePath
     ReservationShareInvitationPreviewResponseDto:
       type: object
       properties:

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -30,7 +30,6 @@ export const env = createEnv(
     AUTH_SERVICE_URL: z.string(),
     BATTLELOG_SERVICE_URL: z.string().default("http://battlelog-service:4000"),
     DISCORD_BOT_SERVICE_URL: z.string().default("http://discord-bot:4000"),
-    WEB_APP_URL: z.string().url().default("http://localhost"),
     RESERVATIONS_CARDS_URL: z.string().url(),
     OTEL_EXPORTER_OTLP_ENDPOINT: z.string().optional(),
     OTEL_EXPORTER_OTLP_HEADERS: z.string().optional(),

--- a/apps/api/src/reservations/dto/reservation-sharing.dto.ts
+++ b/apps/api/src/reservations/dto/reservation-sharing.dto.ts
@@ -28,7 +28,11 @@ export class ReservationSharesResponseDto extends createZodDto(
 ) {}
 
 export class CreateReservationShareInvitationResponseDto extends createZodDto(
-  ReservationShareInvitationSchema.extend({ inviteUrl: z.string().url() }),
+  ReservationShareInvitationSchema.extend({
+    invitePath: z
+      .string()
+      .regex(/^\/reservation-sharing\/invitations\/[\w-]+$/),
+  }),
   { codec: true },
 ) {}
 

--- a/apps/api/src/reservations/reservation-mutations.service.spec.ts
+++ b/apps/api/src/reservations/reservation-mutations.service.spec.ts
@@ -154,7 +154,36 @@ describe("ReservationMutationsService", () => {
     );
   });
 
-  it("checks overlap across every directly visible partner", async () => {
+  it("does not let a partner reservation block a local write", async () => {
+    transaction.reservation.findFirst.mockImplementation(
+      (query: { where: { guildId: string | { in: string[] } } }) =>
+        Promise.resolve(
+          typeof query.where.guildId !== "string" &&
+            query.where.guildId.in.includes("partner-guild")
+            ? { id: 99 }
+            : null,
+        ),
+    );
+
+    await service.create({
+      context,
+      spotId: reservation.spotId,
+      data: {
+        startsAt: reservation.startsAt.toISOString(),
+        endsAt: reservation.endsAt.toISOString(),
+      },
+    });
+
+    expect(transaction.reservation.findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        guildId: guild.id,
+        spotId: reservation.spotId,
+      }),
+      select: { id: true },
+    });
+  });
+
+  it("rejects an overlapping reservation in the current organization", async () => {
     transaction.reservation.findFirst.mockResolvedValue({ id: 99 });
 
     await expect(
@@ -169,28 +198,7 @@ describe("ReservationMutationsService", () => {
     ).rejects.toMatchObject({ status: 409 });
 
     expect(transaction.reservation.findFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({
-        guildId: { in: [guild.id, "partner-guild"] },
-        spotId: reservation.spotId,
-      }),
-      select: { id: true },
-    });
-  });
-
-  it("does not check an unrelated organization without a direct share", async () => {
-    sharingService.getVisibleGuildIds.mockResolvedValue([guild.id]);
-
-    await service.create({
-      context,
-      spotId: reservation.spotId,
-      data: {
-        startsAt: reservation.startsAt.toISOString(),
-        endsAt: reservation.endsAt.toISOString(),
-      },
-    });
-
-    expect(transaction.reservation.findFirst).toHaveBeenCalledWith({
-      where: expect.objectContaining({ guildId: { in: [guild.id] } }),
+      where: expect.objectContaining({ guildId: guild.id }),
       select: { id: true },
     });
   });
@@ -276,6 +284,15 @@ describe("ReservationMutationsService", () => {
     };
     guildsService.getCurrentUserAccessibleGuilds.mockResolvedValue([guild]);
     prisma.reservation.findFirst.mockResolvedValue(reservation);
+    transaction.reservation.findFirst.mockImplementation(
+      (query: { where: { guildId: string | { in: string[] } } }) =>
+        Promise.resolve(
+          typeof query.where.guildId !== "string" &&
+            query.where.guildId.in.includes("partner-guild")
+            ? { id: 99 }
+            : null,
+        ),
+    );
     transaction.reservation.update.mockResolvedValue(updatedReservation);
     reminderService.prepare.mockResolvedValue({
       target: { id: 1 },
@@ -297,7 +314,7 @@ describe("ReservationMutationsService", () => {
     expect(transaction.reservation.findFirst).toHaveBeenCalledWith({
       where: expect.objectContaining({
         id: { not: reservation.id },
-        guildId: { in: [guild.id, "partner-guild"] },
+        guildId: guild.id,
         spotId: reservation.spotId,
       }),
       select: { id: true },
@@ -332,6 +349,34 @@ describe("ReservationMutationsService", () => {
         reminderMinutesBefore: 15,
       }),
     );
+  });
+
+  it("rejects a time edit overlapping the source organization", async () => {
+    guildsService.getCurrentUserAccessibleGuilds.mockResolvedValue([guild]);
+    prisma.reservation.findFirst.mockResolvedValue(reservation);
+    transaction.reservation.findFirst.mockResolvedValue({ id: 99 });
+
+    await expect(
+      service.updateOwned({
+        userId: context.userId,
+        discordId: context.discordId,
+        reservationId: reservation.id,
+        data: {
+          startsAt: "2026-08-26T12:30:00.000Z",
+          endsAt: "2026-08-26T13:30:00.000Z",
+        },
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+
+    expect(transaction.reservation.findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: { not: reservation.id },
+        guildId: guild.id,
+        spotId: reservation.spotId,
+      }),
+      select: { id: true },
+    });
+    expect(transaction.reservation.update).not.toHaveBeenCalled();
   });
 
   it("does not reschedule an unchanged reminder for a comment-only edit", async () => {

--- a/apps/api/src/reservations/reservation-mutations.service.ts
+++ b/apps/api/src/reservations/reservation-mutations.service.ts
@@ -92,7 +92,7 @@ export class ReservationMutationsService {
       async (transaction) => {
         await this.assertNoOverlap(transaction, {
           ...range,
-          visibleGuildIds,
+          guildId: context.guildId,
           spotId: spot.id,
         });
 
@@ -237,7 +237,7 @@ export class ReservationMutationsService {
         if (timeChanged) {
           await this.assertNoOverlap(transaction, {
             ...range,
-            visibleGuildIds,
+            guildId: reservation.guildId,
             spotId: reservation.spotId,
             excludedReservationId: reservation.id,
           });
@@ -368,7 +368,7 @@ export class ReservationMutationsService {
   private async assertNoOverlap(
     transaction: Prisma.TransactionClient,
     options: ReservationRange & {
-      visibleGuildIds: string[];
+      guildId: string;
       spotId: string;
       excludedReservationId?: number;
     },
@@ -378,7 +378,7 @@ export class ReservationMutationsService {
         ...(options.excludedReservationId === undefined
           ? {}
           : { id: { not: options.excludedReservationId } }),
-        guildId: { in: options.visibleGuildIds },
+        guildId: options.guildId,
         spotId: options.spotId,
         startsAt: { lt: options.endsAt },
         endsAt: { gt: options.startsAt },

--- a/apps/api/src/reservations/reservation-sharing.service.spec.ts
+++ b/apps/api/src/reservations/reservation-sharing.service.spec.ts
@@ -15,6 +15,7 @@ describe("ReservationSharingService", () => {
       findMany: vi.fn(),
     },
     reservationShareInvitation: {
+      create: vi.fn(),
       findUnique: vi.fn(),
     },
   };
@@ -44,6 +45,27 @@ describe("ReservationSharingService", () => {
       guildsService as never,
       eventsPublisher as never,
     );
+  });
+
+  it("creates an origin-independent invitation path", async () => {
+    const createdAt = new Date();
+    const expiresAt = future();
+    prisma.reservationShareInvitation.create.mockResolvedValue({
+      id: "invite",
+      createdAt,
+      expiresAt,
+    });
+
+    const invitation = await service.createInvitation("guild", "user");
+
+    expect(invitation).toEqual({
+      id: "invite",
+      invitePath: expect.stringMatching(
+        /^\/reservation-sharing\/invitations\/[\w-]+$/,
+      ),
+      createdAt,
+      expiresAt,
+    });
   });
 
   it("returns only the current organization and its direct partners", async () => {

--- a/apps/api/src/reservations/reservation-sharing.service.ts
+++ b/apps/api/src/reservations/reservation-sharing.service.ts
@@ -5,7 +5,6 @@ import {
   Injectable,
   NotFoundException,
 } from "@nestjs/common";
-import { env } from "#src/config/env";
 import { PrismaService } from "#src/db/prisma.service";
 import { Permission, type Guild } from "#src/generated/prisma/client";
 import { GuildsService } from "#src/guilds/guilds.service";
@@ -110,14 +109,11 @@ export class ReservationSharingService {
         expiresAt,
       },
     });
-    const inviteUrl = new URL(
-      `/reservation-sharing/invitations/${token}`,
-      env.WEB_APP_URL,
-    ).toString();
+    const invitePath = `/reservation-sharing/invitations/${token}`;
 
     return {
       id: invitation.id,
-      inviteUrl,
+      invitePath,
       expiresAt: invitation.expiresAt,
       createdAt: invitation.createdAt,
     };

--- a/apps/api/src/reservations/reservations.service.spec.ts
+++ b/apps/api/src/reservations/reservations.service.spec.ts
@@ -48,6 +48,97 @@ describe("ReservationsService", () => {
     vi.useRealTimers();
   });
 
+  it("keeps a partner-only spot locally available", async () => {
+    catalogService.getSpots.mockResolvedValue([
+      {
+        id: reservation.spotId,
+        name: "Potępione Zamczysko",
+        level: 300,
+        images: [],
+        maps: [],
+      },
+    ]);
+    sharingService.getVisibleGuildIds.mockResolvedValue([
+      guild.id,
+      "partner-guild",
+    ]);
+    prisma.userPinnedReservationSpot.findMany.mockResolvedValue([]);
+    prisma.reservation.findMany.mockResolvedValue([
+      {
+        ...reservation,
+        guildId: "partner-guild",
+        startsAt: new Date("2026-08-26T11:30:00.000Z"),
+        endsAt: new Date("2026-08-26T12:30:00.000Z"),
+        guild: { id: "partner-guild", name: "Partner" },
+      },
+    ]);
+
+    const [spot] = await service.listSpots({
+      guildId: guild.id,
+      userId: "user-1",
+      discordId: "discord-1",
+      actorIsOwner: false,
+      permissions: [],
+    });
+
+    expect(spot).toEqual(
+      expect.objectContaining({
+        isAvailableNow: true,
+        availableUntil: null,
+        activeReservationCount: 0,
+        hasPartnerReservations: true,
+        currentReservation: null,
+        nextReservation: null,
+      }),
+    );
+  });
+
+  it("derives spot availability from local reservations in a mixed calendar", async () => {
+    catalogService.getSpots.mockResolvedValue([
+      {
+        id: reservation.spotId,
+        name: "Potępione Zamczysko",
+        level: 300,
+        images: [],
+        maps: [],
+      },
+    ]);
+    sharingService.getVisibleGuildIds.mockResolvedValue([
+      guild.id,
+      "partner-guild",
+    ]);
+    prisma.userPinnedReservationSpot.findMany.mockResolvedValue([]);
+    prisma.reservation.findMany.mockResolvedValue([
+      {
+        ...reservation,
+        guildId: "partner-guild",
+        startsAt: new Date("2026-08-26T11:30:00.000Z"),
+        endsAt: new Date("2026-08-26T12:30:00.000Z"),
+        guild: { id: "partner-guild", name: "Partner" },
+      },
+      reservation,
+    ]);
+
+    const [spot] = await service.listSpots({
+      guildId: guild.id,
+      userId: "user-1",
+      discordId: "discord-1",
+      actorIsOwner: false,
+      permissions: [],
+    });
+
+    expect(spot).toEqual(
+      expect.objectContaining({
+        isAvailableNow: true,
+        availableUntil: reservation.startsAt,
+        activeReservationCount: 1,
+        hasPartnerReservations: true,
+        currentReservation: null,
+        nextReservation: expect.objectContaining({ id: reservation.id }),
+      }),
+    );
+  });
+
   it("isolates a pin by user, organization, and spot", async () => {
     catalogService.getSpot.mockResolvedValue({ id: reservation.spotId });
 

--- a/apps/api/src/reservations/reservations.service.ts
+++ b/apps/api/src/reservations/reservations.service.ts
@@ -45,14 +45,18 @@ export class ReservationsService {
       const spotReservations = reservations.filter(
         (reservation) => reservation.spotId === spot.id,
       );
+      const localSpotReservations = spotReservations.filter(
+        (reservation) => reservation.guildId === context.guildId,
+      );
       const currentReservation =
-        spotReservations.find(
+        localSpotReservations.find(
           (reservation) =>
             reservation.startsAt <= now && reservation.endsAt > now,
         ) ?? null;
       const nextReservation =
-        spotReservations.find((reservation) => reservation.startsAt > now) ??
-        null;
+        localSpotReservations.find(
+          (reservation) => reservation.startsAt > now,
+        ) ?? null;
 
       return {
         ...spot,
@@ -62,7 +66,7 @@ export class ReservationsService {
           currentReservation === null
             ? (nextReservation?.startsAt ?? null)
             : null,
-        activeReservationCount: spotReservations.length,
+        activeReservationCount: localSpotReservations.length,
         hasPartnerReservations: spotReservations.some(
           (reservation) => reservation.guildId !== context.guildId,
         ),

--- a/apps/web/src/features/guild/reservations/schedule/reservations-schedule.spec.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservations-schedule.spec.tsx
@@ -178,13 +178,18 @@ describe("ReservationsSchedule nearest free slot", () => {
     vi.useRealTimers();
   });
 
-  it("loads the full availability window and opens the nearest partner-safe range", async () => {
+  it("ignores partner reservations while finding the nearest local range", async () => {
     mocks.fetchQuery.mockResolvedValue({
       items: [
         {
           endsAt: new Date(2026, 0, 2, 9, 0).toISOString(),
           sourceOrganization: { isCurrent: false },
           startsAt: new Date(2026, 0, 1, 12, 0).toISOString(),
+        },
+        {
+          endsAt: new Date(2026, 0, 1, 13, 0).toISOString(),
+          sourceOrganization: { isCurrent: true },
+          startsAt: new Date(2026, 0, 1, 12, 30).toISOString(),
         },
       ],
     });
@@ -207,17 +212,17 @@ describe("ReservationsSchedule nearest free slot", () => {
     );
     expect(
       screen.getByTestId("schedule-header").getAttribute("data-date"),
-    ).toBe(new Date(2026, 0, 2, 9, 0).toISOString());
+    ).toBe(new Date(2026, 0, 1, 13, 0).toISOString());
     expect(
       screen
         .getByTestId("reservation-form-dialog")
         .getAttribute("data-starts-at"),
-    ).toBe(new Date(2026, 0, 2, 9, 0).toISOString());
+    ).toBe(new Date(2026, 0, 1, 13, 0).toISOString());
     expect(
       screen
         .getByTestId("reservation-form-dialog")
         .getAttribute("data-ends-at"),
-    ).toBe(new Date(2026, 0, 2, 9, 30).toISOString());
+    ).toBe(new Date(2026, 0, 1, 13, 30).toISOString());
   });
 
   it("shows distinct feedback for no availability and request failures", async () => {
@@ -227,6 +232,7 @@ describe("ReservationsSchedule nearest free slot", () => {
         items: [
           {
             endsAt: unavailableUntil.toISOString(),
+            sourceOrganization: { isCurrent: true },
             startsAt: now.toISOString(),
           },
         ],

--- a/apps/web/src/features/guild/reservations/schedule/reservations-schedule.tsx
+++ b/apps/web/src/features/guild/reservations/schedule/reservations-schedule.tsx
@@ -181,10 +181,12 @@ export function ReservationsSchedule() {
         ),
       );
       const nearestRange = findNearestFreeReservationRange({
-        intervals: result.items.map(({ endsAt, startsAt }) => ({
-          endsAt: new Date(endsAt),
-          startsAt: new Date(startsAt),
-        })),
+        intervals: result.items
+          .filter(({ sourceOrganization }) => sourceOrganization.isCurrent)
+          .map(({ endsAt, startsAt }) => ({
+            endsAt: new Date(endsAt),
+            startsAt: new Date(startsAt),
+          })),
         now,
         settings,
       });

--- a/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.spec.tsx
+++ b/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.spec.tsx
@@ -16,6 +16,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReservationSharingSettings } from "./reservation-sharing-settings";
 
 const mocks = vi.hoisted(() => ({
+  createdInvitationResponse: {
+    id: "invitation-1",
+    invitePath: "/reservation-sharing/invitations/invitation-1",
+    createdAt: "2026-08-26T00:00:00.000Z",
+    expiresAt: "2026-09-02T00:00:00.000Z",
+  } as Record<string, string>,
   invalidateQueries: vi.fn(),
 }));
 
@@ -51,12 +57,7 @@ vi.mock("@lootlog/api-client/react-query/main/reservation-sharing", () => ({
     isPending: false,
     mutate: (variables: unknown) =>
       mutation.onSuccess?.(
-        {
-          id: "invitation-1",
-          invitePath: "/reservation-sharing/invitations/invitation-1",
-          createdAt: "2026-08-26T00:00:00.000Z",
-          expiresAt: "2026-09-02T00:00:00.000Z",
-        },
+        mocks.createdInvitationResponse,
         variables,
         undefined,
       ),
@@ -126,9 +127,36 @@ describe("ReservationSharingSettings", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    mocks.createdInvitationResponse = {
+      id: "invitation-1",
+      invitePath: "/reservation-sharing/invitations/invitation-1",
+      createdAt: "2026-08-26T00:00:00.000Z",
+      expiresAt: "2026-09-02T00:00:00.000Z",
+    };
   });
 
   it("builds the invitation URL from the current web origin", () => {
+    render(<ReservationSharingSettings />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Utwórz zaproszenie" }));
+
+    expect(
+      screen.getByRole<HTMLInputElement>("textbox", {
+        name: "Link zaproszenia",
+      }).value,
+    ).toBe(
+      `${window.location.origin}/reservation-sharing/invitations/invitation-1`,
+    );
+  });
+
+  it("supports the previous API response during a Web-first rollout", () => {
+    mocks.createdInvitationResponse = {
+      id: "invitation-1",
+      inviteUrl:
+        "http://localhost/reservation-sharing/invitations/invitation-1",
+      createdAt: "2026-08-26T00:00:00.000Z",
+      expiresAt: "2026-09-02T00:00:00.000Z",
+    };
     render(<ReservationSharingSettings />);
 
     fireEvent.click(screen.getByRole("button", { name: "Utwórz zaproszenie" }));

--- a/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.spec.tsx
+++ b/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.spec.tsx
@@ -53,7 +53,7 @@ vi.mock("@lootlog/api-client/react-query/main/reservation-sharing", () => ({
       mutation.onSuccess?.(
         {
           id: "invitation-1",
-          inviteUrl: "http://localhost/invitation-1",
+          invitePath: "/reservation-sharing/invitations/invitation-1",
           createdAt: "2026-08-26T00:00:00.000Z",
           expiresAt: "2026-09-02T00:00:00.000Z",
         },
@@ -126,6 +126,20 @@ describe("ReservationSharingSettings", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+  });
+
+  it("builds the invitation URL from the current web origin", () => {
+    render(<ReservationSharingSettings />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Utwórz zaproszenie" }));
+
+    expect(
+      screen.getByRole<HTMLInputElement>("textbox", {
+        name: "Link zaproszenia",
+      }).value,
+    ).toBe(
+      `${window.location.origin}/reservation-sharing/invitations/invitation-1`,
+    );
   });
 
   it("hides a newly created link after its invitation is revoked", async () => {

--- a/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.tsx
+++ b/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.tsx
@@ -27,6 +27,16 @@ import { useGuildId } from "@/hooks/context/use-guild-id";
 import { getReservationErrorMessage } from "@/features/guild/reservations/get-reservation-error-message";
 
 type CreatedInvitation = { id: string; inviteUrl: string };
+type InvitationLink = { invitePath: string } | { inviteUrl: string };
+
+function buildInvitationUrl(invitation: InvitationLink): string {
+  const invitePath =
+    "invitePath" in invitation
+      ? invitation.invitePath
+      : new URL(invitation.inviteUrl).pathname;
+
+  return new URL(invitePath, window.location.origin).toString();
+}
 
 export function ReservationSharingSettings() {
   const { t } = useTranslation();
@@ -45,10 +55,7 @@ export function ReservationSharingSettings() {
       onSuccess: async (invitation) => {
         setCreatedInvitation({
           id: invitation.id,
-          inviteUrl: new URL(
-            invitation.invitePath,
-            window.location.origin,
-          ).toString(),
+          inviteUrl: buildInvitationUrl(invitation),
         });
         await refresh();
       },

--- a/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.tsx
+++ b/apps/web/src/features/guild/settings/reservations/reservation-sharing-settings.tsx
@@ -23,14 +23,10 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@lootlog/ui/components/alert";
-import type { CreateReservationShareInvitationResponseDto } from "@lootlog/api-client/models/main/create-reservation-share-invitation-response-dto";
 import { useGuildId } from "@/hooks/context/use-guild-id";
 import { getReservationErrorMessage } from "@/features/guild/reservations/get-reservation-error-message";
 
-type CreatedInvitation = Pick<
-  CreateReservationShareInvitationResponseDto,
-  "id" | "inviteUrl"
->;
+type CreatedInvitation = { id: string; inviteUrl: string };
 
 export function ReservationSharingSettings() {
   const { t } = useTranslation();
@@ -49,7 +45,10 @@ export function ReservationSharingSettings() {
       onSuccess: async (invitation) => {
         setCreatedInvitation({
           id: invitation.id,
-          inviteUrl: invitation.inviteUrl,
+          inviteUrl: new URL(
+            invitation.invitePath,
+            window.location.origin,
+          ).toString(),
         });
         await refresh();
       },

--- a/apps/web/src/i18n/translations/reservations.json
+++ b/apps/web/src/i18n/translations/reservations.json
@@ -206,13 +206,13 @@
     "accept": "Połącz kalendarze",
     "connecting": "Łączenie kalendarzy...",
     "acceptedTitle": "Kalendarze zostały połączone",
-    "acceptedDescription": "Obie organizacje widzą teraz swoje rezerwacje i nowe kolizje są sprawdzane wspólnie.",
+    "acceptedDescription": "Obie organizacje widzą teraz wzajemnie swoje rezerwacje. Terminy sojusznika nie blokują zapisów.",
     "openSettings": "Otwórz ustawienia rezerwacji",
     "invalidTitle": "Zaproszenie jest niedostępne",
     "invalidDescription": "Link wygasł, został wycofany albo użyto go wcześniej."
   },
   "errors": {
-    "RESERVATION_OVERLAP": "Ten termin koliduje z rezerwacją Twojej organizacji lub organizacji z sojuszu.",
+    "RESERVATION_OVERLAP": "Ten termin koliduje z rezerwacją Twojej organizacji.",
     "ACTIVE_LIMIT_REACHED": "Osiągnięto limit aktywnych rezerwacji na tym expowisku.",
     "INVALID_TIME_GRID": "Początek i koniec muszą pasować do kroku kalendarza.",
     "DM_TARGET_REQUIRED": "Najpierw skonfiguruj aktywny cel powiadomień DM.",

--- a/apps/web/src/i18n/translations/settings.json
+++ b/apps/web/src/i18n/translations/settings.json
@@ -184,7 +184,7 @@
     },
     "sharing": {
       "title": "Współdzielone rezerwacje",
-      "description": "Połącz kalendarze dwóch organizacji. Relacja tworzy bezpośredni, wzajemny sojusz i nie obejmuje kolejnych organizacji.",
+      "description": "Połącz kalendarze dwóch organizacji w trybie podglądu. Rezerwacje sojusznika są widoczne, ale nie blokują zapisów.",
       "createInvite": "Utwórz zaproszenie",
       "inviteReady": "Jednorazowe zaproszenie jest gotowe",
       "inviteLink": "Link zaproszenia",

--- a/docs/adr/0001-direct-reciprocal-reservation-sharing.md
+++ b/docs/adr/0001-direct-reciprocal-reservation-sharing.md
@@ -12,23 +12,23 @@ how conflicts are evaluated, and what revocation does to persisted data.
 
 Transitive sharing would make disclosure depend on another organization's
 partners and would make effective access difficult for administrators to
-predict. Directional grants would permit asymmetric calendars even though new
-reservation conflicts must be checked consistently by both participants.
+predict. Directional grants would permit asymmetric calendars instead of a
+shared, predictable view for both participants.
 
 ## Decision
 
 Reservation calendar sharing is a direct, reciprocal relationship between two
 Organizations. The relationship is persisted as one canonically ordered pair,
 so `(A, B)` and `(B, A)` cannot coexist. Sharing never propagates through a
-partner: if A shares with B and B shares with C, A and C do not see or block one
-another.
+partner: if A shares with B and B shares with C, A and C do not see one another.
 
 An administrator creates a random, single-use invitation. Only its hash is
 stored. It expires after seven days, and an authenticated recipient must choose
 an Organization in which they are an owner or administrator. Accepting the
 invitation activates the reciprocal relationship. Existing overlaps remain
-visible in parallel lanes and do not prevent acceptance; subsequent writes are
-checked against every active reservation belonging to either direct partner.
+visible in parallel lanes and do not prevent acceptance. Partner reservations
+remain view-only: availability, nearest-free suggestions, and write-time
+collision checks use only reservations owned by the current Organization.
 
 Cross-boundary reservation views expose only the author's display snapshot,
 avatar, time range, comment, and the source Organization's presentation data.
@@ -36,17 +36,17 @@ They do not expose Discord identifiers or a separate technical Organization
 identifier. Each Organization may moderate only reservations it owns; a user
 may still cancel their own reservation.
 
-Revocation takes effect immediately for reads, conflict checks, websocket
-audiences, and new writes. It does not delete either Organization's
-reservations or reminder jobs. Events contain no PII and carry the source
-Organization plus an explicitly resolved audience list.
+Revocation takes effect immediately for reads and websocket audiences. It does
+not delete either Organization's reservations or reminder jobs. Events contain
+no PII and carry the source Organization plus an explicitly resolved audience
+list.
 
 ## Consequences
 
 - Effective access can be explained from one direct pair and audited without
   graph traversal.
-- Both participants see the same conflict domain while retaining independent
-  moderation.
+- Both participants see overlapping reservations while retaining independent
+  availability, collision domains, and moderation.
 - Disconnecting is safe and reversible because source records remain owned by
   their original Organization.
 - Supporting multi-party alliances later would require a separate explicit

--- a/packages/api-client/src/generated/models/main/create-reservation-share-invitation-response-dto.ts
+++ b/packages/api-client/src/generated/models/main/create-reservation-share-invitation-response-dto.ts
@@ -12,5 +12,6 @@ export interface CreateReservationShareInvitationResponseDto {
   expiresAt: string;
   /** @pattern ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$ */
   createdAt: string;
-  inviteUrl: string;
+  /** @pattern ^\/reservation-sharing\/invitations\/[\w-]+$ */
+  invitePath: string;
 }


### PR DESCRIPTION
## Summary

- return reservation invitation paths from the API and build full links from the active Web origin
- keep partner reservations visible without including them in local availability, collision checks, counters, or nearest-free suggestions
- preserve detailed calendar rendering, partner markers, permissions, and websocket audiences
- document the view-only partnership semantics and add a Changeset

## Testing

- `pnpm --filter @lootlog/api test`
- `pnpm --filter @lootlog/web test`
- `pnpm --filter @lootlog/api build`
- `pnpm --filter @lootlog/web build`
- repository pre-commit checks for changed packages